### PR TITLE
Send nocache headers when QM is active

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -122,6 +122,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'wp_enqueue_scripts',    array( $this, 'enqueue_assets' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'login_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'send_headers',          'nocache_headers' );
 
 	}
 


### PR DESCRIPTION
This helps prevent caching of QM data, especially when using the
authentication cookie on anonymous requests (which may otherwise cache)