### PR TITLE
Scroll to all the query monitor area

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -180,7 +180,7 @@ body.wp-admin.folded #qm {
 #qm-title {
 	color: #777 !important;
 	font: 13px/15px 'Open Sans', Arial !important;
-	margin: 20px 0 -15px !important;
+	margin: 35px 0 -15px !important;
 }
 
 #qm-title p {

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -130,9 +130,14 @@ GNU General Public License for more details.
 }
 
 #qm.qm-show,
+#qm.qm-peek,
 .no-js #qm,
 .nojs #qm {
 	display: block;
+}
+
+#qm.qm-peek .qm {
+	display: none;
 }
 
 #qm:after {
@@ -168,11 +173,43 @@ body.wp-admin.folded #qm {
 	margin: 0 auto 60px !important;
 }
 
-#qm-wrapper > p {
+#qm.qm-peek #qm-wrapper {
+	margin: 0 auto !important;
+}
+
+#qm-title {
 	color: #777 !important;
 	font: 13px/15px 'Open Sans', Arial !important;
-	margin: 20px 20px -15px !important;
+	margin: 20px 0 -15px !important;
+}
+
+#qm-title p {
 	font-style: italic !important;
+	margin: 0 20px !important;
+}
+
+#qm-title ul {
+	margin: 10px 10px 0 !important;
+	font-family: Menlo, Monaco, Consolas, monospace !important;
+	font-size: 11px !important;
+	font-weight: normal !important;
+	font-style: normal !important;
+	line-height: 16px !important;
+	list-style: none !important;
+	padding: 0 !important;
+}
+
+#qm-title li {
+	display: inline-block !important;
+	width: 24em !important;
+	background: #fff !important;
+	border: 1px solid #e8e8e8 !important;
+	margin: 0 5px 5px 0 !important;
+}
+
+#qm-title li a {
+	display: block !important;
+	padding: 4px 7px !important;
 }
 
 .qm {
@@ -203,7 +240,7 @@ body.wp-admin.folded #qm {
 	margin-bottom: -45px !important;
 }
 
-#qm.qm-theme-twentysixteen #qm-wrapper > p {
+#qm.qm-theme-twentysixteen #qm-title {
 	margin-bottom: -45px !important;
 }
 
@@ -389,12 +426,16 @@ body.wp-admin.folded #qm {
 	display: none;
 }
 
+#qm-title a,
 .qm a {
 	color: #00a0d2 !important;
 	text-decoration: none !important;
 	text-shadow: none !important;
 	font-weight: normal !important;
 }
+
+#qm-title a:focus,
+#qm-title a:hover,
 .qm a:focus,
 .qm a:hover {
 	text-decoration: underline !important;

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -266,6 +266,11 @@ body.wp-admin.folded #qm {
 	margin: 0 !important;
 }
 
+#qm-conditionals table,
+#qm-overview table {
+	table-layout: fixed !important;
+}
+
 .qm td,
 .qm th {
 	background: #fff !important;

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -122,11 +122,31 @@ jQuery( function($) {
 				console.debug( qm_l10n.infinitescroll_paused );
 			}
 
-			$('#qm').show();
+			$('#qm').addClass('qm-show').removeClass('qm-hide');
 		});
 
 		$('#wp-admin-bar-query-monitor,#wp-admin-bar-query-monitor-default').show();
 
+	} else {
+
+		var container = document.createDocumentFragment();
+
+		$.each( qm.menu.sub, function( i, el ) {
+
+			var new_menu = $('<li><a/></li>');
+			new_menu
+				.find('a').eq(0)
+				.html(el.title)
+				.attr('href',el.href)
+			;
+
+			container.appendChild( new_menu.get(0) );
+
+		} );
+
+		$('<ul/>').appendTo('#qm-title').append(container).find('a').on('click',function(e){
+			$('#qm').addClass('qm-show').removeClass('qm-hide qm-peek');
+		} );
 	}
 
 	$('#qm').find('.qm-filter').on('change',function(e){

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -282,5 +282,19 @@ class QM_Util {
 
 	}
 
+	public static function get_query_type( $sql ) {
+		$sql = $type = trim( $sql );
+
+		if ( 0 === strpos( $sql, '/*' ) ) {
+			// Strip out leading comments such as `/*NO_SELECT_FOUND_ROWS*/` before calculating the query type
+			$type = preg_replace( '|^/\*[^\*/]+\*/|', '', $sql );
+		}
+
+		$type = preg_split( '/\b/', trim( $type ), 2, PREG_SPLIT_NO_EMPTY );
+		$type = strtoupper( $type[0] );
+
+		return $type;
+	}
+
 }
 }

