### PR TITLE
fix php errors when $wp_scripts is null

### DIFF
--- a/collectors/assets.php
+++ b/collectors/assets.php
@@ -32,7 +32,7 @@ class QM_Collector_Assets extends QM_Collector {
 		global $wp_scripts, $wp_styles;
 
 		$this->data['header']['styles'] = $wp_styles->done;
-		$this->data['header']['scripts'] = $wp_scripts->done;
+		$this->data['header']['scripts'] = $wp_scripts ? $wp_scripts->done : array();
 
 	}
 
@@ -47,7 +47,7 @@ class QM_Collector_Assets extends QM_Collector {
 		$this->data['raw']['scripts'] = $wp_scripts;
 		$this->data['raw']['styles']  = $wp_styles;
 
-		$this->data['footer']['scripts'] = array_diff( $wp_scripts->done, $this->data['header']['scripts'] );
+		$this->data['footer']['scripts'] = array_diff( $wp_scripts ? $wp_scripts->done : array(), $this->data['header']['scripts'] );
 		$this->data['footer']['styles']  = array_diff( $wp_styles->done, $this->data['header']['styles'] );
 
 	}


### PR DESCRIPTION
While debugging WordPress with XDebug, I noticed that in the login page at `/wp-admin/` the debugger stopped due to PHP errors because of `$wp_scripts` is null and it's not checked. Don't know if it happens on any other page, but this PR fixes that.