### PR TITLE
Trim asset source

### DIFF
--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -214,7 +214,7 @@ class QM_Output_Html_Assets extends QM_Output_Html {
 			printf(
 				'<a href="%s" class="qm-link">%s</a>',
 				esc_attr( $src ),
-				esc_html( $src )
+				esc_html( str_replace( home_url(), '', $src ) )
 			);
 		}
 		echo '</td>';


### PR DESCRIPTION
Remove `home_url()` from printed asset source (URL).