### PR TITLE
updated CSS to avoid conflicts with themes using ul, nav, and li class names

### DIFF
--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -355,6 +355,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		flex-shrink: 0 !important;
 		overflow-y:  scroll !important;
 		overscroll-behavior: contain !important;
+		height: auto !important;
 	}
 
 	#qm-panel-menu ul {
@@ -362,12 +363,15 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		list-style: none !important;
 		margin: 0 !important;
 		padding: 0 !important;
+		width: auto !important;
+		height: auto !important;
 	}
 
 	#qm-panel-menu li {
 		display: list-item !important;
 		margin: 0 !important;
 		padding: 0 !important;
+		height: auto !important;
 	}
 
 	#qm-panel-menu li button {


### PR DESCRIPTION
## Issue
I recently ran into an issue with the CSS of a WordPress theme affecting layout of the Query Monitor panel. Specifically, class names in the Theme using `ul`, `li`, and `nav`.

## Proposed Solution
Update the following CSS classes to maintain the layout of the Query Monitor panel.

```
#query-monitor-main #qm-panel-menu ul {
  width: auto !important;
  height: auto !important;
}

#query-monitor-main #qm-panel-menu li {
  height: auto !important;
}

#query-monitor-main #qm-panel-menu {
  height: auto !important;
}
```

My PR details this, but it also included some formatting fixes which are based purely on VS Code. Those are not essential to this PR or fix.