### PR TITLE
Use include_once instead of include for loading REST dispatcher plugin

### DIFF
--- a/dispatchers/REST.php
+++ b/dispatchers/REST.php
@@ -56,7 +56,7 @@ class QM_Dispatcher_REST extends QM_Dispatcher {
 		require_once $this->qm->plugin_path( 'output/Headers.php' );
 
 		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
-			include $file;
+			include_once $file;
 		}
 	}
 


### PR DESCRIPTION
Fixes issue with REST `_embed` requests:

> <b>Fatal error</b>:  Cannot redeclare register_qm_output_headers_overview() (previously declared in /srv/www/wordpress-develop/src/wp-content/plugins/query-monitor/output/headers/overview.php:49) in <b>/srv/www/wordpress-develop/src/wp-content/plugins/query-monitor/output/headers/overview.php</b> on line <b>49</b>