### PR TITLE
Fix PHP notice: queries data "total time"

### DIFF
--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -32,7 +32,7 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 		if ( $db_queries ) {
 			# @TODO: make this less derpy:
 			$db_queries_data = $db_queries->get_data();
-			if ( isset( $db_queries_data['types'] ) ) {
+			if ( isset( $db_queries_data['types'] ) && isset( $db_queries_data['total_time'] ) ) {
 				$db_query_num = $db_queries_data['types'];
 				$db_stime = number_format_i18n( $db_queries_data['total_time'], 4 );
 			}


### PR DESCRIPTION
Fixes PHP notices like this one:

```
PHP Notice:  Undefined index: total_time in /srv/www/.../wp-content/plugins/query-monitor/output/html/overview.php on line 37
```