### PR TITLE
reset inline height and remove localStorage height on close

### DIFF
--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -395,8 +395,9 @@ if ( window.jQuery ) {
 		});
 
 		$('.qm-button-container-close').click(function(){
-			$('#query-monitor').removeClass('qm-show');
+			$('#query-monitor').removeClass('qm-show').height('');
 			localStorage.removeItem( container_pinned_key );
+			localStorage.removeItem( container_storage_key );
 			$('.qm-button-container-pin').removeClass( 'qm-button-active' );
 		});
 


### PR DESCRIPTION
Fixes #326 

Reset the height on the `#query-monitor` element and remove the localStorage `qm-container-height` item when `.qm-button-container-close` gets clicked.