### PR TITLE
fix menu color when using light admin theme and has suppressed notice

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -77,7 +77,7 @@ GNU General Public License for more details.
 	color: #fff !important;
 }
 
-body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover) .ab-label,
+body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover):not(.qm-notice-suppressed) .ab-label,
 #wp-admin-bar-query-monitor-deprecateds a,
 #wp-admin-bar-query-monitor-stricts a,
 #wp-admin-bar-query-monitor-notices a,


### PR DESCRIPTION
When using the light color scheme in the admin, and there's a suppressed notice, color of stats in top-level menu item is #eee, making it difficult to read. This change fixes that.