### PR TITLE
Filter QM_Util::get_file_dirs to add 3rd-party components

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -69,23 +69,31 @@ class QM_Util {
 
 	public static function get_file_dirs() {
 		if ( empty( self::$file_dirs ) ) {
-			self::$file_dirs['plugin']     = self::standard_dir( WP_PLUGIN_DIR );
-			self::$file_dirs['mu-vendor']  = self::standard_dir( WPMU_PLUGIN_DIR . '/vendor' );
-			self::$file_dirs['go-plugin']  = self::standard_dir( WPMU_PLUGIN_DIR . '/shared-plugins' );
-			self::$file_dirs['mu-plugin']  = self::standard_dir( WPMU_PLUGIN_DIR );
-			self::$file_dirs['vip-plugin'] = self::standard_dir( get_theme_root() . '/vip/plugins' );
+
+			self::$file_dirs = apply_filters( 'qm/component_dirs', self::$file_dirs );
+
+			self::$file_dirs['plugin']     = WP_PLUGIN_DIR ;
+			self::$file_dirs['mu-vendor']  = WPMU_PLUGIN_DIR . '/vendor';
+			self::$file_dirs['go-plugin']  = WPMU_PLUGIN_DIR . '/shared-plugins';
+			self::$file_dirs['mu-plugin']  = WPMU_PLUGIN_DIR;
+			self::$file_dirs['vip-plugin'] = get_theme_root() . '/vip/plugins';
 
 			if ( defined( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR' ) ) {
-				self::$file_dirs['vip-client-mu-plugin'] = self::standard_dir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR );
+				self::$file_dirs['vip-client-mu-plugin'] = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR;
 			}
 
 			self::$file_dirs['theme']      = null;
-			self::$file_dirs['stylesheet'] = self::standard_dir( get_stylesheet_directory() );
-			self::$file_dirs['template']   = self::standard_dir( get_template_directory() );
-			self::$file_dirs['other']      = self::standard_dir( WP_CONTENT_DIR );
-			self::$file_dirs['core']       = self::standard_dir( ABSPATH );
+			self::$file_dirs['stylesheet'] = get_stylesheet_directory();
+			self::$file_dirs['template']   = get_template_directory();
+			self::$file_dirs['other']      = WP_CONTENT_DIR;
+			self::$file_dirs['core']       = ABSPATH;
 			self::$file_dirs['unknown']    = null;
+
+			foreach ( self::$file_dirs as $type => $dir ) {
+				self::$file_dirs[$type] = self::standard_dir($dir);
+			}
 		}
+
 		return self::$file_dirs;
 	}
 
@@ -176,6 +184,7 @@ class QM_Util {
 			case 'unknown':
 			default:
 				$name = __( 'Unknown', 'query-monitor' );
+				$name = apply_filters( "qm/component_name/{$type}", $name, $file );
 				break;
 		}
 

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -70,6 +70,18 @@ class QM_Util {
 	public static function get_file_dirs() {
 		if ( empty( self::$file_dirs ) ) {
 
+			/**
+			 * Filters the absolute directory paths that correlate to components.
+			 *
+			 * Note that this filter is applied before QM adds its built-in list of components. This is
+			 * so custom registered components take precedence during component detection.
+			 *
+			 * See the corresponding `qm/component_name/{$type}` filter for specifying the component name.
+			 *
+			 * @since 3.6.0
+			 *
+			 * @param string[] $dirs Array of absolute directory paths keyed by component identifier.
+			 */
 			self::$file_dirs = apply_filters( 'qm/component_dirs', self::$file_dirs );
 
 			self::$file_dirs['plugin']     = WP_PLUGIN_DIR ;
@@ -184,6 +196,19 @@ class QM_Util {
 			case 'unknown':
 			default:
 				$name = __( 'Unknown', 'query-monitor' );
+
+				/**
+				 * Filters the name of a custom or unknown component.
+				 *
+				 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
+				 *
+				 * See the corresponding `qm/component_dirs` filter for specifying the component directories.
+				 *
+				 * @since 3.6.0
+				 *
+				 * @param string $name The component name.
+				 * @param string $file The full file path for the file within the component.
+				 */
 				$name = apply_filters( "qm/component_name/{$type}", $name, $file );
 				break;
 		}


### PR DESCRIPTION
fixes #450 

- Added the filters. They work as expected with a custom plugin directory I have installed. Doesn't seem to break anything.
- Did not remove any of the hard-coded external directories already in QM_Util. Frankly I've no idea where they would go in the code.
- Filtered directories are added first in `get_file_dirs` because of the foreach-break in `get_file_component` (we can't know where the 3rd-party directory is installed - might be a subdirectory of a normal plugin in `plugins`. Very likely it's a subdirectory of ABSPATH or WP_CONTENT_DIR etc.)