### PR TITLE
Create a symlink that is contained within the WordPress directory str…

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -94,7 +94,8 @@ class QueryMonitor extends QM_Plugin {
 		}
 
 		if ( ! file_exists( $db = WP_CONTENT_DIR . '/db.php' ) and function_exists( 'symlink' ) ) {
-			@symlink( $this->plugin_path( 'wp-content/db.php' ), $db );
+			$target = str_replace(WP_CONTENT_DIR . '/', '', $this->plugin_path( 'wp-content/db.php' ));
+			@symlink( $target, $db );
 		}
 
 		if ( $sitewide ) {


### PR DESCRIPTION
I received wordpress files that had a broken symlink for wp-content/db.php which is automatically created when query monitor is activated (and deleted when it is deactivated).

Unfortunately the symlink in my use case was not functional, and at first I did not understand whether it was something created by the prior webdev crew. I eventually realized that it was not, and as a result, I considered to prepare a fix to the code to make sure this inconvenient issue doesn't unnecessarily occur for others as well.

Additionally, I considered using:

    $target = str_replace(WP_CONTENT_DIR . '/', '', $this->plugin_path( 'wp-content/db.php' ));
    $link = str_replace(ABSPATH, '../', $db);
    @symlink( $target, $link );

but using the full path to link target resolves to the same relative path so it seemed unnecessary in my environment.