### PR TITLE
Add collector for Language Debugging

### DIFF
--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -1,0 +1,70 @@
+<?php
+/*
+Copyright 2009-2015 John Blackbourn
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+class QM_Collector_Languages extends QM_Collector {
+
+	public $id = 'languages';
+
+	public function name() {
+		return __( 'Languages', 'query-monitor' );
+	}
+
+	public function __construct() {
+
+		parent::__construct();
+
+		add_filter(	'override_load_textdomain',	array ( $this, 'log_file_load' ), 99, 3	);
+
+	}
+
+
+	/**
+	 * Store log data.
+	 *
+	 * @wp-hook override_load_textdomain
+	 * @param   bool $false FALSE, passed through
+	 * @param   string $domain Text domain
+	 * @param   string $mofile Path to file.
+	 * @return  bool
+	 */
+	public function log_file_load( $false, $domain, $mofile ) {
+
+		// DEBUG_BACKTRACE_IGNORE_ARGS is available since 5.3.6
+		if ( version_compare(PHP_VERSION, '5.3.6') >= 0 )
+			$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		else
+			$trace = debug_backtrace();
+
+		$this->data['languages'][] = array(
+			'caller' => $trace[ 4 ], // entry 4 is the calling file
+			'domain' => $domain,
+			'mofile' => $mofile,
+			'found'  => file_exists( $mofile ) ? round( filesize( $mofile ) / 1024, 2 ): FALSE
+		);
+
+		return $false;
+
+	}
+
+
+}
+
+function register_qm_collector_languages( array $collectors, QueryMonitor $qm ) {
+	$collectors['languages'] = new QM_Collector_Languages;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_languages', 21, 2 );

--- a/output/html/languages.php
+++ b/output/html/languages.php
@@ -1,0 +1,104 @@
+<?php
+/*
+Copyright 2009-2015 John Blackbourn
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+class QM_Output_Html_Languages extends QM_Output_Html {
+
+	public $id = 'languages';
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 80 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['languages'] ) ) {
+			return;
+		}
+
+		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
+		echo '<table cellspacing="0">';
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th>' . __( 'Languages', 'query-monitor' ) . '</th>';
+		echo '<th colspan="3">' . __( 'Language Setting:', 'query-monitor' ) . ' ' . get_locale() . '</th>';
+		echo '</tr>';
+		echo '<tr>';
+		echo '<td>' . __( 'Text Domain', 'query-monitor' ) . '</td>';
+		echo '<td>' . __( 'Files and Functions', 'query-monitor' ) . '</td>';
+		echo '<td>' . __( 'Loaded', 'query-monitor' ) . '</td>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $data['languages'] as $mofile ) {
+
+			echo '<tr>';
+
+			echo '<td valign="top" class="qm-num">' . $mofile['domain'] . '</td>';
+
+			echo '<td valign="top" class="qm-nowrap">';
+			echo __( 'Translation File:', 'query-monitor' ) . ' ' . $mofile['mofile'] . '<br />';
+			echo __( 'Function File:', 'query-monitor' ) . ' ' . $mofile['caller']['file'] . ' ';
+			echo __( '(line:', 'query-monitor' ) . ' ' . $mofile['caller']['line'] . ')';
+			echo '</td>';
+
+			if ( isset($mofile['found']) && $mofile['found'] ) {
+				echo '<td valign="top" class="qm-nowrap">';
+				echo __( 'Found:', 'query-monitor' ) . '<br />';
+				echo $mofile['found'] . ' KiB';
+				echo '</td>';
+			} else {
+				echo '<td valign="top" class="qm-warn">';
+				echo __( 'Not Found', 'query-monitor' );
+				echo '</td>';
+			}
+
+			echo '</tr>';
+
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+		echo '</div>';
+
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+		$args = array(
+			'title' => $this->collector->name(),
+		);
+
+		$menu[] = $this->menu( $args );
+
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_languages( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'languages' ) ) {
+		$output['languages'] = new QM_Output_Html_Languages( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_languages', 81, 2 );


### PR DESCRIPTION
New collector for Query Monitor, which shows Language information.

Current features:
* Mention current locale
* List Text Domain of each MO file
* List of MO files that have been asked to load, together with the file of the function call
* List result of Found / Not Found for that MO file, together with size of the file

Not implemented:
* Available languages (locales)
* List of Plugins / themes which do not try to load a MO file
* Strings on the page which don't have a translation in the current locale

It is partly based on other Collectors, and partly on the GPL v2 plugin from:
https://marketpress.com/product/debug-translations/

This is the first time I work with the code in Query Monitor, so there are probably lots of details you might want different :). If you want it reworked just let me know.
I do think this addon would be of great benefit to developers and translators already.