### PR TITLE
Calling static method on class name, not variable.

### DIFF
--- a/output/headers/php_errors.php
+++ b/output/headers/php_errors.php
@@ -66,7 +66,7 @@ class QM_Output_Headers_PHP_Errors extends QM_Output_Headers {
 }
 
 function register_qm_output_headers_php_errors( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'php_errors' ) ) {
+	if ( $collector = QM_Collectors::get( 'php_errors' ) ) {
 		$output['php_errors'] = new QM_Output_Headers_PHP_Errors( $collector );
 	}
 	return $output;

--- a/output/headers/redirects.php
+++ b/output/headers/redirects.php
@@ -33,7 +33,7 @@ class QM_Output_Headers_Redirects extends QM_Output_Headers {
 }
 
 function register_qm_output_headers_redirects( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'redirects' ) ) {
+	if ( $collector = QM_Collectors::get( 'redirects' ) ) {
 		$output['redirects'] = new QM_Output_Headers_Redirects( $collector );
 	}
 	return $output;

--- a/output/html/admin.php
+++ b/output/html/admin.php
@@ -125,7 +125,7 @@ class QM_Output_Html_Admin extends QM_Output_Html {
 }
 
 function register_qm_output_html_admin( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'admin' ) ) {
+	if ( $collector = QM_Collectors::get( 'admin' ) ) {
 		$output['admin'] = new QM_Output_Html_Admin( $collector );
 	}
 	return $output;

--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -193,7 +193,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 }
 
 function register_qm_output_html_assets( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'assets' ) ) {
+	if ( $collector = QM_Collectors::get( 'assets' ) ) {
 		$output['assets'] = new QM_Output_Html_Assets( $collector );
 	}
 	return $output;

--- a/output/html/conditionals.php
+++ b/output/html/conditionals.php
@@ -91,7 +91,7 @@ class QM_Output_Html_Conditionals extends QM_Output_Html {
 }
 
 function register_qm_output_html_conditionals( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'conditionals' ) ) {
+	if ( $collector = QM_Collectors::get( 'conditionals' ) ) {
 		$output['conditionals'] = new QM_Output_Html_Conditionals( $collector );
 	}
 	return $output;

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -122,7 +122,7 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 }
 
 function register_qm_output_html_db_callers( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'db_callers' ) ) {
+	if ( $collector = QM_Collectors::get( 'db_callers' ) ) {
 		$output['db_callers'] = new QM_Output_Html_DB_Callers( $collector );
 	}
 	return $output;

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -123,7 +123,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 }
 
 function register_qm_output_html_db_components( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'db_components' ) ) {
+	if ( $collector = QM_Collectors::get( 'db_components' ) ) {
 		$output['db_components'] = new QM_Output_Html_DB_Components( $collector );
 	}
 	return $output;

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -411,7 +411,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 }
 
 function register_qm_output_html_db_queries( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'db_queries' ) ) {
+	if ( $collector = QM_Collectors::get( 'db_queries' ) ) {
 		$output['db_queries'] = new QM_Output_Html_DB_Queries( $collector );
 	}
 	return $output;

--- a/output/html/debug_bar.php
+++ b/output/html/debug_bar.php
@@ -61,7 +61,7 @@ function register_qm_output_html_debug_bar( array $output, QM_Collectors $collec
 
 	foreach ( $debug_bar->panels as $panel ) {
 		$panel_id  = strtolower( get_class( $panel ) );
-		$collector = $collectors::get( "debug_bar_{$panel_id}" );
+		$collector = QM_Collectors::get( "debug_bar_{$panel_id}" );
 
 		if ( $collector and $collector->is_visible() ) {
 			$output["debug_bar_{$panel_id}"] = new QM_Output_Html_Debug_Bar( $collector );

--- a/output/html/environment.php
+++ b/output/html/environment.php
@@ -241,7 +241,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 }
 
 function register_qm_output_html_environment( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'environment' ) ) {
+	if ( $collector = QM_Collectors::get( 'environment' ) ) {
 		$output['environment'] = new QM_Output_Html_Environment( $collector );
 	}
 	return $output;

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -180,7 +180,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 }
 
 function register_qm_output_html_hooks( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'hooks' ) ) {
+	if ( $collector = QM_Collectors::get( 'hooks' ) ) {
 		$output['hooks'] = new QM_Output_Html_Hooks( $collector );
 	}
 	return $output;

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -202,7 +202,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 }
 
 function register_qm_output_html_http( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'http' ) ) {
+	if ( $collector = QM_Collectors::get( 'http' ) ) {
 		$output['http'] = new QM_Output_Html_HTTP( $collector );
 	}
 	return $output;

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -112,7 +112,7 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 }
 
 function register_qm_output_html_overview( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'overview' ) ) {
+	if ( $collector = QM_Collectors::get( 'overview' ) ) {
 		$output['overview'] = new QM_Output_Html_Overview( $collector );
 	}
 	return $output;

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -152,7 +152,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 }
 
 function register_qm_output_html_php_errors( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'php_errors' ) ) {
+	if ( $collector = QM_Collectors::get( 'php_errors' ) ) {
 		$output['php_errors'] = new QM_Output_Html_PHP_Errors( $collector );
 	}
 	return $output;

--- a/output/html/request.php
+++ b/output/html/request.php
@@ -170,7 +170,7 @@ class QM_Output_Html_Request extends QM_Output_Html {
 }
 
 function register_qm_output_html_request( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'request' ) ) {
+	if ( $collector = QM_Collectors::get( 'request' ) ) {
 		$output['request'] = new QM_Output_Html_Request( $collector );
 	}
 	return $output;

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -103,7 +103,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 }
 
 function register_qm_output_html_theme( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'theme' ) ) {
+	if ( $collector = QM_Collectors::get( 'theme' ) ) {
 		$output['theme'] = new QM_Output_Html_Theme( $collector );
 	}
 	return $output;

--- a/output/html/transients.php
+++ b/output/html/transients.php
@@ -107,7 +107,7 @@ class QM_Output_Html_Transients extends QM_Output_Html {
 }
 
 function register_qm_output_html_transients( array $output, QM_Collectors $collectors ) {
-	if ( $collector = $collectors::get( 'transients' ) ) {
+	if ( $collector = QM_Collectors::get( 'transients' ) ) {
 		$output['transients'] = new QM_Output_Html_Transients( $collector );
 	}
 	return $output;


### PR DESCRIPTION
Resolves #118. Calling a static method on a variable causes a fatal error in PHP 5.2. 