### PR TITLE
Check for ajax request with core function

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -263,10 +263,8 @@ class QM_Util {
 	}
 
 	public static function is_ajax() {
-		if ( defined( 'DOING_AJAX' ) and DOING_AJAX ) {
-			return true;
-		}
-		return false;
+
+		return function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : apply_filters( 'wp_doing_ajax', defined( 'DOING_AJAX' ) && DOING_AJAX );
 	}
 
 	public static function is_async() {


### PR DESCRIPTION
Since 4.7.0 `wp_doing_ajax` is introduced in core to check the ajax request. So, this can be used unless found.