### PR TITLE
Get name from component when outputting logs

### DIFF
--- a/output/logger/transients.php
+++ b/output/logger/transients.php
@@ -44,7 +44,7 @@ class QM_Output_Logger_Transients extends QM_Output_Logger {
 				$transient,
 				$row['type'],
 				$expiration,
-				$row['trace']->get_component()
+				$row['trace']->get_component()->name
 			) );
 
 		}


### PR DESCRIPTION
This caused a fatal due to object to string conversion.