### PR TITLE
Add filter on built-in collectors files before including them

### DIFF
--- a/classes/QueryMonitor.php
+++ b/classes/QueryMonitor.php
@@ -26,7 +26,7 @@ class QueryMonitor extends QM_Plugin {
 		parent::__construct( $file );
 
 		# Load and register built-in collectors:
-		foreach ( glob( $this->plugin_path( 'collectors/*.php' ) ) as $file ) {
+		foreach ( apply_filters( 'qm/built-in-collectors', glob( $this->plugin_path( 'collectors/*.php' ) ) ) as $file ) {
 			include $file;
 		}
 


### PR DESCRIPTION
Just added a filter on built-in collectors files array, before including them, so we can remove / override a built-in collector from a third-party component.