--- a/collectors/cache.php
+++ b/collectors/cache.php
@@ -1,0 +1,65 @@
+<?php
+/*
+Copyright 2009-2016 John Blackbourn
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+class QM_Collector_Cache extends QM_Collector {
+
+	public $id = 'cache';
+
+	public function name() {
+		return __( 'Cache', 'query-monitor' );
+	}
+
+	public function process() {
+		global $wp_object_cache;
+
+		$this->data['ext_object_cache'] = (bool) wp_using_ext_object_cache();
+
+		if ( is_object( $wp_object_cache ) ) {
+
+			if ( isset( $wp_object_cache->cache_hits ) ) {
+				$this->data['stats']['cache_hits'] = $wp_object_cache->cache_hits;
+			}
+
+			if ( isset( $wp_object_cache->cache_misses ) ) {
+				$this->data['stats']['cache_misses'] = $wp_object_cache->cache_misses;
+			}
+
+			if ( isset( $wp_object_cache->stats ) ) {
+				foreach ( $wp_object_cache->stats as $key => $value ) {
+					if ( ! is_scalar( $value ) ) {
+						continue;
+					}
+					$this->data['stats'][ $key ] = $value;
+				}
+			}
+
+		}
+
+		if ( isset( $this->data['stats']['cache_hits'] ) && $this->data['stats']['cache_misses'] ) {
+			$total = $this->data['stats']['cache_misses'] + $this->data['stats']['cache_hits'];
+			$this->data['cache_hit_percentage'] = ( 100 / $total ) * $this->data['stats']['cache_hits'];
+		}
+
+	}
+
+}
+
+function register_qm_collector_cache( array $collectors, QueryMonitor $qm ) {
+	$collectors['cache'] = new QM_Collector_Cache;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_cache', 20, 2 );

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -148,15 +148,8 @@ class QM_Collector_DB_Queries extends QM_Collector {
 
 			}
 
-			$sql = $type = trim( $sql );
-
-			if ( 0 === strpos( $sql, '/*' ) ) {
-				// Strip out leading comments such as `/*NO_SELECT_FOUND_ROWS*/` before calculating the query type
-				$type = preg_replace( '|^/\*[^\*/]+\*/|', '', $sql );
-			}
-
-			$type = preg_split( '/\b/', trim( $type ), 2, PREG_SPLIT_NO_EMPTY );
-			$type = strtoupper( $type[0] );
+			$sql  = trim( $sql );
+			$type = QM_Util::get_query_type( $sql );
 
 			$this->log_type( $type );
 			$this->log_caller( $caller_name, $ltime, $type );

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -95,6 +95,7 @@ class QM_Collector_DB_Queries extends QM_Collector {
 	}
 
 	public function process_db_object( $id, wpdb $db ) {
+		global $EZSQL_ERROR;
 
 		$rows       = array();
 		$types      = array();
@@ -191,6 +192,23 @@ class QM_Collector_DB_Queries extends QM_Collector {
 			$rows[ $i ] = $row;
 			$i++;
 
+		}
+
+		if ( '$wpdb' === $id && ! $has_result && ! empty( $EZSQL_ERROR ) && is_array( $EZSQL_ERROR ) ) {
+			// Fallback for displaying database errors when wp-content/db.php isn't in place
+			foreach ( $EZSQL_ERROR as $error ) {
+				$row = array(
+					'caller'      => 'Unknown',
+					'caller_name' => 'Unknown',
+					'stack'       => array(),
+					'sql'         => $error['query'],
+					'result'      => new WP_Error( 'qmdb', $error['error_str'] ),
+					'type'        => '',
+					'component'   => false,
+					'trace'       => null,
+				);
+				$this->data['errors'][] = $row;
+			}
 		}
 
 		$total_qs = count( $rows );

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -130,6 +130,7 @@ class QM_Collector_HTTP extends QM_Collector {
 	public function log_http_response( $response, array $args, $url ) {
 		$this->data['http'][$args['_qm_key']]['end']      = microtime( true );
 		$this->data['http'][$args['_qm_key']]['response'] = $response;
+		$this->data['http'][$args['_qm_key']]['args']     = $args;
 		if ( isset( $args['_qm_original_key'] ) ) {
 			$this->data['http'][$args['_qm_original_key']]['end']      = $this->data['http'][$args['_qm_original_key']]['start'];
 			$this->data['http'][$args['_qm_original_key']]['response'] = new WP_Error( 'http_request_not_executed', __( 'Request not executed due to a filter on pre_http_request', 'query-monitor' ) );

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -47,7 +47,7 @@ class QM_Collector_Theme extends QM_Collector {
 			$template_directory   = QM_Util::standard_dir( get_template_directory() );
 			$theme_directory      = QM_Util::standard_dir( get_theme_root() );
 
-			$template_file       = str_replace( array( $stylesheet_directory, $template_directory ), '', $template_path );
+			$template_file       = str_replace( array( $stylesheet_directory, $template_directory, ABSPATH ), '', $template_path );
 			$template_file       = ltrim( $template_file, '/' );
 			$theme_template_file = str_replace( array( $theme_directory, ABSPATH ), '', $template_path );
 			$theme_template_file = ltrim( $theme_template_file, '/' );
@@ -58,8 +58,9 @@ class QM_Collector_Theme extends QM_Collector {
 
 		}
 
-		$this->data['stylesheet'] = get_stylesheet();
-		$this->data['template']   = get_template();
+		$this->data['stylesheet']     = get_stylesheet();
+		$this->data['template']       = get_template();
+		$this->data['is_child_theme'] = ( $this->data['stylesheet'] != $this->data['template'] );
 
 		if ( isset( $this->data['body_class'] ) ) {
 			asort( $this->data['body_class'] );

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -227,9 +227,15 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			$class[] = sprintf( 'qm-theme-%s', get_stylesheet() );
 		}
 
+		if ( !is_admin_bar_showing() ) {
+			$class[] = 'qm-peek';
+		}
+
 		echo '<div id="qm" class="' . implode( ' ', array_map( 'esc_attr', $class ) ) . '">';
 		echo '<div id="qm-wrapper">';
+		echo '<div id="qm-title">';
 		echo '<p>' . esc_html__( 'Query Monitor', 'query-monitor' ) . '</p>';
+		echo '</div>';
 
 	}
 
@@ -281,8 +287,10 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '<script type="text/javascript">' . "\n\n";
 		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
 		?>
-		if ( ( 'undefined' === typeof QM_i18n ) || ( ! document.getElementById( 'wpadminbar' ) ) ) {
+		if ( 'undefined' === typeof QM_i18n ) {
 			document.getElementById( 'qm' ).style.display = 'block';
+		} else if ( ! document.getElementById( 'wpadminbar' ) ) {
+			document.getElementById( 'qm' ).className += ' qm-peek';
 		}
 		<?php
 		echo '</script>' . "\n\n";

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -241,8 +241,6 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 	protected function after_output() {
 
-		$collectors = QM_Collectors::init();
-
 		echo '<div class="qm qm-half qm-clear" id="qm-authentication">';
 		echo '<table cellspacing="0">';
 		echo '<thead>';
@@ -332,7 +330,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			return false;
 		}
 
-		if ( QM_Util::is_async() ) {
+		if ( QM_Util::is_async() && ! is_customize_preview() ) {
 			return false;
 		}
 

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -32,6 +32,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'admin_footer',               array( $this, 'action_footer' ) );
 		add_action( 'login_footer',               array( $this, 'action_footer' ) );
 		add_action( 'embed_footer',               array( $this, 'action_footer' ) );
+		add_action( 'amp_post_template_footer',   array( $this, 'action_footer' ) );
 
 		parent::__construct( $qm );
 
@@ -126,6 +127,18 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'enqueue_embed_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'send_headers',          'nocache_headers' );
 
+		add_action( 'amp_post_template_head', array( $this, 'enqueue_assets' ) );
+		add_action( 'amp_post_template_head', array( $this, 'manually_print_assets' ), 11 );
+
+	}
+
+	public function manually_print_assets() {
+		wp_print_scripts( array(
+			'query-monitor',
+		) );
+		wp_print_styles( array(
+			'query-monitor',
+		) );
 	}
 
 	public function enqueue_assets() {
@@ -214,10 +227,6 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			$class[] = sprintf( 'qm-theme-%s', get_stylesheet() );
 		}
 
-		if ( !is_admin_bar_showing() ) {
-			$class[] = 'qm-show';
-		}
-
 		echo '<div id="qm" class="' . implode( ' ', array_map( 'esc_attr', $class ) ) . '">';
 		echo '<div id="qm-wrapper">';
 		echo '<p>' . esc_html__( 'Query Monitor', 'query-monitor' ) . '</p>';
@@ -272,7 +281,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '<script type="text/javascript">' . "\n\n";
 		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
 		?>
-		if ( 'undefined' === typeof QM_i18n ) {
+		if ( ( 'undefined' === typeof QM_i18n ) || ( ! document.getElementById( 'wpadminbar' ) ) ) {
 			document.getElementById( 'qm' ).style.display = 'block';
 		}
 		<?php

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -96,7 +96,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		$wp_admin_bar->add_menu( array(
 			'id'    => 'query-monitor',
 			'title' => esc_html( $title ),
-			'href'  => '#qm-overview',
+			'href'  => '#qm',
 			'meta'  => array(
 				'classname' => 'hide-if-js',
 			),
@@ -106,7 +106,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			'parent' => 'query-monitor',
 			'id'     => 'query-monitor-placeholder',
 			'title'  => esc_html( $title ),
-			'href'   => '#qm-overview',
+			'href'   => '#qm',
 		) );
 
 	}

--- a/output/Html.php
+++ b/output/Html.php
@@ -131,17 +131,8 @@ abstract class QM_Output_Html extends QM_Output {
 		$sql = esc_html( $sql );
 		$sql = trim( $sql );
 
-		foreach( array(
-			'ALTER', 'AND', 'COMMIT', 'CREATE', 'DESCRIBE', 'DELETE', 'DROP', 'ELSE', 'END', 'FROM', 'GROUP',
-			'HAVING', 'INNER', 'INSERT', 'LEFT', 'LIMIT', 'ON', 'OR', 'ORDER', 'OUTER', 'REPLACE', 'RIGHT', 'ROLLBACK', 'SELECT', 'SET',
-			'SHOW', 'START', 'THEN', 'TRUNCATE', 'UPDATE', 'VALUES', 'WHEN', 'WHERE'
-		) as $cmd ) {
-			// Why does this trim() every time?
-			$sql = trim( str_replace( " $cmd ", "<br>$cmd ", $sql ) );
-		}
-
-		# @TODO profile this as an alternative:
-		# $sql = preg_replace( '# (ALTER|AND|COMMIT|CREATE|DESCRIBE) #', '<br>$1 ', $sql );
+		$regex = 'ADD|AFTER|ALTER|AND|COMMIT|CREATE|DESCRIBE|DELETE|DROP|ELSE|END|EXCEPT|FROM|GROUP|HAVING|INNER|INSERT|INTERSECT|LEFT|LIMIT|ON|OR|ORDER|OUTER|REPLACE|RIGHT|ROLLBACK|SELECT|SET|SHOW|START|THEN|TRUNCATE|UNION|UPDATE|VALUES|WHEN|WHERE|XOR';
+		$sql = preg_replace( '# (' . $regex . ') #', '<br>$1 ', $sql );
 
 		return $sql;
 

--- a/output/html/conditionals.php
+++ b/output/html/conditionals.php
@@ -27,7 +27,6 @@ class QM_Output_Html_Conditionals extends QM_Output_Html {
 
 		$cols = 6;
 		$i = 0;
-		$w = floor( 100 / $cols );
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
@@ -43,7 +42,7 @@ class QM_Output_Html_Conditionals extends QM_Output_Html {
 			if ( 1 === $i % $cols ) {
 				echo '<tr>';
 			}
-			echo '<td class="qm-ltr qm-true" width="' . absint( $w ) . '%">' . esc_html( $cond ) . '()&nbsp;&#x2713;</td>';
+			echo '<td class="qm-ltr qm-true">' . esc_html( $cond ) . '()&nbsp;&#x2713;</td>';
 			if ( 0 === $i % $cols ) {
 				echo '</tr>';
 			}
@@ -54,7 +53,7 @@ class QM_Output_Html_Conditionals extends QM_Output_Html {
 			if ( 1 === $i % $cols ) {
 				echo '<tr>';
 			}
-			echo '<td class="qm-ltr qm-false" width="' . absint( $w ) . '%">' . esc_html( $cond ) . '()</td>';
+			echo '<td class="qm-ltr qm-false">' . esc_html( $cond ) . '()</td>';
 			if ( 0 === $i % $cols ) {
 				echo '</tr>';
 			}

--- a/output/html/db_dupes.php
+++ b/output/html/db_dupes.php
@@ -53,14 +53,23 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 		echo '<tbody>';
 
 		foreach ( $data['dupes'] as $sql => $queries ) {
+
+			// This should probably happen in the collector's processor
+			$type    = QM_Util::get_query_type( $sql );
+			$sql_out = self::format_sql( $sql );
+
+			if ( 'SELECT' !== $type ) {
+				$sql_out = "<span class='qm-nonselectsql'>{$sql_out}</span>";
+			}
+
 			echo '<tr>';
-			echo '<td>';
-			echo self::format_sql( $sql ); // WPCS: XSS ok;
+			echo '<td class="qm-row-sql qm-ltr qm-wrap">';
+			echo $sql_out; // WPCS: XSS ok;
 			echo '</td>';
 			echo '<td class="qm-num">';
 			echo esc_html( number_format_i18n( count( $queries ), 0 ) );
 			echo '</td>';
-			echo '<td class="qm-nowrap qm-ltr">';
+			echo '<td class="qm-row-caller qm-nowrap qm-ltr">';
 			foreach ( $data['dupe_callers'][ $sql ] as $caller => $calls ) {
 				printf(
 					'<a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="%s">%s</a><br><span class="qm-info">&nbsp;%s</span><br>',
@@ -74,7 +83,7 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 			}
 			echo '</td>';
 			if ( isset( $data['dupe_components'][ $sql ] ) ) {
-				echo '<td class="qm-nowrap">';
+				echo '<td class="qm-row-component qm-nowrap">';
 				foreach ( $data['dupe_components'][ $sql ] as $component => $calls ) {
 					printf(
 						'%s<br><span class="qm-info">&nbsp;%s</span><br>',
@@ -87,7 +96,7 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 				}
 				echo '</td>';
 			}
-			echo '<td class="qm-nowrap qm-ltr">';
+			echo '<td class="qm-row-caller qm-nowrap qm-ltr">';
 			foreach ( $data['dupe_sources'][ $sql ] as $source => $calls ) {
 				printf(
 					'%s<br><span class="qm-info">&nbsp;%s</span><br>',

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -329,7 +329,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		if ( isset( $cols['sql'] ) ) {
 			$row_attr['data-qm-type'] = $row['type'];
 		}
-		if ( isset( $cols['component'] ) ) {
+		if ( isset( $cols['component'] ) && $row['component'] ) {
 			$row_attr['data-qm-component'] = $row['component']->name;
 		}
 		if ( isset( $cols['caller'] ) ) {
@@ -378,7 +378,11 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		}
 
 		if ( isset( $cols['component'] ) ) {
+			if ( $row['component'] ) {
 			echo "<td class='qm-row-component qm-nowrap'>" . esc_html( $row['component']->name ) . "</td>\n";
+			} else {
+				echo "<td class='qm-row-component qm-nowrap'>" . esc_html__( 'Unknown', 'query-monitor' ) . "</td>\n";
+			}
 		}
 
 		if ( isset( $cols['result'] ) ) {

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -92,10 +92,22 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 
 				}
 
-				$method = $row['args']['method'];
-				if ( !$row['args']['blocking'] ) {
-					$method .= '&nbsp;' . _x( '(non-blocking)', 'non-blocking HTTP transport', 'query-monitor' );
+				$method = esc_html( $row['args']['method'] );
+
+				if ( ! $row['args']['blocking'] ) {
+					$method .= '<br><span class="qm-info">' . esc_html( sprintf(
+						_x( '(Non-blocking request: %s)', 'non-blocking HTTP transport', 'query-monitor' ),
+						'blocking=false'
+					) ) . '</span>';
 				}
+
+				if ( $row['args']['ssl'] && ! $row['args']['sslverify'] && ! $row['args']['local'] ) {
+					$method .= '<br><span class="qm-warn">' . esc_html( sprintf(
+						__( '(Certificate verification disabled: %s)', 'query-monitor' ),
+						'sslverify=false'
+					) ) . '</span>';
+				}
+
 				$url = self::format_url( $row['url'] );
 
 				if ( isset( $row['transport'] ) ) {
@@ -133,7 +145,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				);
 				printf( // WPCS: XSS ok.
 					'<td class="qm-url qm-ltr qm-wrap">%s<br>%s</td>',
-					esc_html( $method ),
+					$method,
 					$url
 				);
 				printf(

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -37,6 +37,15 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 			}
 		}
 
+		$cache = QM_Collectors::get( 'cache' );
+
+		if ( $cache ) {
+			$cache_data = $cache->get_data();
+			if ( isset( $cache_data['stats'] ) && isset( $cache_data['cache_hit_percentage'] ) ) {
+				$cache_hit_percentage = $cache_data['cache_hit_percentage'];
+			}
+		}
+
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
 
@@ -47,6 +56,9 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 		if ( isset( $db_query_num ) ) {
 			echo '<th scope="col">' . esc_html__( 'Database query time', 'query-monitor' ) . '</th>';
 			echo '<th scope="col">' . esc_html__( 'Database queries', 'query-monitor' ) . '</th>';
+		}
+		if ( isset( $cache_hit_percentage ) ) {
+			echo '<th scope="col">' . esc_html__( 'Object cache', 'query-monitor' ) . '</th>';
 		}
 		echo '</tr>';
 		echo '</thead>';
@@ -96,6 +108,20 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 
 			echo '</td>';
 		}
+
+		if ( isset( $cache_hit_percentage ) ) {
+			echo '<td>';
+			echo esc_html( sprintf(
+				'%s%% hit rate',
+				number_format_i18n( $cache_hit_percentage, 1 )
+			) );
+			echo '<br>' . esc_html( sprintf(
+				__( 'External object cache: %s'),
+				( $cache_data['ext_object_cache'] ? 'true' : 'false' )
+			) );
+			echo '</td>';
+		}
+
 		echo '</tr>';
 		echo '</tbody>';
 

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -29,8 +29,6 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 			return;
 		}
 
-		$child_theme = ( $data['stylesheet'] !== $data['template'] );
-
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
 		echo '<tbody>';
@@ -39,7 +37,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 			echo '<tr>';
 			echo '<td>' . esc_html__( 'Template File', 'query-monitor' ) . '</td>';
-			if ( $child_theme ) {
+			if ( $data['is_child_theme'] ) {
 				echo '<td>' . self::output_filename( $data['theme_template_file'], $data['template_path'] ) . '</td>'; // WPCS: XSS ok.
 			} else {
 				echo '<td>' . self::output_filename( $data['template_file'], $data['template_path'] ) . '</td>'; // WPCS: XSS ok.
@@ -49,7 +47,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 		}
 
 		echo '<tr>';
-		if ( $child_theme ) {
+		if ( $data['is_child_theme'] ) {
 			echo '<td>' . esc_html__( 'Child Theme', 'query-monitor' ) . '</td>';
 		} else {
 			echo '<td>' . esc_html__( 'Theme', 'query-monitor' ) . '</td>';
@@ -57,7 +55,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 		echo '<td>' . esc_html( $data['stylesheet'] ) . '</td>';
 		echo '</tr>';
 
-		if ( $child_theme ) {
+		if ( $data['is_child_theme'] ) {
 			echo '<tr>';
 			echo '<td>' . esc_html__( 'Parent Theme', 'query-monitor' ) . '</td>';
 			echo '<td>' . esc_html( $data['template'] ) . '</td>';
@@ -99,7 +97,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 			$menu[] = $this->menu( array(
 				'title' => esc_html( sprintf(
 					__( 'Template: %s', 'query-monitor' ),
-					$data['template_file']
+					( $data['is_child_theme'] ? $data['theme_template_file'] : $data['template_file'] )
 				) ),
 			) );
 		}

--- a/tests/phpunit/test-dispatcher-html.php
+++ b/tests/phpunit/test-dispatcher-html.php
@@ -67,6 +67,7 @@ class Test_Dispatcher_HTML extends QM_UnitTestCase {
 		$expected = array(
 			'admin'         => false,
 			'assets'        => true,
+			'cache'         => false,
 			'conditionals'  => false,
 			'db_callers'    => true,
 			'db_components' => true,


### PR DESCRIPTION
With https://github.com/johnbillion/query-monitor/pull/178 we have a button that when you click on the admin bar is covered from the browser window.
With that the scroll position on click on the admin bar move the visibile area also to the query monitor title and botton.