### PR TITLE
Fix PHP notices if variable undefined in http.php

### DIFF
--- a/output/html/http.php
+++ b/output/html/http.php
@@ -70,6 +70,9 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			$i = 0;
 
 			foreach ( $data['http'] as $key => $row ) {
+			        if ( ! isset( $row['ltime'], $row['component'] ) ){
+					continue;
+				}
 				$ltime = $row['ltime'];
 				$i++;
 				$is_error = false;

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -70,7 +70,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			$i = 0;
 
 			foreach ( $data['http'] as $key => $row ) {
-			        if ( ! isset( $row['ltime'], $row['component'] ) ){
+							if ( ! isset( $row['ltime'], $row['component'] ) ) {
 					continue;
 				}
 				$ltime = $row['ltime'];

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -70,7 +70,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			$i = 0;
 
 			foreach ( $data['http'] as $key => $row ) {
-							if ( ! isset( $row['ltime'], $row['component'] ) ) {
+				if ( ! isset( $row['ltime'], $row['component'] ) ) {
 					continue;
 				}
 				$ltime = $row['ltime'];


### PR DESCRIPTION
Exit foreach loop early if certain data are not defined. When undefined they cause many PHP notices.

Fixes https://github.com/johnbillion/query-monitor/issues/500