### PR TITLE
Restore admin menu behavior by moving the #qm div into another position via javascript 

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -193,14 +193,6 @@ body:not(.iframe).sticky-menu.folded #qm {
 	margin-left: 36px !important;
 }
 
-body:not(.iframe).sticky-menu.js #qm {
-	margin-left: 0 !important;
-}
-
-body:not(.iframe).sticky-menu.folded.js #qm {
-	margin-left: 0 !important;
-}
-
 #qm-wrapper {
 	margin: 0 auto;
 	max-width: 85em;

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -59,6 +59,7 @@ jQuery( function($) {
 	if ( $('#wp-admin-bar-query-monitor').length ) {
 
 		var container = document.createDocumentFragment();
+		var is_admin = $('body').hasClass('wp-admin');
 
 		$('#wp-admin-bar-query-monitor')
 			.addClass(qm.menu.top.classname)
@@ -88,6 +89,9 @@ jQuery( function($) {
 		$('#wp-admin-bar-query-monitor ul').append(container);
 
 		$('#wp-admin-bar-query-monitor').find('a').on('click',function(e){
+			if ( is_admin ) {
+				$('#wpfooter').css('position','relative');
+			}
 			$('#qm').show();
 		});
 
@@ -170,6 +174,8 @@ jQuery( function($) {
 
 	} );
 
-	$('#qm').detach().appendTo('#wpbody-content .wrap');
+	if ( is_admin ) {
+		$('#qm').detach().appendTo('#wpwrap');
+	}
 
 } );


### PR DESCRIPTION
The query-monitor div is added to the admin page via the [shutdown hook](http://codex.wordpress.org/Plugin_API/Action_Reference/shutdown). The resulting markup causes the sidebar to behave awkwardly. Might be a nice idea to move the div into a more favorable position via jQuery?
