### PR TITLE
Remember the scrollbar position when clicking a toolbar link

### DIFF
--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -56,7 +56,8 @@ jQuery( function($) {
 	if ( !window.qm )
 		return;
 
-	var is_admin = $('body').hasClass('wp-admin');
+	var is_admin = $('body').hasClass('wp-admin'),
+		lastHref, resetTop;
 
 	if ( $('#wp-admin-bar-query-monitor').length ) {
 
@@ -90,10 +91,26 @@ jQuery( function($) {
 		$('#wp-admin-bar-query-monitor ul').append(container);
 
 		$('#wp-admin-bar-query-monitor').find('a').on('click',function(e){
+			var currentHref = $(this).attr('href'),
+				scrollTop = $(window).scrollTop(),
+				qmTop;
+
 			if ( is_admin ) {
 				$('#wpfooter').css('position','relative');
 			}
-			$('#qm').show();
+			qmTop = $('#qm').show().offset().top;
+
+			if ( scrollTop < qmTop ) {
+				resetTop = scrollTop;
+			}
+
+			if ( ( lastHref && lastHref === currentHref ) || ( scrollTop > qmTop && '#qm-overview' === currentHref ) ) {
+				e.preventDefault();
+				lastHref = null;
+				$('html,body').scrollTop(resetTop);
+			} else {
+				lastHref = currentHref;
+			}
 		});
 
 		$('#wp-admin-bar-query-monitor,#wp-admin-bar-query-monitor-default').show();


### PR DESCRIPTION
If the scroll position is above the Query Monitor panel when a toolbar link is clicked, it will be saved so that clicking the same link will return to the original scroll position. Clicking the overview link while viewing the QM panel also returns to the previous scroll position.

This makes it easier to quickly view a notice and return to the previous position without having to scroll back up a couple thousand pixels if the notice can be ignored.

Thanks for the great plugin!