### PR TITLE
Support for invokable objects in stack trace

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -162,16 +162,16 @@ class QM_Util {
 
 			} else if ( is_object( $callback['function'] ) && is_callable( $callback['function'] ) ) {
 
-                if( is_a( $callback['function'], 'Closure' ) ) {
-                    $ref  = new ReflectionFunction( $callback['function'] );
-                    $file = trim( QM_Util::standard_dir( $ref->getFileName(), '' ), '/' );
-                    $callback['name'] = sprintf( __( 'Closure on line %1$d of %2$s', 'query-monitor' ), $ref->getStartLine(), $file );
-                } else {
-                    // the object is callable so it must have a __invoke() method
-                    $class = get_class( $callback['function'] );
-                    $callback['name'] = $class . $access . '__invoke()';
-                    $ref = new ReflectionMethod( $class, '__invoke' );
-                }
+			if( is_a( $callback['function'], 'Closure' ) ) {
+				$ref  = new ReflectionFunction( $callback['function'] );
+				$file = trim( QM_Util::standard_dir( $ref->getFileName(), '' ), '/' );
+				$callback['name'] = sprintf( __( 'Closure on line %1$d of %2$s', 'query-monitor' ), $ref->getStartLine(), $file );
+			} else {
+				// the object is callable so it must have a __invoke() method
+				$class = get_class( $callback['function'] );
+				$callback['name'] = $class . $access . '__invoke()';
+				$ref = new ReflectionMethod( $class, '__invoke' );
+			}
 
 			} else {
 

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -160,11 +160,18 @@ class QM_Util {
 				$callback['name'] = $class . $access . $callback['function'][1] . '()';
 				$ref = new ReflectionMethod( $class, $callback['function'][1] );
 
-			} else if ( is_object( $callback['function'] ) and is_a( $callback['function'], 'Closure' ) ) {
+			} else if ( is_object( $callback['function'] ) && is_callable( $callback['function'] ) ) {
 
-				$ref  = new ReflectionFunction( $callback['function'] );
-				$file = trim( QM_Util::standard_dir( $ref->getFileName(), '' ), '/' );
-				$callback['name'] = sprintf( __( 'Closure on line %1$d of %2$s', 'query-monitor' ), $ref->getStartLine(), $file );
+                if( is_a( $callback['function'], 'Closure' ) ) {
+                    $ref  = new ReflectionFunction( $callback['function'] );
+                    $file = trim( QM_Util::standard_dir( $ref->getFileName(), '' ), '/' );
+                    $callback['name'] = sprintf( __( 'Closure on line %1$d of %2$s', 'query-monitor' ), $ref->getStartLine(), $file );
+                } else {
+                    // the object is callable so it must have a __invoke() method
+                    $class = get_class( $callback['function'] );
+                    $callback['name'] = $class . $access . '__invoke()';
+                    $ref = new ReflectionMethod( $class, '__invoke' );
+                }
 
 			} else {
 


### PR DESCRIPTION
At the moment, `QM_Util::populate_callback()` method only supports these kind of callbacks:

 - array (both static and dymamic methods)
 - closures
 - functions

However is possible that an invokable object (an object that has an `__invoke()` method) is used as callback, in which case `populate_callback()` thrown a recoverable fatal error trying to use that invokable object as a string.

This PR handle the usage of invokable objects as callback.