### PR TITLE
Ignore invalid requests to prevent error messages

### DIFF
--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && QM_DISABLED ) {
+if ( ( defined( 'QM_DISABLED' ) && QM_DISABLED ) || ( ! defined( 'DB_USER' ) ) ) {
 	return;
 }
 


### PR DESCRIPTION
For some invalid requests served by WordPress, probably caused by bots
or script kiddies attempting to load random PHP files directly thereby
bypassing the WordPress stack, QM was causing warnings/errors to be
logged when it attempted to access DB vars that weren't defined:

```
[21-May-2020 18:57:18 UTC] PHP Warning:  Use of undefined constant DB_HOST - assumed 'DB_HOST' (this will throw an Error in a future version of PHP) in /var/www/neosmart.net/wordpress/wp-content/plugins/query-monitor/wp-content/db.php on line 139
[21-May-2020 18:57:18 UTC] PHP Stack trace:
[21-May-2020 18:57:18 UTC] PHP   1. {main}() /var/www/neosmart.net/wordpress/wp-admin/setup-config.php:0
[21-May-2020 18:57:18 UTC] PHP   2. require() /var/www/neosmart.net/wordpress/wp-admin/setup-config.php:33
[21-May-2020 18:57:18 UTC] PHP   3. require_wp_db() /var/www/neosmart.net/wordpress/wp-settings.php:126
[21-May-2020 18:57:18 UTC] PHP   4. require_once() /var/www/neosmart.net/wordpress/wp-includes/load.php:414
```

This patch aborts early if DB_USER (and, presumably, and co) are not
defined.