### PR TITLE
Build/PHPCS: use PHPCompatibilityWP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require-dev" : {
 		"squizlabs/php_codesniffer": "^3.2",
-		"phpcompatibility/php-compatibility": "~8.2",
+		"phpcompatibility/phpcompatibility-wp": "^1.0",
 		"wp-coding-standards/wpcs": "0.13",
 		"phpunit/phpunit": "^5"
   }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Query Monitor">
 
-	<config name="installed_paths" value="../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility" />
+	<config name="installed_paths" value="../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-wp" />
 	<config name="testVersion" value="5.3-"/>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
@@ -78,6 +78,8 @@
 			<property name="additionalWordDelimiters" value="-/"/>
 		</properties>
 	</rule>
+
+	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- The following files use mysql_*() functions within mysqli conditional logic -->
 	<rule ref="PHPCompatibility.PHP.RemovedExtensions.mysql_DeprecatedRemoved">


### PR DESCRIPTION
This PR:
* Switches the repo over to use `PHPCompatibilityWP` rather than `PHPCompatibility`.
    As this repo and ruleset is a WordPress projects, using the `PHPCompatibilityWP` ruleset is the better choice to prevent false positives for PHP functions and constants which are back-filled by WP.
* Actually adds the `PHPCompatibilityWP` standard to the custom ruleset to activate it.

### References:
* https://github.com/PHPCompatibility/PHPCompatibilityWP
* https://github.com/PHPCompatibility/PHPCompatibility/issues/688
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0