### PR TITLE
Add ability to replace Collectors instance

### DIFF
--- a/classes/Collectors.php
+++ b/classes/Collectors.php
@@ -7,6 +7,7 @@
 
 if ( ! class_exists( 'QM_Collectors' ) ) {
 class QM_Collectors implements IteratorAggregate {
+	private static $instance = null;
 
 	private $items     = array();
 	private $processed = false;
@@ -30,14 +31,16 @@ class QM_Collectors implements IteratorAggregate {
 	}
 
 	public static function init() {
-		static $instance;
-
-		if ( ! $instance ) {
-			$instance = new QM_Collectors();
+		if ( ! static::$instance ) {
+			static::$instance = new QM_Collectors();
 		}
 
-		return $instance;
+		return static::$instance;
 
+	}
+
+	public static function replace_instance( QM_Collectors $instance ) {
+		static::$instance = $instance;
 	}
 
 	public function process() {


### PR DESCRIPTION
Fixes #447.

Two notes:

1. `Dispatchers` follows the same pattern; I haven't patched it here, but can if you'd like.
2. I'm using `static::` here, since WP's minimum version now supports it. The rest of the code is using `self::` however; I can update this to be consistent in either direction if you'd like.