### PR TITLE
Avoid a division by zero when cache hits is 0

### DIFF
--- a/collectors/cache.php
+++ b/collectors/cache.php
@@ -67,8 +67,13 @@ class QM_Collector_Cache extends QM_Collector {
 			}
 		}
 
-		if ( isset( $this->data['stats']['cache_hits'] ) && isset( $this->data['stats']['cache_misses'] ) ) {
-			$total                              = $this->data['stats']['cache_misses'] + $this->data['stats']['cache_hits'];
+		if ( ! empty( $this->data['stats']['cache_hits'] ) {
+			$total = $this->data['stats']['cache_hits'];
+			
+			if ( ! empty( $this->data['stats']['cache_misses'] ) ) {
+				$total += $this->data['stats']['cache_misses'];
+			}
+			
 			$this->data['cache_hit_percentage'] = ( 100 / $total ) * $this->data['stats']['cache_hits'];
 		}
 


### PR DESCRIPTION
Fixes #459.