### PR TITLE
add alert color for failed resource and HTTP requests

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -69,7 +69,7 @@ GNU General Public License for more details.
 }
 
 #wpadminbar .qm-alert {
-	background-color: #f90 !important;
+	background-color: #f70 !important;
 }
 
 #wpadminbar .qm-error > a,

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -68,7 +68,12 @@ GNU General Public License for more details.
 	background-color: #c00 !important;
 }
 
-#wpadminbar .qm-error > a {
+#wpadminbar .qm-alert {
+	background-color: #c75411 !important;
+}
+
+#wpadminbar .qm-error > a,
+#wpadminbar .qm-alert > a {
 	color: #fff !important;
 }
 

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -69,7 +69,7 @@ GNU General Public License for more details.
 }
 
 #wpadminbar .qm-alert {
-	background-color: #c75411 !important;
+	background-color: #f90 !important;
 }
 
 #wpadminbar .qm-error > a,

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -179,7 +179,7 @@ class QM_Collector_HTTP extends QM_Collector {
 
 			if ( is_wp_error( $http['response'] ) ) {
 				if ( !in_array( $http['response']->get_error_code(), $silent ) ) {
-					$this->data['errors']['error'][] = $key;
+					$this->data['errors']['alert'][] = $key;
 				}
 				$http['type'] = __( 'Error', 'query-monitor' );
 			} else {

--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -196,7 +196,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		if ( !empty( $data['broken'] ) or !empty( $data['missing'] ) ) {
-			$class[] = 'qm-error';
+			$class[] = 'qm-alert';
 		}
 
 		return $class;
@@ -211,7 +211,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 		);
 
 		if ( !empty( $data['broken'] ) or !empty( $data['missing'] ) ) {
-			$args['meta']['classname'] = 'qm-error';
+			$args['meta']['classname'] = 'qm-alert';
 		}
 
 		$menu[] = $this->menu( $args );

--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -196,7 +196,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		if ( !empty( $data['broken'] ) or !empty( $data['missing'] ) ) {
-			$class[] = 'qm-alert';
+			$class[] = 'qm-error';
 		}
 
 		return $class;
@@ -211,7 +211,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 		);
 
 		if ( !empty( $data['broken'] ) or !empty( $data['missing'] ) ) {
-			$args['meta']['classname'] = 'qm-alert';
+			$args['meta']['classname'] = 'qm-error';
 		}
 
 		$menu[] = $this->menu( $args );

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -224,7 +224,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		if ( isset( $data['errors']['error'] ) ) {
-			$class[] = 'qm-error';
+			$class[] = 'qm-alert';
 		} else if ( isset( $data['errors']['warning'] ) ) {
 			$class[] = 'qm-warning';
 		}
@@ -251,7 +251,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 		);
 
 		if ( isset( $data['errors']['error'] ) ) {
-			$args['meta']['classname'] = 'qm-error';
+			$args['meta']['classname'] = 'qm-alert';
 		} else if ( isset( $data['errors']['warning'] ) ) {
 			$args['meta']['classname'] = 'qm-warning';
 		}

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -223,7 +223,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 
 		$data = $this->collector->get_data();
 
-		if ( isset( $data['errors']['error'] ) ) {
+		if ( isset( $data['errors']['alert'] ) ) {
 			$class[] = 'qm-alert';
 		} else if ( isset( $data['errors']['warning'] ) ) {
 			$class[] = 'qm-warning';
@@ -250,7 +250,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			) ),
 		);
 
-		if ( isset( $data['errors']['error'] ) ) {
+		if ( isset( $data['errors']['alert'] ) ) {
 			$args['meta']['classname'] = 'qm-alert';
 		} else if ( isset( $data['errors']['warning'] ) ) {
 			$args['meta']['classname'] = 'qm-warning';


### PR DESCRIPTION
In my development workflow, I will often see QM in the admin bar with a red background, and immediately investigate to see what PHP error is in my code, but most of the time, it's just a script or stylesheet that failed to load, or an HTTP request that failed.

This may just be a personal preference, but I'd like to prioritize PHP warnings by creating another error type/color for those events, to distinguish between a coding error and the instability of the Internet.

I wasn't sure about creating a whole new error type, so the attached code merely adds and uses a new class, `qm-alert`.