### PR TITLE
Ability to silence PHP errors from select plugins

### DIFF
--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -182,6 +182,145 @@ class QM_Collector_PHP_Errors extends QM_Collector {
 		restore_error_handler();
 	}
 
+	/**
+	 * Runs post-processing on the collected errors and updates the
+	 * errors collected in the data->errors property.
+	 *
+	 * Any unreportable errors are placed in the data->filtered_errors
+	 * property.
+	 */
+	public function process() {
+		if ( ! empty( $this->data ) && ! empty( $this->data['errors'] ) ) {
+			/**
+			 * Filters out non-reportable errors based on the errors
+			 * table.
+			 *
+			 * The table is empty by default. Users can specify errors
+			 * to filter by overriding it and adding PHP Error flags.
+			 *
+			 * Eg:- To show all errors in the 'foo' plugin except
+			 * phu notices use,
+			 *
+			 * ```php
+			 * add_filter( 'qm/collect/silent_php_errors', function( $table ) {
+			 *   $table['foo'] = E_ALL & ~E_NOTICE;
+			 *   return $table;
+			 * } );
+			 * ```
+			 */
+			$table = apply_filters( 'qm/collect/silent_php_errors', array() );
+
+			$this->data['filtered_errors'] = $this->filter_reportable_errors(
+				$this->data['errors'], $table
+			);
+
+			/**
+			 * Hides silent php errors from Query Monitor entirely.
+			 * Default is false, ie:- no hiding of silent php errors.
+			 *
+			 * ```php
+			 * add_filter( 'qm/collect/silent_php_errors', function( $hide ) {
+			 *   return false;
+			 * } );
+			 * ```
+			 */
+			$hide_silent_php_errors = apply_filters( 'qm/collect/hide_silent_php_errors', false );
+
+			if ( $hide_silent_php_errors ) {
+				$this->data['errors'] = $this->data['filtered_errors'];
+			}
+		}
+	}
+
+	/**
+	 * Filters the reportable php errors using the table specified. The
+	 * table used is empty by default. Users can customize the table
+	 * using the qm/collect/silent_php_errors filter.
+	 *
+	 * @param array $errors The collected errors
+	 * @param array $table The table of flags by plugin name
+	 * @return void Returns the filtered errors excluded non-reportable errors
+	 */
+	public function filter_reportable_errors( $errors, $table ) {
+		foreach ( $errors as $type => $type_errors ) {
+			foreach ( $type_errors as $error_id => $error ) {
+				$error_no   = $error->errno;
+				$error_file = $error->file;
+
+				foreach ( $table as $plugin_name => $flags ) {
+					if ( $this->is_plugin_file( $plugin_name, $error_file ) ) {
+						if ( ! $this->is_reportable_error( $error_no, $flags ) ) {
+							unset( $errors[ $type ][ $error_id ] );
+						}
+					}
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Checks if the file path is within the specified plugin. This is
+	 * used to scope an error's file path to a plugin.
+	 *
+	 * @param string $plugin_name The name of the plugin
+	 * @param string $file_path The full path to the file
+	 * @return bool
+	 */
+	public function is_plugin_file( $plugin_name, $file_path ) {
+		$plugin_name = trim( $plugin_name );
+		$file_path   = trim( $file_path );
+
+		if ( ! empty( $plugin_name ) && ! empty( $file_path ) ) {
+			$file_dir   = dirname( $file_path ) . '/';
+			$plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_name . '/';
+
+			return strpos( $file_dir, $plugin_dir ) === 0;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Checks if the error number specified is viewable based on the
+	 * flags specified.
+	 *
+	 * @param int $error_no The errno from PHP
+	 * @param int $flags The config flags specified by users
+	 * @return int Truthy int value if reportable else 0.
+	 *
+	 * Eg:- If a plugin had the config flags,
+	 *
+	 * E_ALL & ~E_NOTICE
+	 *
+	 * then,
+	 *
+	 * is_reportable_error( E_NOTICE, E_ALL & ~E_NOTICE ) is false
+	 * is_reportable_error( E_WARNING, E_ALL & ~E_NOTICE ) is true
+	 *
+	 * If the $flag is null, all errors are assumed to be
+	 * reportable by default.
+	 */
+	public function is_reportable_error( $error_no, $flags ) {
+		if ( ! is_null( $flags ) ) {
+			$result = $error_no & $flags;
+		} else {
+			$result = 1;
+		}
+
+		return (bool) $result;
+	}
+
+	/**
+	 * For testing purposes only. Sets the errors property manually.
+	 * Needed to test the filter since the data property is protected.
+	 *
+	 * @param array $errors The list of errors
+	 */
+	public function set_php_errors( $errors ) {
+		$this->data['errors'] = $errors;
+	}
 }
 
 # Load early to catch early errors

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -125,9 +125,11 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 
 		$data = $this->collector->get_data();
 
-		if ( ! empty( $data['errors'] ) ) {
-			foreach ( $data['errors'] as $type => $errors ) {
-				$class[] = 'qm-' . $type;
+		if ( ! empty( $data['filtered_errors'] ) ) {
+			foreach ( $data['filtered_errors'] as $type => $errors ) {
+				if ( ! empty( $errors ) ) {
+					$class[] = 'qm-' . $type;
+				}
 			}
 		}
 

--- a/tests/phpunit/test-collector-php-errors.php
+++ b/tests/phpunit/test-collector-php-errors.php
@@ -1,0 +1,178 @@
+<?php
+
+class TestCollectorPHPErrors extends QM_UnitTestCase {
+
+	public $collector;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->collector = new QM_Collector_PHP_Errors();
+	}
+
+	function tearDown() {
+		$this->collector->tear_down();
+
+		parent::tearDown();
+	}
+
+	function test_it_knows_null_flag_is_always_reportable() {
+		$actual = $this->collector->is_reportable_error(
+			E_NOTICE, null
+		);
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_knows_error_in_flags_is_reportable() {
+		$actual = $this->collector->is_reportable_error(
+			E_NOTICE, E_ALL & ~E_WARNING
+		);
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_knows_error_outside_flags_is_not_reportable() {
+		$actual = $this->collector->is_reportable_error(
+			E_NOTICE, E_ALL & ~E_NOTICE
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_same_error_and_flag_is_reportable() {
+		$actual = $this->collector->is_reportable_error(
+			E_NOTICE, E_NOTICE
+		);
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_knows_core_file_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-includes/plugin.php'
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_theme_file_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-content/themes/foo/taxonomy.php'
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_another_plugin_file_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-content/plugins/another-plugin/taxonomy.php'
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_empty_file_path_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . ''
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_empty_plugin_name_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'', ABSPATH . 'wp-content/plugins/foo/foo.php'
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_knows_plugin_file_is_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-content/plugins/foo/foo.php'
+		);
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_knows_internal_plugin_file_is_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-content/plugins/foo/includes/A/B/foo.php'
+		);
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_knows_plugin_extension_file_is_not_in_plugin() {
+		$actual = $this->collector->is_plugin_file(
+			'foo', ABSPATH . 'wp-content/plugins/foo-extension/foo-extension.php'
+		);
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_not_filter_any_error_by_default() {
+		$table = array();
+		$errors = array(
+			'notice' => array(
+				'abc' => array(
+					(object) array(
+						'errno' => 2,
+						'file'  => ABSPATH . 'wp-content/plugins/foo/foo.php'
+					)
+				)
+			)
+		);
+
+		$actual = $this->collector->filter_reportable_errors( $errors, $table );
+		$this->assertEquals( 1, count( $actual['notice'] ) );
+	}
+
+	function test_it_will_filter_notices_from_plugin() {
+		$table = array(
+			'foo' => ~E_NOTICE,
+		);
+
+		$errors = array(
+			'notice' => array(
+				'abc' => (object) array(
+					'errno' => E_NOTICE,
+					'file'  => ABSPATH . 'wp-content/plugins/foo/foo.php'
+				)
+			)
+		);
+
+		$actual = $this->collector->filter_reportable_errors( $errors, $table );
+		$this->assertEmpty( $actual['notice'] );
+	}
+
+	function test_it_can_process_and_filter_out_unreportable_errors() {
+		add_filter( 'qm/collect/silent_php_errors', function( $table ) {
+			$table['foo'] = ~E_NOTICE;
+			$table['bar'] = E_ALL;
+
+			return $table;
+		} );
+
+		$errors = array(
+			'notice' => array(
+				'abc' => (object) array(
+					'errno' => E_NOTICE,
+					'file'  => ABSPATH . 'wp-content/plugins/foo/foo.php'
+				),
+				'efg' => (object) array(
+					'errno' => E_NOTICE,
+					'file'  => ABSPATH . 'wp-content/plugins/bar/bar.php'
+				)
+			),
+		);
+
+		$this->collector->set_php_errors( $errors );
+		$this->collector->process();
+
+		$actual = $this->collector->get_data();
+
+		$this->assertEquals( 1, count( $actual['filtered_errors']['notice'] ) );
+	}
+}


### PR DESCRIPTION
I've added support for silencing PHP errors from select plugins in this PR. This fixes #239. The approach is pretty close to the filter hook mentioned on that ticket.

```php
	add_filter( 'qm/collect/silent_php_errors', function( $table ) {
		$table['bad-plugin'] = E_ALL & ~E_NOTICE & ~E_WARNING;
		return $table;
	} );
```
Here's the full [bad-plugin example](https://gist.github.com/dsawardekar/2a3e22d57d43de3ecfc726c4c28e7186). I'm excluding Notices & Warnings from it.

I also included a small filter hook(qm/collect/hide_silent_php_errors) to hide such errors from QM entirely. It is set to false by default. I found it handy in development environments.

Screenshot: http://imgur.com/a/kG70A