### PR TITLE
Allow clicking URL's to open

### DIFF
--- a/output/Html.php
+++ b/output/Html.php
@@ -154,7 +154,8 @@ abstract class QM_Output_Html extends QM_Output {
 	 * @return string      The URL formatted with markup.
 	 */
 	public static function format_url( $url ) {
-		return str_replace( '&amp;', '<br>&amp;', esc_html( $url ) );
+		$formatted_url = str_replace( '&amp;', '<br>&amp;', esc_html( $url ) );
+		return '<a href="'.esc_html( $url ).'" target="_blank">'.$formatted_url.'</a>' );
 	}
 
 	/**


### PR DESCRIPTION
Chrome by default if copying the URL converts the `<br>` into `%20`, resulting in malformed requests, this would allow 1 click access to the URL's