### PR TITLE
Use latest HHVM on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
   - 5.6
   - 5.3
   - 5.2
-  - hhvm
 
 env:
   # WP nightly:
@@ -29,6 +28,29 @@ env:
 
 matrix:
   fast_finish: true
+  include:
+    - php: hhvm
+      env: WP_VERSION=nightly WP_MULTISITE=0
+      sudo: required
+      dist: trusty
+      group: edge
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+    - php: hhvm
+      env: WP_VERSION=nightly WP_MULTISITE=1
+      sudo: required
+      dist: trusty
+      group: edge
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
   allow_failures:
     - php: 7.1
     # allow failures on WP nightlies:
@@ -36,7 +58,7 @@ matrix:
     - env: WP_VERSION=nightly WP_MULTISITE=1
 
 before_script:
-    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
+    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script:
     - if [[ "$WP_VERSION" == "latest" ]]; then if find . -not \( -path ./vendor -prune \) -not \( -path ./features -prune \) -not \( -path ./tests/phpunit/includes/dummy-closures.php -prune \) -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi;


### PR DESCRIPTION
HHVM is no longer being developed for Ubuntu Precise, to use a current version of HHVM Ubuntu Trusty is required. Also HHVM on Trusty requires MySQL 5.6.

As the build matrix cannot mix and match OS environments with MySQL versions I've only added HHVM with `nightly` WordPress version for both single and multisite.

If WordPress versions `4.5` and `latest` are required a follow up pull request can be made.

See also: https://core.trac.wordpress.org/changeset/37555/trunk/.travis.yml
