### PR TITLE
fixed PHP notice in QM_Collector_Cache

### DIFF
--- a/collectors/cache.php
+++ b/collectors/cache.php
@@ -48,7 +48,7 @@ class QM_Collector_Cache extends QM_Collector {
 
 		}
 
-		if ( isset( $this->data['stats']['cache_hits'] ) && $this->data['stats']['cache_misses'] ) {
+		if ( isset( $this->data['stats']['cache_hits'] ) && isset( $this->data['stats']['cache_misses'] ) ) {
 			$total = $this->data['stats']['cache_misses'] + $this->data['stats']['cache_hits'];
 			$this->data['cache_hit_percentage'] = ( 100 / $total ) * $this->data['stats']['cache_hits'];
 		}


### PR DESCRIPTION
Was getting a PHP notice on the `cache_misses` array index after updating to 2.11.0

```
Notice:  Undefined index: cache_misses in /srv/www/wordpress-default/htdocs/wp-content/plugins/query-monitor/collectors/cache.php on line 51
```