### PR TITLE
PHP error handler : Add new hook qm/collect/new_php_error

### DIFF
--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -51,7 +51,9 @@ class QM_Collector_PHP_Errors extends QM_Collector {
 
 	}
 
-	public function error_handler( $errno, $message, $file = null, $line = null ) {
+	public function error_handler( $errno, $message, $file = null, $line = null, $context = null ) {
+
+		do_action( 'qm/collect/new_php_error', $errno, $message, $file, $line, $context );
 
 		switch ( $errno ) {
 


### PR DESCRIPTION
Hello,

Related to https://github.com/inpsyde/Wonolog/issues/22

The pull request adds a hook `qm/collect/new_php_error` on query-monitor PHP error collector, allowing third parties to catch all errors data. It is especially required when query-monitor overrides an error_handler function that was registered by an other component.

The pull request allows to write separate compatibility layers that hook the first component's handler on query-monitor new action, to completely restore the functionalities of the two handlers.

Note: I added the `$context` argument to query-monitor error_handler, so we could forwards to third parties the exact same arguments that PHP produced.

Bests regards,
Pierre