### PR TITLE
MySQL 5.7.20 query_cache_* deprecated

### DIFF
--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -102,7 +102,7 @@ class QM_Collector_Environment extends QM_Collector {
 				if ( method_exists( $db, 'db_version' ) ) {
 					$server = $db->db_version();
 					// query_cache_* deprecated since MySQL 5.7.20
-					if ( version_compare( $server, '5.7.0', '>=' ) ) {
+					if ( version_compare( $server, '5.7.20', '>=' ) ) {
 						unset( $mysql_vars['query_cache_limit'], $mysql_vars['query_cache_size'], $mysql_vars['query_cache_type'] );
 					}
 				} else {

--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -99,6 +99,16 @@ class QM_Collector_Environment extends QM_Collector {
 
 			foreach ( $dbq->db_objects as $id => $db ) {
 
+				if ( method_exists( $db, 'db_version' ) ) {
+					$server = $db->db_version();
+					// query_cache_* deprecated since MySQL 5.7.20
+					if ( version_compare( $server, '5.7.0', '>=' ) ) {
+						unset( $mysql_vars['query_cache_limit'], $mysql_vars['query_cache_size'], $mysql_vars['query_cache_type'] );
+					}
+				} else {
+					$server = null;
+				}
+
 				$variables = $db->get_results( "
 					SHOW VARIABLES
 					WHERE Variable_name IN ( '" . implode( "', '", array_keys( $mysql_vars ) ) . "' )
@@ -113,12 +123,6 @@ class QM_Collector_Environment extends QM_Collector {
 				} else {
 					# Who knows?
 					$extension = null;
-				}
-
-				if ( method_exists( $db, 'db_version' ) ) {
-					$server = $db->db_version();
-				} else {
-					$server = null;
 				}
 
 				if ( isset( $db->use_mysqli ) && $db->use_mysqli ) {


### PR DESCRIPTION
MySQL 5.7.20 deprecated `query_cache_*` which results in false warnings.

See: https://dev.mysql.com/doc/refman/5.7/en/query-cache-configuration.html

This PR unsets the values in the `$mysql_vars` array when on a site running MySQL 5.7.20 or later.