### PR TITLE
Bugfix: min-width CSS for buttons

### DIFF
--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -250,6 +250,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		margin: 0 0 0 0px !important;
 		display: inline-block !important;
 		padding: 0px 4px !important;
+		min-width: auto !important;
 	}
 
 	#qm-title button:focus,

--- a/assets/query-monitor-dark.css
+++ b/assets/query-monitor-dark.css
@@ -3,6 +3,18 @@
  *
  * @package query-monitor
  */
+/**
+ * Dark Mode Colours
+ */
+/** 
+ * The colours below are loosely based on the WordPress branding colours.
+ * https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
+ */
+/**
+ * All the styles for Query Monitor.
+ *
+ * @package query-monitor
+ */
 /* === Admin Toolbar === */
 #wpadminbar .quicklinks .menupop ul li.qm-true > a {
   color: #8c8 !important;
@@ -221,6 +233,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 0 0 0px !important;
   display: inline-block !important;
   padding: 0px 4px !important;
+  min-width: auto !important;
 }
 #query-monitor #qm-title button:focus,
 #query-monitor #qm-title button:hover {

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -3,6 +3,11 @@
  *
  * @package query-monitor
  */
+/**
+ * All the styles for Query Monitor.
+ *
+ * @package query-monitor
+ */
 /* === Admin Toolbar === */
 #wpadminbar .quicklinks .menupop ul li.qm-true > a {
   color: #8c8 !important;
@@ -221,6 +226,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 0 0 0px !important;
   display: inline-block !important;
   padding: 0px 4px !important;
+  min-width: auto !important;
 }
 #query-monitor #qm-title button:focus,
 #query-monitor #qm-title button:hover {


### PR DESCRIPTION
I had a client project that used `min-width` for the global button styles and I noticed it was affecting the QM styles as well.

I'm not sure if the output is correct, but hopefully this will point you in the right direction if I messed up. :) 