### PR TITLE
Add word wrap so that long strings don't break out of container

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -209,6 +209,8 @@ body.js #qm-wrapper {
 	vertical-align: top !important;
 	text-shadow: none !important;
 	text-transform: none !important;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
 }
 
 .qm tbody tr:hover th,


### PR DESCRIPTION
Before:
![screenshot 2014-11-03 09 40 37](https://cloud.githubusercontent.com/assets/30460/4882466/aa1d4878-6356-11e4-9b7b-5b1d3f4e40e2.png)

After:

![screenshot 2014-11-03 09 40 48](https://cloud.githubusercontent.com/assets/30460/4882465/aa14e976-6356-11e4-9256-dbaada093df1.png)
