### PR TITLE
Table accessibility improvements

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -286,7 +286,8 @@ body.wp-admin.folded #qm {
 }
 
 .qm td,
-.qm th {
+.qm th,
+.qm caption {
 	background: #fff !important;
 	box-sizing: border-box !important;
 	text-align: left !important;
@@ -303,11 +304,9 @@ body.wp-admin.folded #qm {
 	-webkit-font-smoothing: auto !important;
 }
 
-.qm .qm-totally-legit-spacer td {
-	background-color: #f1f1f1 !important;
-	border-right-color: #f1f1f1 !important;
-	border-left-color: #f1f1f1 !important;
-	height: 20px !important;
+.qm caption,
+.qm th[scope=col] {
+	border-bottom-width: 0 !important;
 }
 
 .qm tbody tr:hover th,

--- a/output/html/admin.php
+++ b/output/html/admin.php
@@ -31,34 +31,30 @@ class QM_Output_Html_Admin extends QM_Output_Html {
 
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
+		echo '<thead class="screen-reader-text">';
 		echo '<tr>';
-		echo '<th colspan="2">' . esc_html( $this->collector->name() ) . '</th>';
+		echo '<th>' . esc_html__( 'Data', 'query-monitor' ) . '</th>';
+		echo '<th>' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th>' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
 
 		echo '<tr>';
-		echo '<td class="qm-ltr">get_current_screen()</td>';
-		echo '<td class="qm-has-inner">';
+		echo '<th class="qm-ltr" rowspan="' . absint( count( get_object_vars( $data['current_screen'] ) ) + 1 ) . '">get_current_screen()</th>';
+		echo '</tr>';
 
-		echo '<table class="qm-inner" cellspacing="0">';
-		echo '<tbody>';
 		foreach ( $data['current_screen'] as $key => $value ) {
 			echo '<tr>';
 			echo '<th>' . esc_html( $key ) . '</th>';
 			echo '<td>' . esc_html( $value ) . '</td>';
 			echo '</tr>';
 		}
-		echo '</tbody>';
-		echo '</table>';
-
-		echo '</td>';
-		echo '</tr>';
 
 		echo '<tr>';
-		echo '<td class="qm-ltr">$pagenow</td>';
-		echo '<td>' . esc_html( $data['pagenow'] ) . '</td>';
+		echo '<th class="qm-ltr">$pagenow</th>';
+		echo '<td colspan="2">' . esc_html( $data['pagenow'] ) . '</td>';
 		echo '</tr>';
 
 		$screens = array(
@@ -103,7 +99,7 @@ class QM_Output_Html_Admin extends QM_Output_Html {
 			}
 
 			echo '<tr>';
-			echo '<td rowspan="2">' . esc_html__( 'Column Filters', 'query-monitor' ) . '</td>';
+			echo '<th rowspan="2">' . esc_html__( 'Column Filters', 'query-monitor' ) . '</th>';
 			echo '<td colspan="2">manage_<span class="qm-current">' . esc_html( $cols ) . '</span>_columns</td>';
 			echo '</tr>';
 			echo '<tr>';
@@ -111,7 +107,7 @@ class QM_Output_Html_Admin extends QM_Output_Html {
 			echo '</tr>';
 
 			echo '<tr>';
-			echo '<td rowspan="1">' . esc_html__( 'Column Action', 'query-monitor' ) . '</td>';
+			echo '<th>' . esc_html__( 'Column Action', 'query-monitor' ) . '</th>';
 			echo '<td colspan="2">manage_<span class="qm-current">' . esc_html( $col ) . '</span>_custom_column</td>';
 			echo '</tr>';
 

--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -30,8 +30,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 			return;
 		}
 
-		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
-		echo '<table cellspacing="0">';
+		echo '<div id="' . esc_attr( $this->collector->id() ) . '">';
 
 		$position_labels = array(
 			'scripts' => array(
@@ -48,24 +47,29 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 			),
 		);
 
-		foreach ( array(
-			'scripts' => __( 'Scripts', 'query-monitor' ),
-			'styles'  => __( 'Styles', 'query-monitor' ),
-		) as $type => $type_label ) {
+		$type_labels = array(
+			'scripts' => array(
+				'singular' => __( 'Script', 'query-monitor' ),
+				'plural'   => __( 'Scripts', 'query-monitor' ),
+			),
+			'styles' => array(
+				'singular' => __( 'Style', 'query-monitor' ),
+				'plural'   => __( 'Styles', 'query-monitor' ),
+			),
+		);
 
+		foreach ( $type_labels as $type => $type_label ) {
+
+			echo '<div class="qm">';
+			echo '<table cellspacing="0">';
+			echo '<caption>' . esc_html( $type_label['plural'] ) . '</caption>';
 			echo '<thead>';
-
-			if ( 'scripts' !== $type ) {
-				echo '<tr class="qm-totally-legit-spacer">';
-				echo '<td colspan="6"></td>';
-				echo '</tr>';
-			}
-
 			echo '<tr>';
-			echo '<th colspan="2">' . esc_html( $type_label ) . '</th>';
-			echo '<th>' . esc_html__( 'Dependencies', 'query-monitor' ) . '</th>';
-			echo '<th>' . esc_html__( 'Dependents', 'query-monitor' ) . '</th>';
-			echo '<th>' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Position', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html( $type_label['singular'] ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Dependencies', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Dependents', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
 			echo '</tr>';
 			echo '</thead>';
 			echo '<tbody>';
@@ -84,10 +88,11 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 			}
 
 			echo '</tbody>';
+			echo '</table>';
+			echo '</div>';
 
 		}
 
-		echo '</table>';
 		echo '</div>';
 
 	}
@@ -114,7 +119,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 
 			if ( $first ) {
 				$rowspan = count( $handles );
-				echo '<th rowspan="' . esc_attr( $rowspan ) . '" class="qm-nowrap">' . esc_html( $label ) . '</th>';
+				echo '<th scope="row" rowspan="' . esc_attr( $rowspan ) . '" class="qm-nowrap">' . esc_html( $label ) . '</th>';
 			}
 
 			$this->dependency_row( $dependencies->query( $handle ), $dependencies, $type );
@@ -172,7 +177,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 		$highlight_deps       = array_map( array( $this, '_prefix_type' ), $deps );
 		$highlight_dependents = array_map( array( $this, '_prefix_type' ), $dependents );
 
-		echo '<td class="qm-wrap">' . esc_html( $dependency->handle ) . '<br><span class="qm-info">&nbsp;';
+		echo '<th scope="row" class="qm-wrap">' . esc_html( $dependency->handle ) . '<br><span class="qm-info">&nbsp;';
 		if ( is_wp_error( $source ) ) {
 			printf( '<span class="qm-warn">%s</span>',
 				esc_html( $src )

--- a/output/html/conditionals.php
+++ b/output/html/conditionals.php
@@ -30,11 +30,7 @@ class QM_Output_Html_Conditionals extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th colspan="' . absint( $cols ) . '">' . esc_html( $this->collector->name() ) . '</th>';
-		echo '</tr>';
-		echo '</thead>';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<tbody>';
 
 		foreach ( $data['conds']['true'] as $cond ) {

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -34,21 +34,19 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0" class="qm-sortable">';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th colspan="' . absint( $span ) . '">' . esc_html( $this->collector->name() ) . '</th>';
-		echo '</tr>';
-		echo '<tr>';
-		echo '<th>' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 
 		foreach ( $data['types'] as $type_name => $type_count ) {
-			echo '<th class="qm-num">';
+			echo '<th scope="col" class="qm-num">';
 			echo esc_html( $type_name );
 			echo $this->build_sorter(); // WPCS: XSS ok;
 			echo '</th>';
 		}
 
-		echo '<th class="qm-num qm-sorted-desc">';
+		echo '<th scope="col" class="qm-num qm-sorted-desc">';
 		esc_html_e( 'Time', 'query-monitor' );
 		echo $this->build_sorter(); // WPCS: XSS ok;
 		echo '</th>';
@@ -64,7 +62,7 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 				$stime = number_format_i18n( $row['ltime'], 4 );
 
 				echo '<tr>';
-				echo '<td class="qm-ltr"><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="' . esc_attr( $row['caller'] ) . '">' . esc_html( $row['caller'] ) . '</a></td>';
+				echo '<th scope="row" class="qm-ltr"><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="' . esc_attr( $row['caller'] ) . '">' . esc_html( $row['caller'] ) . '</a></th>';
 
 				foreach ( $data['types'] as $type_name => $type_count ) {
 					if ( isset( $row['types'][$type_name] ) ) {

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -35,23 +35,21 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0" class="qm-sortable">';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<thead>';
-		echo '<tr>';
-		echo '<th colspan="' . esc_attr( $span ) . '">' . esc_html( $this->collector->name() ) . '</th>';
-		echo '</tr>';
 
 		if ( !empty( $data['times'] ) ) {
 			echo '<tr>';
-			echo '<th>' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
 
 			foreach ( $data['types'] as $type_name => $type_count ) {
-				echo '<th class="qm-num">';
+				echo '<th scope="col" class="qm-num">';
 				echo esc_html( $type_name );
 				echo $this->build_sorter(); // WPCS: XSS ok;
 				echo '</th>';
 			}
 
-			echo '<th class="qm-num qm-sorted-desc">';
+			echo '<th scope="col" class="qm-num qm-sorted-desc">';
 			esc_html_e( 'Time', 'query-monitor' );
 			echo $this->build_sorter(); // WPCS: XSS ok;
 			echo '</th>';
@@ -69,7 +67,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 				$total_calls += $row['calls'];
 
 				echo '<tr>';
-				echo '<td><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="component" data-qm-value="' . esc_attr( $row['component'] ) . '">' . esc_html( $row['component'] ) . '</a></td>';
+				echo '<th scope="row"><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="component" data-qm-value="' . esc_attr( $row['component'] ) . '">' . esc_html( $row['component'] ) . '</a></th>';
 
 				foreach ( $data['types'] as $type_name => $type_count ) {
 					if ( isset( $row['types'][$type_name] ) ) {

--- a/output/html/db_dupes.php
+++ b/output/html/db_dupes.php
@@ -33,19 +33,17 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<thead>';
-		echo '<tr>';
-		echo '<th colspan="' . absint( $colspan ) . '">' . esc_html( $this->collector->name() ) . '</th>';
-		echo '</tr>';
 
 		echo '<tr>';
-		echo '<th>' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
-		echo '<th class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Callers', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Callers', 'query-monitor' ) . '</th>';
 		if ( ! empty( $data['dupe_components'] ) ) {
 			echo '<th>' . esc_html__( 'Components', 'query-monitor' ) . '</th>';
 		}
-		echo '<th>' . esc_html__( 'Potential Troublemakers', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Potential Troublemakers', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 
 		echo '</thead>';

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -52,11 +52,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		echo '<div class="qm qm-queries" id="' . esc_attr( $this->collector->id() ) . '-wpdb">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th>' . esc_html__( 'Database Queries', 'query-monitor' ) . '</th>';
-		echo '</tr>';
-		echo '</thead>';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<tbody>';
 		echo '<tr>';
 		echo '<td class="qm-warn">';
@@ -77,15 +73,13 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		echo '<div class="qm qm-queries" id="qm-query-errors">';
 		echo '<table cellspacing="0">';
+		echo '<caption>' . esc_html__( 'Database Errors', 'query-monitor' ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th colspan="4">' . esc_html__( 'Database Errors', 'query-monitor' ) . '</th>';
-		echo '</tr>';
-		echo '<tr>';
-		echo '<th>' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Error', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Error', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
@@ -106,15 +100,13 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		echo '<div class="qm qm-queries" id="qm-query-expensive">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th colspan="5" class="qm-expensive">';
+		echo '<caption>';
 		/* translators: %s: Database query time in seconds */
 		printf( esc_html__( 'Slow Database Queries (above %ss)', 'query-monitor' ),
 			'<span class="qm-expensive">' . esc_html( number_format_i18n( QM_DB_EXPENSIVE, $dp ) ) . '</span>'
 		);
-		echo '</th>';
-		echo '</tr>';
+		echo '</caption>';
+		echo '<thead>';
 		echo '<tr>';
 		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
@@ -127,7 +119,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			echo '<th scope="col" class="qm-num">' . esc_html__( 'Rows', 'query-monitor' ) . '</th>';
 		}
 
-		echo '<th class="qm-num">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
@@ -155,11 +147,9 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		echo '<div class="qm qm-queries" id="' . esc_attr( $this->collector->id() . '-' . sanitize_title_with_dashes( $name ) ) . '">';
 		echo '<table cellspacing="0" class="qm-sortable">';
-		echo '<thead>';
-		echo '<tr>';
 		/* translators: %s: Name of database controller */
-		echo '<th colspan="' . absint( $span ) . '">' . esc_html( sprintf( __( '%s Queries', 'query-monitor' ), $name ) ) . '</th>';
-		echo '</tr>';
+		echo '<caption>' . esc_html( sprintf( __( '%s Queries', 'query-monitor' ), $name ) ) . '</caption>';
+		echo '<thead>';
 
 		if ( !empty( $db->rows ) ) {
 

--- a/output/html/debug_bar.php
+++ b/output/html/debug_bar.php
@@ -27,11 +27,7 @@ class QM_Output_Html_Debug_Bar extends QM_Output_Html {
 
 		echo '<div class="qm qm-debug-bar" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th>' . esc_html( $this->collector->name() ) . '</th>';
-		echo '</tr>';
-		echo '</thead>';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
 		echo '<tbody>';
 
 		echo '<tr>';

--- a/output/html/environment.php
+++ b/output/html/environment.php
@@ -29,32 +29,34 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 
 		echo '<div class="qm qm-third">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
+		echo '<caption>PHP</caption>';
+		echo '<thead class="screen-reader-text">';
 		echo '<tr>';
-		echo '<th colspan="2">PHP</th>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
 
 		echo '<tr>';
-		echo '<td>version</td>';
+		echo '<th scope="row">version</th>';
 		echo '<td>' . esc_html( $data['php']['version'] ) . '</td>';
 		echo '</tr>';
 
 		echo '<tr>';
-		echo '<td>sapi</td>';
+		echo '<th scope="row">sapi</th>';
 		echo '<td>' . esc_html( $data['php']['sapi'] ) . '</td>';
 		echo '</tr>';
 
 		if ( isset( $data['php']['hhvm'] ) ) {
 			echo '<tr>';
-			echo '<td>hhvm</td>';
+			echo '<th scope="row">hhvm</th>';
 			echo '<td>' . esc_html( $data['php']['hhvm'] ) . '</td>';
 			echo '</tr>';
 		}
 
 		echo '<tr>';
-		echo '<td>user</td>';
+		echo '<th scope="row">user</th>';
 		if ( !empty( $data['php']['user'] ) ) {
 			echo '<td>' . esc_html( $data['php']['user'] ) . '</td>';
 		} else {
@@ -65,7 +67,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		foreach ( $data['php']['variables'] as $key => $val ) {
 
 			echo '<tr>';
-			echo '<td>' . esc_html( $key ) . '</td>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
 			echo '<td class="qm-wrap">';
 			echo esc_html( $val['after'] );
 
@@ -87,7 +89,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		$error_levels = implode( '<br>&nbsp;', array_map( 'esc_html', $this->collector->get_error_levels( $data['php']['error_reporting'] ) ) );
 
 		echo '<tr>';
-		echo '<td>error_reporting</td>';
+		echo '<th scope="row">error_reporting</th>';
 		echo '<td class="qm-wrap">' . esc_html( $data['php']['error_reporting'] ) . '<br><span class="qm-info">&nbsp;';
 		echo $error_levels; // WPCS: XSS ok.
 		echo '</span></td>';
@@ -110,9 +112,11 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 
 				echo '<div class="qm qm-third">';
 				echo '<table cellspacing="0">';
-				echo '<thead>';
+				echo '<caption>' . esc_html( $name ) . '</caption>';
+				echo '<thead class="screen-reader-text">';
 				echo '<tr>';
-				echo '<th colspan="2">' . esc_html( $name ) . '</th>';
+				echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+				echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
 				echo '</tr>';
 				echo '</thead>';
 				echo '<tbody>';
@@ -120,7 +124,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 				foreach ( $db['info'] as $key => $value ) {
 
 					echo '<tr>';
-					echo '<td>' . esc_html( $key ) . '</td>';
+					echo '<th scope="row">' . esc_html( $key ) . '</th>';
 
 					if ( ! isset( $value ) ) {
 						echo '<td><span class="qm-warn">' . esc_html__( 'Unknown', 'query-monitor' ) . '</span></td>';
@@ -147,7 +151,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 
 					if ( ( true === $db['vars'][$key] ) and empty( $val ) ) {
 						$show_warning = true;
-					} else if ( is_string( $db['vars'][$key] ) and ( $val !== $db['vars'][$key] ) ) {
+					} elseif ( is_string( $db['vars'][$key] ) and ( $val !== $db['vars'][$key] ) ) {
 						$show_warning = true;
 					}
 
@@ -172,7 +176,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 						echo '<tr class="' . esc_attr( $class ) . '"">';
 					}
 
-					echo '<td>' . esc_html( $key ) . '</td>';
+					echo '<th scope="row">' . esc_html( $key ) . '</th>';
 					echo '<td class="qm-wrap">';
 					echo esc_html( $val );
 					echo $append; // WPCS: XSS ok.
@@ -194,9 +198,11 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 
 		echo '<div class="qm qm-third" style="float:right !important">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
+		echo '<caption>WordPress</caption>';
+		echo '<thead class="screen-reader-text">';
 		echo '<tr>';
-		echo '<th colspan="2">WordPress</th>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
@@ -204,7 +210,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		foreach ( $data['wp'] as $key => $val ) {
 
 			echo '<tr>';
-			echo '<td>' . esc_html( $key ) . '</td>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
 			echo '<td class="qm-wrap">' . esc_html( $val ) . '</td>';
 			echo '</tr>';
 
@@ -216,20 +222,22 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 
 		echo '<div class="qm qm-third">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
+		echo '<caption>' . esc_html__( 'Server', 'query-monitor' ) . '</caption>';
+		echo '<thead class="screen-reader-text">';
 		echo '<tr>';
-		echo '<th colspan="2">' . esc_html__( 'Server', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
 
 		echo '<tr>';
-		echo '<td>' . esc_html__( 'software', 'query-monitor' ) . '</td>';
+		echo '<th scope="row">' . esc_html__( 'software', 'query-monitor' ) . '</th>';
 		echo '<td class="qm-wrap">' . esc_html( $data['server']['name'] ) . '</td>';
 		echo '</tr>';
 
 		echo '<tr>';
-		echo '<td>' . esc_html__( 'version', 'query-monitor' ) . '</td>';
+		echo '<th scope="row">' . esc_html__( 'version', 'query-monitor' ) . '</th>';
 		if ( !empty( $data['server']['version'] ) ) {
 			echo '<td class="qm-wrap">' . esc_html( $data['server']['version'] ) . '</td>';
 		} else {
@@ -238,7 +246,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		echo '</tr>';
 
 		echo '<tr>';
-		echo '<td>' . esc_html__( 'address', 'query-monitor' ) . '</td>';
+		echo '<th scope="row">' . esc_html__( 'address', 'query-monitor' ) . '</th>';
 		if ( !empty( $data['server']['address'] ) ) {
 			echo '<td class="qm-wrap">' . esc_html( $data['server']['address'] ) . '</td>';
 		} else {
@@ -247,7 +255,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		echo '</tr>';
 
 		echo '<tr>';
-		echo '<td>' . esc_html__( 'host', 'query-monitor' ) . '</td>';
+		echo '<th scope="row">' . esc_html__( 'host', 'query-monitor' ) . '</th>';
 		echo '<td class="qm-wrap">' . esc_html( $data['server']['host'] ) . '</td>';
 		echo '</tr>';
 

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -39,12 +39,13 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption class="screen-reader-text">' . esc_html__( 'Hooks', 'query-monitor' ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th>';
+		echo '<th scope="col">';
 		echo $this->build_filter( 'name', $data['parts'], __( 'Hook', 'query-monitor' ) ); // WPCS: XSS ok.
 		echo '</th>';
-		echo '<th colspan="3">';
+		echo '<th  scope="col" colspan="3">';
 		echo $this->build_filter( 'component', $data['components'], __( 'Actions', 'query-monitor' ), 'subject' ); // WPCS: XSS ok.
 		echo '</th>';
 		echo '</tr>';
@@ -101,7 +102,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 
 					if ( $first ) {
 
-						echo "<th rowspan='" . absint( $rowspan ) . "' class='qm-nowrap'>";
+						echo '<th scope="row" rowspan="' . absint( $rowspan ) . '" class="qm-nowrap">';
 						echo $hook_name; // WPCS: XSS ok.
 						if ( 'all' === $hook['name'] ) {
 							echo '<br><span class="qm-warn">';
@@ -145,7 +146,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 
 			} else {
 				echo "<tr{$attr}>"; // WPCS: XSS ok.
-				echo '<th>';
+				echo '<th scope="row">';
 				echo $hook_name; // WPCS: XSS ok.
 				echo '</th>';
 				echo '<td colspan="3">&nbsp;</td>';

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -30,9 +30,10 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0" class="qm-sortable">';
+		echo '<caption class="screen-reader-text">' . esc_html__( 'HTTP Requests', 'query-monitor' ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th class="qm-sorted-asc">&nbsp;';
+		echo '<th scope="col" class="qm-sorted-asc">&nbsp;';
 		echo $this->build_sorter(); // WPCS: XSS ok.
 		echo '</th>';
 		echo '<th scope="col">' . esc_html__( 'HTTP Request', 'query-monitor' ) . '</th>';

--- a/output/html/languages.php
+++ b/output/html/languages.php
@@ -33,14 +33,12 @@ class QM_Output_Html_Languages extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th colspan="4">' . esc_html( sprintf(
+		echo '<caption>' . esc_html( sprintf(
 			/* translators: %s: Name of current language */
 			__( 'Language Setting: %s', 'query-monitor' ),
 			$data['locale']
-		) ) . '</th>';
-		echo '</tr>';
+		) ) . '</caption>';
+		echo '<thead>';
 		echo '<tr>';
 		echo '<th>' . esc_html__( 'Text Domain', 'query-monitor' ) . '</th>';
 		echo '<th>' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -48,7 +48,7 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
-
+		echo '<caption class="screen-reader-text">' . esc_html( $this->collector->name() ). '</caption>';
 		echo '<thead>';
 		echo '<tr>';
 		echo '<th scope="col">' . esc_html__( 'Page generation time', 'query-monitor' ) . '</th>';

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -32,13 +32,14 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption class="screen-reader-text">' . esc_html( 'PHP Errors', 'query-monitor' ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th colspan="2">' . esc_html__( 'PHP Error', 'query-monitor' ) . '</th>';
-		echo '<th class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Location', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" colspan="2">' . esc_html__( 'PHP Error', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Location', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 		echo '<tbody>';
@@ -59,7 +60,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 			if ( isset( $data['errors'][$type] ) ) {
 
 				echo '<tr>';
-				echo '<td rowspan="' . count( $data['errors'][$type] ) . '">' . esc_html( $title ) . '</td>';
+				echo '<th scope="row" rowspan="' . count( $data['errors'][$type] ) . '">' . esc_html( $title ) . '</th>';
 				$first = true;
 
 				foreach ( $data['errors'][$type] as $error ) {
@@ -71,7 +72,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 					$component = $error->trace->get_component();
 					$message   = wp_strip_all_tags( $error->message );
 
-					echo '<td>' . esc_html( $message ) . '</td>';
+					echo '<th scope="row">' . esc_html( $message ) . '</th>';
 					echo '<td>' . esc_html( number_format_i18n( $error->calls ) ) . '</td>';
 					echo '<td>';
 					echo self::output_filename( $error->filename . ':' . $error->line, $error->file, $error->line ); // WPCS: XSS ok.

--- a/output/html/request.php
+++ b/output/html/request.php
@@ -27,6 +27,13 @@ class QM_Output_Html_Request extends QM_Output_Html {
 
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption class="screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
+		echo '<thead class="screen-reader-text">';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" colspan="2">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
 		echo '<tbody>';
 
 		foreach ( array(

--- a/output/html/rewrites.php
+++ b/output/html/rewrites.php
@@ -28,9 +28,11 @@ class QM_Output_Html_Rewrites extends QM_Output_Html {
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
 
-		echo '<thead>';
+		echo '<caption>' . esc_html__( 'Matching Rewrite Rules', 'query-monitor' ) . '</caption>';
+		echo '<thead class="screen-reader-text">';
 		echo '<tr>';
-		echo '<th valign="top" colspan="2">' . esc_html__( 'Matching Rewrite Rules', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Rule', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -31,10 +31,17 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 		echo '<div class="qm qm-half" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption>' . esc_html( $this->collector->name() ) . '</caption>';
+		echo '<thead>';
+		echo '<tr class="screen-reader-text">';
+		echo '<th scope="col">' . esc_html__( 'Data', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
 		echo '<tbody>';
 
 		echo '<tr>';
-		echo '<th>' . esc_html__( 'Template File', 'query-monitor' ) . '</th>';
+		echo '<th scope="row">' . esc_html__( 'Template File', 'query-monitor' ) . '</th>';
 		if ( ! empty( $data['template_path'] ) ) {
 
 			if ( $data['is_child_theme'] ) {
@@ -53,7 +60,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 			$count = count( $data['template_parts'] );
 			echo '<tr>';
-			echo '<th rowspan="' . absint( $count ) . '">' . esc_html__( 'Template Parts', 'query-monitor' ) . '</th>';
+			echo '<th scope="row" rowspan="' . absint( $count ) . '">' . esc_html__( 'Template Parts', 'query-monitor' ) . '</th>';
 			if ( $data['is_child_theme'] ) {
 				$parts = $data['theme_template_parts'];
 			} else {
@@ -76,7 +83,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 		} else {
 			echo '<tr>';
-			echo '<th>' . esc_html__( 'Template Parts', 'query-monitor' ) . '</th>';
+			echo '<th scope="row">' . esc_html__( 'Template Parts', 'query-monitor' ) . '</th>';
 			echo '<td><em>' . esc_html__( 'None', 'query-monitor' ) . '</em></td>';
 			echo '</tr>';
 		}
@@ -85,7 +92,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 			$count = count( $data['timber_files'] );
 			echo '<tr>';
-			echo '<th rowspan="' . absint( $count ) . '">' . esc_html__( 'Timber Files', 'query-monitor' ) . '</th>';
+			echo '<th scope="row" rowspan="' . absint( $count ) . '">' . esc_html__( 'Timber Files', 'query-monitor' ) . '</th>';
 			$first = true;
 
 			foreach ( $data['timber_files'] as $filename ) {
@@ -105,16 +112,16 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 
 		echo '<tr>';
 		if ( $data['is_child_theme'] ) {
-			echo '<th>' . esc_html__( 'Child Theme', 'query-monitor' ) . '</th>';
+			echo '<th scope="row">' . esc_html__( 'Child Theme', 'query-monitor' ) . '</th>';
 		} else {
-			echo '<th>' . esc_html__( 'Theme', 'query-monitor' ) . '</th>';
+			echo '<th scope="row">' . esc_html__( 'Theme', 'query-monitor' ) . '</th>';
 		}
 		echo '<td>' . esc_html( $data['stylesheet'] ) . '</td>';
 		echo '</tr>';
 
 		if ( $data['is_child_theme'] ) {
 			echo '<tr>';
-			echo '<th>' . esc_html__( 'Parent Theme', 'query-monitor' ) . '</th>';
+			echo '<th scope="row">' . esc_html__( 'Parent Theme', 'query-monitor' ) . '</th>';
 			echo '<td>' . esc_html( $data['template'] ) . '</td>';
 			echo '</tr>';
 		}
@@ -122,7 +129,7 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 		if ( !empty( $data['body_class'] ) ) {
 
 			echo '<tr>';
-			echo '<th rowspan="' . count( $data['body_class'] ) . '">' . esc_html__( 'Body Classes', 'query-monitor' ) . '</th>';
+			echo '<th row="scope" rowspan="' . count( $data['body_class'] ) . '">' . esc_html__( 'Body Classes', 'query-monitor' ) . '</th>';
 			$first = true;
 
 			foreach ( $data['body_class'] as $class ) {

--- a/output/html/transients.php
+++ b/output/html/transients.php
@@ -27,17 +27,18 @@ class QM_Output_Html_Transients extends QM_Output_Html {
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
+		echo '<caption class="screen-reader-text">' . esc_html__( 'Transients', 'query-monitor' ) . '</caption>';
 		echo '<thead>';
 		echo '<tr>';
-		echo '<th>' . esc_html__( 'Transient Set', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Transient Set', 'query-monitor' ) . '</th>';
 		if ( is_multisite() ) {
-			echo '<th>' . esc_html__( 'Type', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Type', 'query-monitor' ) . '</th>';
 		}
 		if ( !empty( $data['trans'] ) and isset( $data['trans'][0]['expiration'] ) ) {
-			echo '<th>' . esc_html__( 'Expiration', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Expiration', 'query-monitor' ) . '</th>';
 		}
-		echo '<th>' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
-		echo '<th>' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 


### PR DESCRIPTION
Many of the output tables were using a single row `thead` as a way to _title_ the table. This is incorrect, and a `caption` element is both more semantic and user-friendly to screen-readers (it won't potentially get read out again and again like a table heading would).

Most of the tables also didn't have `scope` attributes for `th` elements. This commit adds explicit values in for the `scope` attributes.

All bar a couple of instances, the tables should visually look exactly the same as they do now.

There are two discrepancies:

1. The _Conditionals_ table isn't really tabular data, and may need further improvements to indicate to screen readers which conditionals are true and which are not. Something like the following may benefit screen readers:

    ```
    <h3 class="screen-reader-text">Satisfied Conditionals</h3>
    <ul>
        <li>...</li>
        <li>...</li>
    </ul>
    <ul aria-hidden="true">
        <li>...</li>
        <li>...</li>
    </ul>
    ```

    Where the second list (unsatisfied conditionals) is hidden from screen readers - just indicate success to them, like the admin toolbar dropdown does. Obviously some CSS is needed to then turn that into the appearance similar to how it currently is.

2. The _Admin_ table is sufficiently complex, that [this table validator](http://wet-boew.github.io/wet-boew-legacy/v3.1/demos/tableparser/validator-htmltable.html#fnb2) suggests using `id` and `headers` attributes instead of `scope`. As such, I've not added `scope` in to this table so it's no worse than it currently is.

I've left each output file as an individual commit to allow easier following, and notes per commit. You may wish to squash these down during merging.