### PR TITLE
Template Part file string normalization

### DIFF
--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -121,6 +121,7 @@ class QM_Collector_Theme extends QM_Collector {
 			$this->data['template_hierarchy']   = array_unique( $this->data['template_hierarchy'] );
 
 			foreach ( get_included_files() as $file ) {
+				$file = wp_normalize_path( $file );
 				$filename = str_replace( array(
 					$stylesheet_directory,
 					$template_directory,


### PR DESCRIPTION
The template parts were not showing up on my machine because the file strings returned by get_included_files() have \ instead of / directory separators which caused the string comparisons to fail. Using wp_normalize_path ensures the separators match.