### PR TITLE
Update theme.php

### DIFF
--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -34,7 +34,8 @@ class QM_Collector_Theme extends QM_Collector {
 
 	public function process() {
 
-		global $template;
+		// global $template;
+		$template  = get_page_template();
 
 		$template_path        = QM_Util::standard_dir( $template );
 		$stylesheet_directory = QM_Util::standard_dir( get_stylesheet_directory() );


### PR DESCRIPTION
began seeing PHP Warning:
*PHP Warning:  ltrim() expects parameter 1 to be string, array given in /var/www/hbq-tricare.dev/htdocs/wp-content/plugins/query-monitor/collectors/theme.php on line 60*

global $template does not seem to be returning the correct output and I cant find it in the Globals list so I replaced with current method to retrieve the current template page. This appears to return the intended results.
