### PR TITLE
Plugin compatibility check may result in empty $filtered_trace

### DIFF
--- a/dispatchers/WP_Die.php
+++ b/dispatchers/WP_Die.php
@@ -46,6 +46,10 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 			$stack[] = QM_Output_Html::output_filename( $item['display'], $item['file'], $item['line'] );
 		}
 
+		if ( empty( $filtered_trace ) ) {
+			return;
+		}
+
 		if ( isset( $filtered_trace[ $i - 1 ] ) ) {
 			$culprit = $filtered_trace[ $i - 1 ];
 		} else {


### PR DESCRIPTION
In WP 5.2 a plugin that doesn't meet the minimum PHP requirements will throw a WP_Die error. When tracing this in QM there there is only a single item in $filtered_trace. After the `array_pop( $filtered_trace );` the value of $filtered_trace is an empty array.

This PR accounts for that edge case.