### PR TITLE
Fix fatal error when activating Debug Bar plugin after Query Monitor has...

### DIFF
--- a/collectors/debug_bar.php
+++ b/collectors/debug_bar.php
@@ -54,7 +54,7 @@ function register_qm_collectors_debug_bar() {
 
 	global $debug_bar;
 
-	if ( class_exists( 'Debug_Bar' ) ) {
+	if ( class_exists( 'Debug_Bar' ) || qm_debug_bar_being_activated() ) {
 		return;
 	}
 
@@ -84,6 +84,54 @@ function register_qm_collectors_debug_bar() {
 
 		$collectors->add( $collector );
 	}
+
+}
+
+function qm_debug_bar_being_activated() {
+
+	if ( ! is_admin() ) {
+
+		return false;
+
+	}
+
+	if ( ! isset( $_REQUEST['action'] ) ) {
+
+		return false;
+
+	}
+
+	if ( isset( $_GET['action'] ) ) {
+
+		if ( ! isset( $_GET['plugin'] ) || ! isset( $_GET['_wpnonce'] ) ) {
+
+			return false;
+
+		}
+
+		if ( 'activate' === $_GET['action'] && false !== strpos( $_GET['plugin'], 'debug-bar.php' ) ) {
+
+			return true;
+
+		}
+
+	} elseif ( isset( $_POST['action'] ) ) {
+
+		if ( ! isset( $_POST['checked'] ) || ! is_array( $_POST['checked'] ) || ! isset( $_POST['_wpnonce'] ) ) {
+
+			return false;
+
+		}
+
+		if ( 'activate-selected' === $_POST['action'] && in_array( 'debug-bar/debug-bar.php', $_POST['checked'] ) ) {
+
+			return true;
+
+		}
+
+	}
+
+	return false;
 
 }
 


### PR DESCRIPTION
... already been activated

Related to #109 

Created a new pull request, the last one did not fix an error in case bulk activate was being used.

Anyway, hacky hack, but it works, worth considering.