### PR TITLE
Prevent QM tables from hiding behind the admin menu

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -138,7 +138,7 @@ GNU General Public License for more details.
 }
 
 body.wp-admin #qm {
-	margin: 0 !important;
+	margin: 0 0 0 160px !important;
 }
 
 body:not(.iframe).sticky-menu #qm {


### PR DESCRIPTION
Currently the admin menu overlaps the query monitor tables; this edit
adds a left margin to the outer QM div to prevent that behavior.

Example of current behavior:
![2015-01-13 at 11 55 am](https://cloud.githubusercontent.com/assets/796639/5725757/6bbff0c4-9b1b-11e4-81ef-c3bd4c9be846.png)