### PR TITLE
Add constant to disable error handling

### DIFF
--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -40,7 +40,10 @@ class QM_Collector_PHP_Errors extends QM_Collector {
 	}
 
 	public function __construct() {
-
+		if ( defined( 'QM_PHP_ERRORS_DISABLED' ) and QM_PHP_ERRORS_DISABLED ) {
+			return;
+		}
+		
 		parent::__construct();
 		set_error_handler( array( $this, 'error_handler' ) );
 		register_shutdown_function( array( $this, 'shutdown_handler' ) );


### PR DESCRIPTION
Adds support to disable the error handler in QM via constant.

If the site is using for example [Sentry](https://sentry.io) or [BugSnag](https://www.bugsnag.com/) or any other error tracker for handling errors we don't want QM overriding the error handling.