### PR TITLE
Remove `is_comments_popup()` from collected conditionals

### DIFF
--- a/collectors/conditionals.php
+++ b/collectors/conditionals.php
@@ -33,7 +33,6 @@ class QM_Collector_Conditionals extends QM_Collector {
 			'is_blog_admin',
 			'is_category',
 			'is_comment_feed',
-			'is_comments_popup',
 			'is_customize_preview',
 			'is_date',
 			'is_day',


### PR DESCRIPTION
Allows comments to be submitted or edited while running trunk without triggering a deprecated notice.