### PR TITLE
Scroll to all the query monitor area

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -180,7 +180,7 @@ body.wp-admin.folded #qm {
 #qm-title {
 	color: #777 !important;
 	font: 13px/15px 'Open Sans', Arial !important;
-	margin: 20px 0 -15px !important;
+	margin: 35px 0 -15px !important;
 }
 
 #qm-title p {

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -96,7 +96,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		$wp_admin_bar->add_menu( array(
 			'id'    => 'query-monitor',
 			'title' => esc_html( $title ),
-			'href'  => '#qm-overview',
+			'href'  => '#qm',
 			'meta'  => array(
 				'classname' => 'hide-if-js',
 			),
@@ -106,7 +106,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			'parent' => 'query-monitor',
 			'id'     => 'query-monitor-placeholder',
 			'title'  => esc_html( $title ),
-			'href'   => '#qm-overview',
+			'href'   => '#qm',
 		) );
 
 	}


### PR DESCRIPTION
With https://github.com/johnbillion/query-monitor/pull/178 we have a button that when you click on the admin bar is covered from the browser window.
With that the scroll position on click on the admin bar move the visibile area also to the query monitor title and botton.