### PR TITLE
Save user options

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -577,6 +577,8 @@ select.qm-filter {
 	margin: 0 auto !important;
 }
 
+.qm .qm-sort:focus { box-shadow: none !important; }
+
 .qm .qm-sort-asc {
 	margin-bottom: 1px !important;
 }
@@ -588,7 +590,10 @@ select.qm-filter {
 .qm .qm-sorted-asc .qm-sort-asc:before {
 	color: #333 !important;
 	content: "\25b2" !important;
+	transition: 0.4s;
 }
+
+	.qm .qm-sort-asc.qm-user-option-saved:before { color: #2196F3 !important; }
 
 .qm .qm-sort-desc {
 	margin-top: 1px !important;
@@ -601,7 +606,10 @@ select.qm-filter {
 .qm .qm-sorted-desc .qm-sort-desc:before {
 	color: #333 !important;
 	content: "\25bc" !important;
+	transition: 0.4s;
 }
+
+	.qm .qm-sort-desc.qm-user-option-saved:before { color: #2196F3 !important; }
 
 /* RTL */
 

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -233,6 +233,44 @@ jQuery( function($) {
 
 	});
 
+	$('#qm').find('[data-qm-user-option-key]').on('click',function(ev) {
+		if (
+			'undefined' !== ev.shiftKey
+			&& ev.shiftKey
+		) {
+			var el = $(this),
+				value = el.val();
+
+			if ('undefined' !== typeof el.data('qm-user-option-value'))
+				value = el.data('qm-user-option-value');
+			else if (
+				el.is('[type="checkbox"]')
+				|| el.is('[type="radio"]')
+			)
+				value = el.is(':checked');
+			else if (el.is('select'))
+				value = el.find('option[selected="selected"]').val();
+
+			var ajax_data = {
+				action : 'qm_save_user_pref',
+				key : el.data('qm-user-option-key'),
+				value : value
+			};
+
+			$.ajax(qm_l10n.ajaxurl,{
+				type : 'POST',
+				data : ajax_data,
+				success : function(response) {
+					el.addClass('qm-user-option-saved');
+					setTimeout(function() {
+						el.removeClass('qm-user-option-saved');
+					},1500);
+				}
+			});
+		}
+		return ev;
+	});
+
 	$( document ).ajaxSuccess( function( event, response, options ) {
 
 		var errors = response.getResponseHeader( 'X-QM-error-count' );

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -299,7 +299,7 @@ jQuery( function($) {
 
 /**
  * This is a modified version of:
- * 
+ *
  * jQuery table-sort v0.1.1
  * https://github.com/gajus/table-sort
  *
@@ -314,60 +314,60 @@ jQuery( function($) {
 		var settings = $.extend({
 			'debug': false
 		}, options);
-		
+
 		// @param	object	columns	NodeList table colums.
 		// @param	integer	row_width	defines the number of columns per row.
 		var table_to_array	= function (columns, row_width) {
 			if (settings.debug) {
 				console.time('table to array');
 			}
-		
+
 			columns = Array.prototype.slice.call(columns, 0);
-			
+
 			var rows      = [];
 			var row_index = 0;
-			
+
 			for (var i = 0, j = columns.length; i < j; i += row_width) {
 				var row	= [];
-				
+
 				for (var k = 0, l = row_width; k < l; k++) {
 					var e = columns[i+k];
-					
+
 					var data = e.dataset.qmSortWeight;
-					
+
 					if (data === undefined) {
 						data = e.textContent || e.innerText;
 					}
-					
+
 					var number = parseFloat(data);
-					
+
 					data = isNaN(number) ? data : number;
-					
+
 					row.push(data);
 				}
-				
+
 				rows.push({index: row_index++, data: row});
 			}
-			
+
 			if (settings.debug) {
 				console.timeEnd('table to array');
 			}
-			
+
 			return rows;
 		};
-		
+
 		if (!settings.target || !settings.target instanceof $) {
 			throw 'Target is not defined or it is not instance of jQuery.';
 		}
-		
+
 		settings.target.each(function () {
 			var table = $(this);
-			
+
 			table.find('.qm-sort').on('click', function (e) {
 				var desc = $(this).hasClass('qm-sort-desc');
-				
+
 				var index = $(this).closest('th').index();
- 
+
 				table.find('th').removeClass('qm-sorted-asc qm-sorted-desc');
 
 				if ( desc )
@@ -377,63 +377,63 @@ jQuery( function($) {
 
 				table.find('tbody:not(.qm-sort-no)').each(function () {
 					var tbody = $(this);
-					
+
 					var rows = this.rows;
-					
+
 					var anomalies = $(rows).has('[colspan]').detach();
-					
+
 					var columns = this.getElementsByTagName('td');
-					
+
 					if (this.data_matrix === undefined) {
 						this.data_matrix = table_to_array(columns, $(rows[0]).find('td').length);
 					}
-					
+
 					var data = this.data_matrix;
-					
+
 					if (settings.debug) {
 						console.time('sort data');
 					}
-					
+
 					data.sort(function (a, b) {
 						if (a.data[index] == b.data[index]) {
 							return 0;
 						}
-						
+
 						return (desc ? a.data[index] > b.data[index] : a.data[index] < b.data[index]) ? -1 : 1;
 					});
-										
+
 					if (settings.debug) {
 						console.timeEnd('sort data');
 						console.time('build table');
 					}
-					
+
 					// Will use this to re-attach the tbody object.
 					var table = tbody.parent();
-					
+
 					// Detach the tbody to prevent unnecassy overhead related
 					// to the browser environment.
 					tbody = tbody.detach();
-					
+
 					// Convert NodeList into an array.
 					rows = Array.prototype.slice.call(rows, 0);
-					
+
 					var last_row = rows[data[data.length-1].index];
-					
+
 					for (var i = 0, j = data.length-1; i < j; i++) {
 						tbody[0].insertBefore(rows[data[i].index], last_row);
-						
+
 						// Restore the index.
 						data[i].index = i;
 					}
-					
+
 					// // Restore the index.
 					data[data.length-1].index = data.length-1;
-					
+
 					tbody.prepend(anomalies);
-					
+
 					table.append(tbody);
-					
-					
+
+
 					if (settings.debug) {
 						console.timeEnd('build table');
 					}

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -172,7 +172,7 @@ class QM_Collector_DB_Queries extends QM_Collector {
 				$types[$type]['callers'][$caller]++;
 			}
 
-			$row = compact( 'caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace' );
+			$row = compact( 'i', 'caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace' );
 
 			if ( is_wp_error( $result ) ) {
 				$this->data['errors'][] = $row;

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -173,7 +173,9 @@ class QM_Collector_HTTP extends QM_Collector {
 			'airplane_mode_enabled'
 		) );
 
+		$i = 0;
 		foreach ( $this->data['http'] as $key => & $http ) {
+			$this->data['http'][$key]['i'] = $i;
 
 			if ( !isset( $http['response'] ) ) {
 				// Timed out
@@ -201,6 +203,7 @@ class QM_Collector_HTTP extends QM_Collector {
 			$this->log_type( $http['type'] );
 			$this->log_component( $http['component'], $http['ltime'], $http['type'] );
 
+			$i++;
 		}
 
 	}

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -36,7 +36,7 @@ class QM_Collector_HTTP extends QM_Collector {
 	 * Filter the arguments used in an HTTP request.
 	 *
 	 * Used to log the request, and to add the logging key to the arguments array.
-	 * 
+	 *
 	 * @param  array  $args HTTP request arguments.
 	 * @param  string $url  The request URL.
 	 * @return array        HTTP request arguments.
@@ -89,7 +89,7 @@ class QM_Collector_HTTP extends QM_Collector {
 
 	/**
 	 * Debugging action for the HTTP API.
-	 * 
+	 *
 	 * @param mixed  $response A parameter which varies depending on $action.
 	 * @param string $action   The debug action. Currently one of 'response' or 'transports_list'.
 	 * @param string $class    The HTTP transport class name.

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -25,6 +25,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'wp_ajax_qm_auth_on',         array( $this, 'ajax_on' ) );
 		add_action( 'wp_ajax_qm_auth_off',        array( $this, 'ajax_off' ) );
 		add_action( 'wp_ajax_nopriv_qm_auth_off', array( $this, 'ajax_off' ) );
+		add_action( 'wp_ajax_qm_save_user_pref',  array( $this, 'ajax_save_user_pref' ) );
 
 		add_action( 'shutdown',                   array( $this, 'dispatch' ), 0 );
 
@@ -82,6 +83,30 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		$text = __( 'Authentication cookie cleared.', 'query-monitor' );
 
 		wp_send_json_success( $text );
+
+	}
+
+	public function ajax_save_user_pref() {
+		$qm_prefs = get_user_option( 'qm_prefs' );
+		$key = $_REQUEST['key'];
+
+		if ( false === $qm_prefs )
+			$qm_prefs = array();
+
+		if ( !array_key_exists( $key, $qm_prefs ) || !is_array( $qm_prefs[$key] ) )
+			$qm_prefs[$key] = array();
+
+		if ( 'true' === $_REQUEST['value'] )
+			$_REQUEST['value'] = true;
+
+		if ( 'false' === $_REQUEST['value'] )
+			$_REQUEST['value'] = false;
+
+		$qm_prefs[$key] = $_REQUEST['value'];
+
+		update_user_option( get_current_user_id(), 'qm_prefs', $qm_prefs );
+
+		die(print_r($qm_prefs));
 
 	}
 

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -19,7 +19,12 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 	public $id = 'html';
 	public $did_footer = false;
 
+	public static $user_prefs = false;
+
 	public function __construct( QM_Plugin $qm ) {
+
+		if ( false === self::$user_prefs )
+			self::$user_prefs = get_user_option( 'qm_prefs' );
 
 		add_action( 'admin_bar_menu',             array( $this, 'action_admin_bar_menu' ), 999 );
 		add_action( 'wp_ajax_qm_auth_on',         array( $this, 'ajax_on' ) );

--- a/output/Html.php
+++ b/output/Html.php
@@ -223,10 +223,10 @@ abstract class QM_Output_Html extends QM_Output {
 	}
 
 	protected function get_user_pref( $key, $default = false ) {
-		$qm_prefs = get_user_option( 'qm_prefs' );
+		$prefs = get_user_option( 'qm_prefs' );
 
-		if ( false !== $qm_prefs && array_key_exists( $key, $qm_prefs ) )
-			return $qm_prefs[$key];
+		if ( $this->has_user_pref( $key, $prefs ) )
+			return $prefs[$key];
 
 		return $default;
 	}
@@ -234,6 +234,13 @@ abstract class QM_Output_Html extends QM_Output {
 		protected function get_user_pref_sort( $key, $default = false ) {
 			return $this->user_pref_sort = $this->get_user_pref( $key, $default );
 		}
+
+	protected function has_user_pref( $key, $prefs = false ) {
+		if ( false === $prefs )
+			$prefs = get_user_option( 'qm_prefs' );
+
+		return $prefs && is_array( $prefs ) && count( $prefs ) && array_key_exists( $key, $prefs );
+	}
 
 	protected function get_user_pref_sort_class( $col, $default = '' ) {
 		if (

--- a/output/Html.php
+++ b/output/Html.php
@@ -223,10 +223,8 @@ abstract class QM_Output_Html extends QM_Output {
 	}
 
 	protected function get_user_pref( $key, $default = false ) {
-		$prefs = get_user_option( 'qm_prefs' );
-
-		if ( $this->has_user_pref( $key, $prefs ) )
-			return $prefs[$key];
+		if ( $this->has_user_pref( $key, QM_Dispatcher_Html::$user_prefs ) )
+			return QM_Dispatcher_Html::$user_prefs[$key];
 
 		return $default;
 	}
@@ -237,7 +235,7 @@ abstract class QM_Output_Html extends QM_Output {
 
 	protected function has_user_pref( $key, $prefs = false ) {
 		if ( false === $prefs )
-			$prefs = get_user_option( 'qm_prefs' );
+			$prefs = QM_Dispatcher_Html::$user_prefs;
 
 		return $prefs && is_array( $prefs ) && count( $prefs ) && array_key_exists( $key, $prefs );
 	}

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -18,6 +18,15 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 
 	public function __construct( QM_Collector $collector ) {
 		parent::__construct( $collector );
+
+		$this->get_user_pref_sort(
+            $collector->id . '/sort', // user preference key name
+            array(
+                'col' => 'ltime',     // default column sorted
+                'order' => 'asc'      // default sort order
+            )
+        );
+
 		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 30 );
 	}
 
@@ -42,20 +51,22 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 		echo '<th>' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 
 		foreach ( $data['types'] as $type_name => $type_count ) {
-			echo '<th class="qm-num">';
+			echo '<th class="qm-num' . $this->get_user_pref_sort_class( $type_name ) . '">';
 			echo esc_html( $type_name );
-			echo $this->build_sorter(); // WPCS: XSS ok;
+			echo $this->build_sorter( $type_name ); // WPCS: XSS ok;
 			echo '</th>';
 		}
 
-		echo '<th class="qm-num qm-sorted-desc">';
+		echo '<th class="qm-num' . $this->get_user_pref_sort_class( 'ltime', ' qm-sorted-desc' ) . '">';
 		esc_html_e( 'Time', 'query-monitor' );
-		echo $this->build_sorter(); // WPCS: XSS ok;
+		echo $this->build_sorter( 'ltime' ); // WPCS: XSS ok;
 		echo '</th>';
 		echo '</tr>';
 		echo '</thead>';
 
 		if ( !empty( $data['times'] ) ) {
+
+			$data['times'] = $this->get_data_sorted_by_user_pref( $data['times'] );
 
 			echo '<tbody>';
 
@@ -109,6 +120,20 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 		echo '</table>';
 		echo '</div>';
 
+	}
+
+	public function get_sort_column_values( $data ) {
+		$sorter = array();
+
+		foreach ( $data as $row )
+			if ( 'ltime' !== $this->user_pref_sort['col'] )
+				$sorter[] = array_key_exists( $this->user_pref_sort['col'], $row['types'] )
+					? $row['types'][$this->user_pref_sort['col']]
+					: 0;
+			else
+				$sorter[] = $row[$this->user_pref_sort['col']];
+
+		return $sorter;
 	}
 
 	public function admin_menu( array $menu ) {


### PR DESCRIPTION
This PR adds the ability for a user to save their desired default sorting column/order, and other preferences. By holding the Shift key while clicking, the selection can be saved using AJAX and  `update_user_option`, and will be recalled when QM's output is regenerated.

So for example, if you want the Queries panel to be sorted by longest time, hold the Shift key, and click the down arrow under the Time column. That will save the configuration to `{$wpdb->prefix}_qm_prefs`, and will sort the table by that column from there on out.

One thing to note: to allow proper ordering of the DB Queries and HTTP panels by number, I added a new value to the data array, `i`.

This is probably not a finished product, but it's a large start. You can see more examples with [QMX's `qm-save-user-options` branch](https://github.com/crstauf/query-monitor-extend/tree/qm-save-user-options).
