### PR TITLE
Remove connection as param in mysqli_get_client_version

### DIFF
--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -126,7 +126,7 @@ class QM_Collector_Environment extends QM_Collector {
 				}
 
 				if ( isset( $db->use_mysqli ) && $db->use_mysqli ) {
-					$client = mysqli_get_client_version( $db->dbh );
+					$client = mysqli_get_client_version();
 				} else {
 					if ( preg_match( '|[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}|', mysql_get_client_info(), $matches ) ) {
 						$client = $matches[0];


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/31644

As it stands, this throws a verbose warning in hhvm and isn't really necessary.