### PR TITLE
Prevent output of scripts and styles in AMP to avoid validation errors

### DIFF
--- a/classes/debug_bar.php
+++ b/classes/debug_bar.php
@@ -16,6 +16,10 @@ class Debug_Bar {
 	}
 
 	public function enqueue() {
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return;
+		}
+
 		wp_register_style( 'debug-bar', false, array(
 			'query-monitor',
 		) );
@@ -33,6 +37,10 @@ class Debug_Bar {
 	}
 
 	public function ensure_ajaxurl() {
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return;
+		}
+
 		?>
 		<script type="text/javascript">
 		var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';

--- a/classes/debug_bar.php
+++ b/classes/debug_bar.php
@@ -11,7 +11,10 @@ class Debug_Bar {
 	public function __construct() {
 		add_action( 'wp_head', array( $this, 'ensure_ajaxurl' ), 1 );
 
-		$this->enqueue();
+		add_action( 'wp_enqueue_scripts',    array( $this, 'enqueue' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+		add_action( 'login_enqueue_scripts', array( $this, 'enqueue' ) );
+		add_action( 'enqueue_embed_scripts', array( $this, 'enqueue' ) );
 		$this->init_panels();
 	}
 

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -105,7 +105,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 	public function init() {
 
-		if ( ! $this->user_can_view() ) {
+		if ( ! $this->user_can_view() || ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
 			return;
 		}
 

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -105,7 +105,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 	public function init() {
 
-		if ( ! $this->user_can_view() || ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
+		if ( ! $this->user_can_view() ) {
 			return;
 		}
 
@@ -134,6 +134,9 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 	public function enqueue_assets() {
 		global $wp_locale, $wp_version;
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return;
+		}
 
 		$deps = array(
 			'jquery-core',


### PR DESCRIPTION
Version 0.7 of the AMP plugin adds `amp` theme support. When present, any erroneous scripts or styles which are invalid AMP are detected and reported as validation errors. This PR short-circuits Query Monitor from outputting any scripts or styles when serving AMP. Eventually it would be nice if there was a lightweight AMP display of the QM data, but this at least makes it so that Query Monitor doesn't interfere with AMP responses. 