### PR TITLE
Support passing backtrace to QM_Backtrace

### DIFF
--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -54,8 +54,8 @@ class QM_Backtrace {
 	protected $calling_line    = 0;
 	protected $calling_file    = '';
 
-	public function __construct( array $args = array() ) {
-		$this->trace = debug_backtrace( false );
+	public function __construct( array $args = array(), array $trace = null ) {
+		$this->trace = $trace ? $trace : debug_backtrace( false );
 
 		$args = array_merge( array(
 			'ignore_current_filter' => true,

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -55,7 +55,7 @@ class QM_Backtrace {
 	protected $calling_file    = '';
 
 	public function __construct( array $args = array(), array $trace = null ) {
-		$this->trace = is_null($trace) ? debug_backtrace( false ) : $trace;
+		$this->trace = is_null( $trace ) ? debug_backtrace( false ) : $trace;
 
 		$args = array_merge( array(
 			'ignore_current_filter' => true,

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -55,7 +55,7 @@ class QM_Backtrace {
 	protected $calling_file    = '';
 
 	public function __construct( array $args = array(), array $trace = null ) {
-		$this->trace = $trace ? $trace : debug_backtrace( false );
+		$this->trace = is_null($trace) ? debug_backtrace( false ) : $trace;
 
 		$args = array_merge( array(
 			'ignore_current_filter' => true,


### PR DESCRIPTION
This PR adds support for constructing a backtrace with a previously collected backtrace.

My particular use case is related to object caching and decoupling logs from the QM plugin.