### PR TITLE
Log and display user capability checks

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -623,6 +623,7 @@ select.qm-filter {
 }
 
 .qm-hide,
+.qm-hide-user,
 .qm-hide-result,
 .qm-hide-name,
 .qm-hide-type,

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -623,6 +623,7 @@ select.qm-filter {
 }
 
 .qm-hide,
+.qm-hide-result,
 .qm-hide-name,
 .qm-hide-type,
 .qm-hide-caller,

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -53,6 +53,10 @@ class QM_Backtrace {
 		'get_sidebar'                => 1,
 		'get_footer'                 => 1,
 		'class_exists'               => 2,
+		'current_user_can'           => 3,
+		'user_can'                   => 4,
+		'current_user_can_for_blog'  => 4,
+		'author_can'                 => 4,
 	);
 	protected static $filtered = false;
 	protected $trace           = null;

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -248,7 +248,15 @@ class QM_Backtrace {
 					$args = array();
 					for ( $i = 0; $i < $show; $i++ ) {
 						if ( isset( $trace['args'][$i] ) ) {
-							$args[] = '\'' . $trace['args'][$i] . '\'';
+							if ( is_string( $trace['args'][$i] ) ) {
+								$args[] = '\'' . $trace['args'][$i] . '\'';
+							} elseif ( is_scalar( $trace['args'][$i] ) ) {
+								$args[] = $trace['args'][$i];
+							} elseif ( is_object( $trace['args'][$i] ) ) {
+								$args[] = get_class( $trace['args'][$i] );
+							} else {
+								$args[] = gettype( $trace['args'][$i] );
+							}
 						}
 					}
 					$return['id']      = $trace['function'] . '()';

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -254,12 +254,8 @@ class QM_Backtrace {
 						if ( isset( $trace['args'][$i] ) ) {
 							if ( is_string( $trace['args'][$i] ) ) {
 								$args[] = '\'' . $trace['args'][$i] . '\'';
-							} elseif ( is_scalar( $trace['args'][$i] ) ) {
-								$args[] = $trace['args'][$i];
-							} elseif ( is_object( $trace['args'][$i] ) ) {
-								$args[] = get_class( $trace['args'][$i] );
 							} else {
-								$args[] = gettype( $trace['args'][$i] );
+								$args[] = QM_Util::display_variable( $trace['args'][$i] );
 							}
 						}
 					}

--- a/classes/Collector.php
+++ b/classes/Collector.php
@@ -21,6 +21,7 @@ abstract class QM_Collector {
 		'types'           => array(),
 		'component_times' => array(),
 	);
+	protected static $hide_qm = null;
 
 	public function __construct() {}
 
@@ -106,6 +107,19 @@ abstract class QM_Collector {
 		$user['roles'] = $user_object->roles;
 
 		return $user;
+	}
+
+	public static function hide_qm() {
+		if ( null === self::$hide_qm ) {
+			self::$hide_qm = ( defined( 'QM_HIDE_SELF' ) && QM_HIDE_SELF );
+		}
+
+		return self::$hide_qm;
+	}
+
+	public function filter_remove_qm( array $item ) {
+		$component = $item['trace']->get_component();
+		return ( 'query-monitor' !== $component->context );
 	}
 
 	public function process() {}

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -330,6 +330,40 @@ class QM_Util {
 		return $type;
 	}
 
+	public static function display_variable( $value ) {
+		if ( is_string( $value ) ) {
+			return $value;
+		} elseif ( is_bool( $value ) ) {
+			return ( $value ) ? 'true' : 'false';
+		} elseif ( is_scalar( $value ) ) {
+			return $value;
+		} elseif ( is_object( $value ) ) {
+			$class = get_class( $value );
+			$id = false;
+
+			switch ( $class ) {
+
+				case 'WP_Post':
+				case 'WP_User':
+					$id = $value->ID;
+					break;
+
+				case 'WP_Term':
+					$id = $value->term_id;
+					break;
+
+			}
+
+			if ( $id ) {
+				return sprintf( '%s (ID:%d)', $class, $id );
+			}
+
+			return $class;
+		} else {
+			return gettype( $value );
+		}
+	}
+
 	public static function sort( array &$array, $field ) {
 		self::$sort_field = $field;
 		usort( $array, array( __CLASS__, '_sort' ) );

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -52,6 +52,8 @@ class QM_Collector_Caps extends QM_Collector {
 		$all_users = array();
 		$components = array();
 
+		$this->data['caps'] = array_filter( $this->data['caps'], array( $this, 'filter_remove_noise' ) );
+
 		if ( self::hide_qm() ) {
 			$this->data['caps'] = array_filter( $this->data['caps'], array( $this, 'filter_remove_qm' ) );
 		}
@@ -72,6 +74,30 @@ class QM_Collector_Caps extends QM_Collector {
 		$this->data['parts'] = array_unique( array_filter( $all_parts ) );
 		$this->data['users'] = array_unique( array_filter( $all_users ) );
 		$this->data['components'] = $components;
+	}
+
+	public function filter_remove_noise( array $cap ) {
+		$trace = $cap['trace']->get_trace();
+
+		$exclude_files = array(
+			ABSPATH . 'wp-admin/menu.php',
+			ABSPATH . 'wp-admin/includes/menu.php',
+		);
+		$exclude_functions = array(
+			'_wp_menu_output',
+			'wp_admin_bar_render',
+		);
+
+		foreach ( $trace as $item ) {
+			if ( isset( $item['file'] ) && in_array( $item['file'], $exclude_files, true ) ) {
+				return false;
+			}
+			if ( isset( $item['function'] ) && in_array( $item['function'], $exclude_functions, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 }

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -28,22 +28,6 @@ class QM_Collector_Caps extends QM_Collector {
 	}
 
 	public function filter_user_has_cap( array $user_caps, array $caps, array $args, WP_User $user ) {
-		$current = current_action();
-		$ignore  = array(
-			'_admin_menu',
-			'admin_menu',
-			'admin_bar_init',
-			'add_admin_bar_menus',
-			'adminmenu',
-			'admin_bar_menu',
-			'wp_before_admin_bar_render',
-			'wp_after_admin_bar_render',
-		);
-
-		if ( in_array( $current, $ignore, true ) ) {
-			// return $user_caps;
-		}
-
 		$trace = new QM_Backtrace;
 
 		$this->data['caps'][] = array(

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -1,0 +1,80 @@
+<?php
+/*
+Copyright 2009-2017 John Blackbourn
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+class QM_Collector_Caps extends QM_Collector {
+
+	public $id = 'caps';
+
+	public function name() {
+		return __( 'Capability Checks', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 9999, 4 );
+	}
+
+	public function filter_user_has_cap( array $user_caps, array $caps, array $args, WP_User $user ) {
+		$current = current_action();
+		$ignore  = array(
+			'_admin_menu',
+			'admin_menu',
+			'admin_bar_init',
+			'add_admin_bar_menus',
+			'adminmenu',
+			'admin_bar_menu',
+			'wp_before_admin_bar_render',
+			'wp_after_admin_bar_render',
+		);
+
+		if ( in_array( $current, $ignore, true ) ) {
+			// return $user_caps;
+		}
+
+		$trace = new QM_Backtrace;
+
+		$this->data['caps'][] = array(
+			'name'  => $args[0],
+			'trace' => $trace,
+		);
+
+		return $user_caps;
+	}
+
+	public function process() {
+		$all_parts = array();
+		$components = array();
+
+		foreach ( $this->data['caps'] as $i => $cap ) {
+			$parts = array_filter( preg_split( '#[_/-]#', $cap['name'] ) );
+			$this->data['caps'][ $i ]['parts'] = $parts;
+			$all_parts = array_merge( $all_parts, $parts );
+			$component = $cap['trace']->get_component();
+			$components[$component->name] = $component->name;
+		}
+
+		$this->data['parts'] = array_unique( array_filter( $all_parts ) );
+		$this->data['components'] = $components;
+	}
+
+}
+
+function register_qm_collector_caps( array $collectors, QueryMonitor $qm ) {
+	$collectors['caps'] = new QM_Collector_Caps;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_caps', 20, 2 );

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -39,8 +39,8 @@ class QM_Collector_Caps extends QM_Collector {
 		}
 
 		$this->data['caps'][] = array(
-			'name'  => $args[0],
-			'trace' => $trace,
+			'args'   => $args,
+			'trace'  => $trace,
 			'result' => $result,
 		);
 
@@ -52,8 +52,11 @@ class QM_Collector_Caps extends QM_Collector {
 		$components = array();
 
 		foreach ( $this->data['caps'] as $i => $cap ) {
-			$parts = array_filter( preg_split( '#[_/-]#', $cap['name'] ) );
+			$name = $cap['args'][0];
+			$parts = array_filter( preg_split( '#[_/-]#', $name ) );
 			$this->data['caps'][ $i ]['parts'] = $parts;
+			$this->data['caps'][ $i ]['name']  = $name;
+			$this->data['caps'][ $i ]['args']  = array_slice( $cap['args'], 2 );
 			$all_parts = array_merge( $all_parts, $parts );
 			$component = $cap['trace']->get_component();
 			$components[$component->name] = $component->name;

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -28,11 +28,20 @@ class QM_Collector_Caps extends QM_Collector {
 	}
 
 	public function filter_user_has_cap( array $user_caps, array $caps, array $args, WP_User $user ) {
-		$trace = new QM_Backtrace;
+		$trace  = new QM_Backtrace;
+		$result = true;
+
+		foreach ( $caps as $cap ) {
+			if ( empty( $user_caps[ $cap ] ) ) {
+				$result = false;
+				break;
+			}
+		}
 
 		$this->data['caps'][] = array(
 			'name'  => $args[0],
 			'trace' => $trace,
+			'result' => $result,
 		);
 
 		return $user_caps;

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -52,6 +52,10 @@ class QM_Collector_Caps extends QM_Collector {
 		$all_users = array();
 		$components = array();
 
+		if ( self::hide_qm() ) {
+			$this->data['caps'] = array_filter( $this->data['caps'], array( $this, 'filter_remove_qm' ) );
+		}
+
 		foreach ( $this->data['caps'] as $i => $cap ) {
 			$name = $cap['args'][0];
 			$parts = array_filter( preg_split( '#[_/-]#', $name ) );

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -49,6 +49,7 @@ class QM_Collector_Caps extends QM_Collector {
 
 	public function process() {
 		$all_parts = array();
+		$all_users = array();
 		$components = array();
 
 		foreach ( $this->data['caps'] as $i => $cap ) {
@@ -56,13 +57,16 @@ class QM_Collector_Caps extends QM_Collector {
 			$parts = array_filter( preg_split( '#[_/-]#', $name ) );
 			$this->data['caps'][ $i ]['parts'] = $parts;
 			$this->data['caps'][ $i ]['name']  = $name;
+			$this->data['caps'][ $i ]['user']  = $cap['args'][1];
 			$this->data['caps'][ $i ]['args']  = array_slice( $cap['args'], 2 );
 			$all_parts = array_merge( $all_parts, $parts );
+			$all_users[] = $cap['args'][1];
 			$component = $cap['trace']->get_component();
 			$components[$component->name] = $component->name;
 		}
 
 		$this->data['parts'] = array_unique( array_filter( $all_parts ) );
+		$this->data['users'] = array_unique( array_filter( $all_users ) );
 		$this->data['components'] = $components;
 	}
 

--- a/collectors/hooks.php
+++ b/collectors/hooks.php
@@ -18,7 +18,6 @@ class QM_Collector_Hooks extends QM_Collector {
 
 	public $id = 'hooks';
 	protected static $hide_core;
-	protected static $hide_qm;
 
 	public function name() {
 		return __( 'Hooks & Actions', 'query-monitor' );
@@ -28,7 +27,7 @@ class QM_Collector_Hooks extends QM_Collector {
 
 		global $wp_actions, $wp_filter;
 
-		self::$hide_qm = ( defined( 'QM_HIDE_SELF' ) && QM_HIDE_SELF );
+		self::$hide_qm   = self::hide_qm();
 		self::$hide_core = ( defined( 'QM_HIDE_CORE_HOOKS' ) && QM_HIDE_CORE_HOOKS );
 
 		if ( is_admin() and ( $admin = QM_Collectors::get( 'admin' ) ) ) {

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -18,7 +18,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 
 	public function __construct( QM_Collector $collector ) {
 		parent::__construct( $collector );
-		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 100 );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 105 );
 	}
 
 	public function output() {
@@ -171,4 +171,4 @@ function register_qm_output_html_caps( array $output, QM_Collectors $collectors 
 	return $output;
 }
 
-add_filter( 'qm/outputter/html', 'register_qm_output_html_caps', 100, 2 );
+add_filter( 'qm/outputter/html', 'register_qm_output_html_caps', 105, 2 );

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -24,6 +24,10 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 	public function output() {
 
 		$data = $this->collector->get_data();
+		$results = array(
+			'true',
+			'false',
+		);
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
@@ -34,6 +38,9 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 		echo '<tr>';
 		echo '<th scope="col">';
 		echo $this->build_filter( 'name', $data['parts'], __( 'Capability Check', 'query-monitor' ) ); // WPCS: XSS ok;
+		echo '</th>';
+		echo '<th scope="col">';
+		echo $this->build_filter( 'result', $results, __( 'Result', 'query-monitor' ) ); // WPCS: XSS ok;
 		echo '</th>';
 		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">';
@@ -50,6 +57,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			$row_attr = array();
 			$row_attr['data-qm-name']      = implode( ' ', $row['parts'] );
 			$row_attr['data-qm-component'] = $component->name;
+			$row_attr['data-qm-result']    = ( $row['result'] ) ? 'true' : 'false';
 
 			$attr = '';
 
@@ -65,6 +73,12 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			printf(
 				'<td class="qm-ltr qm-nowrap">%s</td>',
 				esc_html( $row['name'] )
+			);
+
+			$result = ( $row['result'] ) ? '<span class="qm-true">true&nbsp;&#x2713;</span>' : '<span class="qm-false">false</span>';
+			printf( // WPCS: XSS ok.
+				'<td class="qm-ltr qm-nowrap">%s</td>',
+				$result
 			);
 
 			$stack          = array();

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -64,7 +64,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			);
 
 			printf(
-				'<td class="qm-ltr">%s</td>',
+				'<td class="qm-ltr qm-nowrap">%s</td>',
 				esc_html( $row['name'] )
 			);
 
@@ -82,7 +82,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			}
 
 			printf( // WPCS: XSS ok.
-				'<td class="qm-nowrap qm-ltr">%s</td>',
+				'<td class="qm-wrap qm-ltr">%s</td>',
 				self::output_filename( $pure_name, $pure[1]['file'], $pure[1]['line'] )
 			);
 

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -1,0 +1,130 @@
+<?php
+/*
+Copyright 2009-2017 John Blackbourn
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+class QM_Output_Html_Caps extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 100 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
+		echo '<table cellspacing="0">';
+
+		echo '<caption class="screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">';
+		echo $this->build_filter( 'name', $data['parts'], __( 'Capability Check', 'query-monitor' ), $args ); // WPCS: XSS ok;
+		echo '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">';
+		echo $this->build_filter( 'component', $data['components'], __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $data['caps'] as $row ) {
+			$component = $row['trace']->get_component();
+
+			$row_attr = array();
+			$row_attr['data-qm-name']      = implode( ' ', $row['parts'] );
+			$row_attr['data-qm-component'] = $component->name;
+
+			$attr = '';
+
+			foreach ( $row_attr as $a => $v ) {
+				$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+			}
+
+			printf( // WPCS: XSS ok.
+				'<tr %s>',
+				$attr
+			);
+
+			printf(
+				'<td class="qm-ltr">%s</td>',
+				esc_html( $row['name'] )
+			);
+
+			$stack          = array();
+			$filtered_trace = $row['trace']->get_display_trace();
+			array_pop( $filtered_trace );
+
+			$pure = $row['trace']->get_trace();
+			$purest = count( $filtered_trace ) - 2;
+
+			if ( isset( $filtered_trace[ $purest ]['display'] ) ) {
+				$pure_name = $filtered_trace[ $purest ]['display'];
+			} else {
+				$pure_name = QM_Util::standard_dir( $pure[1]['file'], '' ) . ':' . $pure[1]['line'];
+			}
+
+			printf( // WPCS: XSS ok.
+				'<td class="qm-nowrap qm-ltr">%s</td>',
+				self::output_filename( $pure_name, $pure[1]['file'], $pure[1]['line'] )
+			);
+
+			foreach ( $filtered_trace as $item ) {
+				$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+			}
+
+			printf( // WPCS: XSS ok.
+				'<td class="qm-nowrap qm-ltr"><ol class="qm-numbered"><li>%s</li></ol></td>',
+				implode( '</li><li>', $stack )
+			);
+			printf(
+				'<td class="qm-nowrap">%s</td>',
+				esc_html( $component->name )
+			);
+
+			echo '</tr>';
+
+		}
+
+		echo '</tbody>';
+
+		echo '</table>';
+		echo '</div>';
+
+	}
+
+	public function admin_menu( array $menu ) {
+		$menu[] = $this->menu( array(
+			'title' => $this->collector->name(),
+		) );
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_caps( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'caps' ) ) {
+		$output['caps'] = new QM_Output_Html_Caps( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_caps', 100, 2 );

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -70,9 +70,17 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 				$attr
 			);
 
-			printf(
+			$name = esc_html( $row['name'] );
+
+			if ( ! empty( $row['args'] ) ) {
+				foreach ( $row['args'] as $arg ) {
+					$name .= '<br>' . esc_html( QM_Util::display_variable( $arg ) );
+				}
+			}
+
+			printf( // WPCS: XSS ok.
 				'<td class="qm-ltr qm-nowrap">%s</td>',
-				esc_html( $row['name'] )
+				$name
 			);
 
 			$result = ( $row['result'] ) ? '<span class="qm-true">true&nbsp;&#x2713;</span>' : '<span class="qm-false">false</span>';

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -33,7 +33,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 		echo '<thead>';
 		echo '<tr>';
 		echo '<th scope="col">';
-		echo $this->build_filter( 'name', $data['parts'], __( 'Capability Check', 'query-monitor' ), $args ); // WPCS: XSS ok;
+		echo $this->build_filter( 'name', $data['parts'], __( 'Capability Check', 'query-monitor' ) ); // WPCS: XSS ok;
 		echo '</th>';
 		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Call Stack', 'query-monitor' ) . '</th>';

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -28,6 +28,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			'true',
 			'false',
 		);
+		$show_user = ( count( $data['users'] ) > 1 );
 
 		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 		echo '<table cellspacing="0">';
@@ -39,6 +40,13 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 		echo '<th scope="col">';
 		echo $this->build_filter( 'name', $data['parts'], __( 'Capability Check', 'query-monitor' ) ); // WPCS: XSS ok;
 		echo '</th>';
+
+		if ( $show_user ) {
+			echo '<th scope="col">';
+			echo $this->build_filter( 'user', $data['users'], __( 'User', 'query-monitor' ) ); // WPCS: XSS ok;
+			echo '</th>';
+		}
+
 		echo '<th scope="col">';
 		echo $this->build_filter( 'result', $results, __( 'Result', 'query-monitor' ) ); // WPCS: XSS ok;
 		echo '</th>';
@@ -56,6 +64,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 
 			$row_attr = array();
 			$row_attr['data-qm-name']      = implode( ' ', $row['parts'] );
+			$row_attr['data-qm-user']      = $row['user'];
 			$row_attr['data-qm-component'] = $component->name;
 			$row_attr['data-qm-result']    = ( $row['result'] ) ? 'true' : 'false';
 
@@ -82,6 +91,13 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 				'<td class="qm-ltr qm-nowrap">%s</td>',
 				$name
 			);
+
+			if ( $show_user ) {
+				printf(
+					'<td class="qm-num">%s</td>',
+					esc_html( $row['user'] )
+				);
+			}
 
 			$result = ( $row['result'] ) ? '<span class="qm-true">true&nbsp;&#x2713;</span>' : '<span class="qm-false">false</span>';
 			printf( // WPCS: XSS ok.

--- a/tests/phpunit/test-dispatcher-html.php
+++ b/tests/phpunit/test-dispatcher-html.php
@@ -68,6 +68,7 @@ class Test_Dispatcher_HTML extends QM_UnitTestCase {
 			'admin'         => false,
 			'assets'        => false,
 			'cache'         => false,
+			'caps'          => true,
 			'conditionals'  => false,
 			'db_callers'    => true,
 			'db_components' => true,


### PR DESCRIPTION
This introduces a new panel which shows user capability checks that have been performed during the current page load.

The panel is quite noisy at the moment as it includes all cap checks from both the admin menu and the admin toolbar, which I think need filtering out by default.

Needs some thorough testing.

![screen shot 2017-10-18 at 13 53 37](https://user-images.githubusercontent.com/208434/31719597-dcdbc8da-b40b-11e7-90e0-31ec67f2903b.png)