### PR TITLE
Define `$return['file']` and `$return['line']`

### DIFF
--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -326,6 +326,8 @@ class QM_Backtrace {
 
 			$return['calling_file'] = $this->calling_file;
 			$return['calling_line'] = $this->calling_line;
+			$return['file']         = isset( $trace['file'] ) ? $trace['file'] : null;
+			$return['line']         = isset( $trace['line'] ) ? $trace['line'] : null;
 
 		}
 


### PR DESCRIPTION
Make sure `$return['file']` and `$return['line']` are defined. 

Fixes #433