### PR TITLE
set 'data-qm-sort-weight' attribute on cells with standard decimal value

### DIFF
--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -335,10 +335,10 @@ jQuery( function($) {
 				
 				for (var k = 0, l = row_width; k < l; k++) {
 					var e = columns[i+k];
-					
-					var data = e.dataset.qmSortWeight;
-					
-					if (data === undefined) {
+
+					var data = e.getAttribute('data-qm-sort-value');
+
+					if (data === undefined || data === null) {
 						data = e.textContent || e.innerText;
 					}
 					

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -335,10 +335,10 @@ jQuery( function($) {
 				
 				for (var k = 0, l = row_width; k < l; k++) {
 					var e = columns[i+k];
-
-					var data = e.getAttribute('data-qm-sort-value');
-
-					if (data === undefined || data === null) {
+					
+					var data = e.dataset.qmSortWeight;
+					
+					if (data === undefined) {
 						data = e.textContent || e.innerText;
 					}
 					

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -74,7 +74,7 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 					}
 				}
 
-				echo '<td class="qm-num">' . esc_html( $stime ) . '</td>';
+				echo '<td class="qm-num" data-qm-sort-weight="' . esc_attr( number_format( $row['ltime'], 4, '.', '' ) ) . '">' . esc_html( $stime ) . '</td>';
 				echo '</tr>';
 
 			}

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -75,7 +75,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 					}
 				}
 
-				echo '<td class="qm-num">' . esc_html( number_format_i18n( $row['ltime'], 4 ) ) . '</td>';
+				echo '<td class="qm-num" data-qm-sort-weight="' . esc_attr( number_format( $row['ltime'], 4 ) ) . '">' . esc_html( number_format_i18n( $row['ltime'], 4, '.', '' ) ) . '</td>';
 				echo '</tr>';
 
 			}

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -401,7 +401,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		}
 
 		if ( isset( $cols['time'] ) ) {
-			echo '<td class="qm-num qm-row-time' . esc_attr( $td ) . '">'. esc_html( $stime ) . "</td>\n";
+			echo '<td class="qm-num qm-row-time' . esc_attr( $td ) . '" data-qm-sort-weight="' . esc_attr( number_format( $row['ltime'], 4, '.', '' ) ) . '">' . esc_html( $stime ) . "</td>\n";
 		}
 
 		echo '</tr>';

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -174,7 +174,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				}
 
 				printf(
-					'<td class="qm-num">%s</td>',
+					'<td class="qm-num" data-qm-sort-weight="' . esc_attr( number_format( $ltime, 4, '.', '' ) ) . '">%s</td>',
 					esc_html( $stime )
 				);
 				echo '</tr>';
@@ -209,7 +209,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				echo '</tr>';
 			}
 			echo '</tbody>';
-		
+
 		}
 
 		echo '</table>';


### PR DESCRIPTION
No matter what I do, I cannot seem to get [`dataset.qmSortWeight`](https://github.com/johnbillion/query-monitor/blob/master/assets/query-monitor.js#L336) to be used for the sorting value... switching to `getAttribute('data-qm-sort-value')` works perfectly in my tests. Searching QM directory for 'weight' results in the one script line, and `font-weight` declarations in the stylesheet; if I've missed a table that uses attributes for the sorting value, @johnbillion, please let me know.