### PR TITLE
Fixing an error for VIP Quickstart: query monitor throws an error when a...

### DIFF
--- a/collectors/admin.php
+++ b/collectors/admin.php
@@ -26,7 +26,7 @@ class QM_Collector_Admin extends QM_Collector {
 
 		global $pagenow;
 
-		if ( isset( $_GET['page'] ) ) {
+		if ( isset( $_GET['page'] ) && get_current_screen() != null ) {
 			$this->data['base'] = get_current_screen()->base;
 		} else {
 			$this->data['base'] = $pagenow;


### PR DESCRIPTION
Fixing an error for VIP Quickstart: query monitor throws an error when a user with 2fa enabled tries to link their account without an application-specific passowrd