### PR TITLE
Add new qm/collect/silent_http_error_statuses filter to silence specific HTTP API requests that result in 400-500 HTTP status codes

### DIFF
--- a/collectors/http.php
+++ b/collectors/http.php
@@ -255,7 +255,38 @@ class QM_Collector_HTTP extends QM_Collector {
 			} else {
 				$http['type'] = intval( wp_remote_retrieve_response_code( $http['response'] ) );
 				if ( $http['type'] >= 400 ) {
-					$this->data['errors']['warning'][] = $key;
+					/**
+					 * List of HTTP error status codes to ignore.
+					 *
+					 * @since vnext
+					 *
+					 * @param array $http_statuses Array of HTTP error statuses to silence.
+					 *              Default: empty array.
+					 * @param array $http {
+					 *     The QM "HTTP" request object.
+					 *
+					 *     @type string $url The URL for the HTTP request.
+					 *     @type array  $args The `$args` for the HTTP request.
+					 *     @type float  $start The start time for the request.
+					 *     @type class  $trace The QM_Backtrace object for the request.
+					 *     @type string $transport The transport for the HTTP request.
+					 *     @type float  $end The end time for the request.
+					 *     @type array  $response The HTTP response.
+					 *     @type array  $info The QM "info" for the HTTP request.
+					 *     @type int    $type The HTTP status code.
+					 * }
+					 */
+					$silent_error_statuses = apply_filters(
+						'qm/collect/silent_http_error_statuses',
+						array(),
+						$http
+					);
+					$silent_error_statuses = array_filter( array_map( 'intval', $silent_error_statuses ) );
+
+					if ( empty( $silent_error_statuses ) ||
+							! in_array( $http['type'], $silent_error_statuses, true ) ) {
+						$this->data['errors']['warning'][] = $key;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes: #474

The new filter is similar to the existing `qm/collect/silent_http_errors`.

The difference are:

1. it is called separately for each `$http` object collected.
2. it is passed the `$http` object so that plugins can decide on a request-by-request basis which HTTP status codes they want to silence.

A sample use of this new filter might be something like:

```
add_filter(
	'qm/collect/silent_http_error_statuses',
	array( $this, 'my_plugin_qm_silence_404s' ), 10, 2
);

function my_plugin_qm_silence_404s( $http_statuses, $http ) {
	if ( in_array( $http['url'], array( 'https://some-host.com/foo', 'https://another-host.com/bar' ) ) &&
			 wp_list_filter( $http['trace']->get_trace(), array( 'function' => 'my_plugin_ping_sites' ) ) ) {
		// tell QM that a 404 is OK in this case.
		$http_statuses[] = 404;
	}

	return $http_statuses;
}

function my_plugin_ping_sites() {
	// these requests should be silenced.
	wp_remote_head( 'https://some-host.com/foo' );
	wp_remote_head( 'https://another-host.com/bar' );
	// this request should not be silenced.
	wp_remote_head( 'https://yet-another-host.com/baz' );
}

my_plugin_ping_sites();

function my_plugin_ping_sites_again() {
	// these requests should not be silenced, even tho they are to the same URLs
	// that are silenced in my_plugin_ping_sites().
	wp_remote_head( 'https://somehost.com/foo' );
	wp_remote_head( 'https://anotherhost.com/bar' );
	// this request should not be silenced.
	wp_remote_head( 'https://yet-another-host.com/baz' );
}

my_plugin_ping_sites_again();

```

Also, on the DocBlock for the new filter, the `@since` tag is `vnext`, because I'm not sure what version of QM this might make it into; and in the hash for the `$http` param, I didn't do a sub-hashes for the array args (e.g., `$response` and `$info`).  I can do that if you'd like.
