### PR TITLE
fixed Undefined index: cache_misses

### DIFF
--- a/collectors/cache.php
+++ b/collectors/cache.php
@@ -48,7 +48,7 @@ class QM_Collector_Cache extends QM_Collector {
 
 		}
 
-		if ( isset( $this->data['stats']['cache_hits'] ) && $this->data['stats']['cache_misses'] ) {
+		if ( isset( $this->data['stats']['cache_hits'] ) && isset( $this->data['stats']['cache_misses'] ) ) {
 			$total = $this->data['stats']['cache_misses'] + $this->data['stats']['cache_hits'];
 			$this->data['cache_hit_percentage'] = ( 100 / $total ) * $this->data['stats']['cache_hits'];
 		}


### PR DESCRIPTION
Fixed the Undefined index: cache_misses notice, which surfaced on PHP 7.0.7, and loaded a screen full of notices and warnings with wp_debug set to true. The headers already sent warnings remain. Below is a list of notices and warnings on plugin activation.

Notice: Undefined index: cache_misses in /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php on line 51

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-content/plugins/query-monitor/output/Headers.php on line 25

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-includes/pluggable.php on line 1171

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/hci/wp-content/plugins/query-monitor/collectors/cache.php:51) in /var/www/html/hci/wp-includes/pluggable.php on line 1171