### PR TITLE
Allow for $plugins parameter to be false

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -229,7 +229,7 @@ class QueryMonitor extends QM_Plugin {
 
 	}
 
-	public function filter_active_sitewide_plugins( array $plugins ) {
+	public function filter_active_sitewide_plugins( $plugins ) {
 
 		$f = $this->plugin_base();
 


### PR DESCRIPTION
When used in multisite and there are no plugins network activated, casting the $plugins parameter as an array leads to a fatal error on activation because the value is `false`, not an array.