### PR TITLE
add 'qm-all-clear' class when no reports, to efficiently style text

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -77,6 +77,7 @@ GNU General Public License for more details.
 	color: #fff !important;
 }
 
+body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover) .ab-label,
 #wp-admin-bar-query-monitor-deprecated a,
 #wp-admin-bar-query-monitor-stricts a,
 #wp-admin-bar-query-monitor-notices a,

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -298,6 +298,16 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 	public function js_admin_bar_menu() {
 
 		$class = implode( ' ', apply_filters( 'qm/output/menu_class', array() ) );
+		if (
+			   false === stripos($class,'qm-deprecated')
+			&& false === stripos($class,'qm-expensive')
+			&& false === stripos($class,'qm-warning')
+			&& false === stripos($class,'qm-notice')
+			&& false === stripos($class,'qm-strict')
+			&& false === stripos($class,'qm-alert')
+			&& false === stripos($class,'qm-error')
+		)
+			$class .= ' qm-all-clear';
 		$title = implode( '&nbsp;&nbsp;&nbsp;', apply_filters( 'qm/output/title', array() ) );
 
 		if ( empty( $title ) ) {


### PR DESCRIPTION
Fix #213 