### PR TITLE
Add filter to allow users to disable the stats

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -186,6 +186,10 @@ class QueryMonitor extends QM_Plugin {
 		if ( ! empty( $e ) and ( 1 === $e['type'] ) ) {
 			return false;
 		}
+		
+		# Allow users to disable the stats
+		if ( ! apply_filters( 'query_monitor_process_stats', true, is_admin_bar_showing() ) )
+			return false;
 
 		foreach ( $this->get_dispatchers() as $dispatcher ) {
 


### PR DESCRIPTION
This will allow users to return false to the filter and hide the stats if desired. Here is an example:

```
add_filter( 'query_monitor_process_stats', 'my_site_process_query_monitor_stats', 100, 2 );
function my_site_process_query_monitor_stats( $show_stats, $is_admin_bar_showing ) {
	
	if ( ! $is_admin_bar_showing )
		return false;
		
	return $show_stats;
	
}
```