### PR TITLE
Add option for showing all hooks

### DIFF
--- a/collectors/hooks.php
+++ b/collectors/hooks.php
@@ -40,7 +40,15 @@ class QM_Collector_Hooks extends QM_Collector {
 			$hooks['all'] = $this->process_action( 'all', $wp_filter );
 		}
 
-		foreach ( $wp_actions as $name => $count ) {
+		if ( defined( 'QM_SHOW_ALL_HOOKS' ) && QM_SHOW_ALL_HOOKS ) {
+			// Show all hooks
+			$hook_names = array_keys( $wp_filter );
+		} else {
+			// Only show action hooks that have been called at least once
+			$hook_names = array_keys( $wp_actions );
+		}
+
+		foreach ( $hook_names as $name ) {
 
 			$hooks[$name] = $this->process_action( $name, $wp_filter );
 


### PR DESCRIPTION
Currently, Query Monitor's Hooks section only displays hooks that have been called at least once by `do_action()`. Filters generally don't show up in Query Monitor, however, since `apply_filters()` doesn't increment the `$wp_actions` counter.

This change adds an option to display all registered hooks instead of just the ones called with `do_action()`. This is useful for determining which filters may have been called (as well as simply listing all hooks that are registered in the installation for debugging/diagnostic purposes).

With this change, defining `QM_SHOW_ALL_HOOKS` as true will make all hooks appear.