### PR TITLE
Add Plugin information (incl. execution time)

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -21,7 +21,13 @@ class QM_Hook {
 
 				foreach ( $callbacks as $callback ) {
 
+					$timer = new QM_Timer();
+					$timer->start();
+
 					$callback = QM_Util::populate_callback( $callback );
+
+					$timer->stop();
+					$time = $timer->get_time();
 
 					if ( isset( $callback['component'] ) ) {
 						if (
@@ -40,6 +46,7 @@ class QM_Hook {
 					$actions[] = array(
 						'priority' => $priority,
 						'callback' => $callback,
+						'time'     => $time,
 					);
 
 				}

--- a/collectors/plugins.php
+++ b/collectors/plugins.php
@@ -12,23 +12,26 @@ class QM_Collector_Plugins extends QM_Collector {
 	private $start;
 
 	public function __construct() {
-		$this->data['plugins'] = [];
-		foreach ( wp_get_active_and_valid_plugins() as $plugin )
-			$this->data['plugins'][dirname( plugin_basename( $plugin ) )]['file'] = $plugin;
+		$this->data['plugins'] = array();
+		$active_and_valid_plugins = wp_get_active_and_valid_plugins();
+		foreach ( $active_and_valid_plugins as $plugin ) {
+			$name = dirname( plugin_basename( $plugin ) );
+			$this->data['plugins'][ $name ]['file'] = $plugin;
+		}
 
 		if ( ! empty( $this->data['plugins'] ) ) {
-			add_action( 'mu_plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
-			add_action( 'network_plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
-			add_action( 'plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
+			add_action( 'mu_plugin_loaded', array( $this, 'action_plugin_loaded' ), 0 );
+			add_action( 'network_plugin_loaded', array( $this, 'action_plugin_loaded' ), 0 );
+			add_action( 'plugin_loaded', array( $this, 'action_plugin_loaded' ), 0 );
 
 			$this->start = microtime( true );
 		}
   }
 
-	function action_plugin_loaded( $plugin ) {
+	protected function action_plugin_loaded( $plugin ) {
 		$name = dirname( plugin_basename( $plugin ) );
 
-		$this->data['plugins'][$name]['load_time'] = microtime( true ) - $this->start;
+		$this->data['plugins'][ $name ]['load_time'] = microtime( true ) - $this->start;
 
 		$this->start = microtime( true );
 	}

--- a/collectors/plugins.php
+++ b/collectors/plugins.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Plugins collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Plugins extends QM_Collector {
+
+	public $id = 'plugins';
+	protected static $hide_core;
+	private $start;
+
+	public function __construct() {
+		$this->data['plugins'] = [];
+		foreach ( wp_get_active_and_valid_plugins() as $plugin )
+			$this->data['plugins'][dirname( plugin_basename( $plugin ) )]['file'] = $plugin;
+
+		if ( ! empty( $this->data['plugins'] ) ) {
+			add_action( 'mu_plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
+			add_action( 'network_plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
+			add_action( 'plugin_loaded', [ $this, 'action_plugin_loaded'], 0 );
+
+			$this->start = microtime( true );
+		}
+  }
+
+	function action_plugin_loaded( $plugin ) {
+		$name = dirname( plugin_basename( $plugin ) );
+
+		$this->data['plugins'][$name]['load_time'] = microtime( true ) - $this->start;
+
+		$this->start = microtime( true );
+	}
+}
+
+class QM_Collector_Plugins_Hooks extends QM_Collector {
+
+	public $id = 'plugins-hooks';
+	protected static $hide_core;
+
+}
+
+# Load early to catch all plugins
+QM_Collectors::add( new QM_Collector_Plugins() );
+QM_Collectors::add( new QM_Collector_Plugins_Hooks() );

--- a/output/Html.php
+++ b/output/Html.php
@@ -142,6 +142,7 @@ abstract class QM_Output_Html extends QM_Output {
 		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Callback', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -45,6 +45,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 			'highlight' => 'subject',
 		) ); // WPCS: XSS ok.
 		echo '</th>';
+		echo '<th scope="col">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
 		echo '</tr>';
 		echo '</thead>';
 
@@ -95,6 +96,8 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 					if ( $core !== $component ) {
 						$subject .= ' non-core';
 					}
+
+					$time = number_format_i18n( $action['time'], 4 );
 
 					printf( // WPCS: XSS ok.
 						'<tr data-qm-subject="%s" %s>',
@@ -173,6 +176,9 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 					echo '<td class="qm-nowrap' . esc_attr( $class ) . '">';
 					echo esc_html( $component );
 					echo '</td>';
+					echo '<td class="qm-nowrap' . esc_attr( $class ) . '">';
+					echo esc_html( $time );
+					echo '</td>';
 					echo '</tr>';
 					$first = false;
 				}
@@ -184,7 +190,8 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 				echo '<td></td>';
 				echo '<td></td>';
 				echo '<td></td>';
-				echo '</tr>';
+				echo '<td></td>';
+			echo '</tr>';
 			}
 		}
 

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -191,7 +191,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 				echo '<td></td>';
 				echo '<td></td>';
 				echo '<td></td>';
-			echo '</tr>';
+				echo '</tr>';
 			}
 		}
 

--- a/output/html/plugins.php
+++ b/output/html/plugins.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Plugin output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Plugins extends QM_Output_Html {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Theme Collector.
+	 */
+	protected $collector;
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 60 );
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 60 );
+	}
+
+	public function name() {
+		return __( 'Plugins', 'query-monitor' );
+	}
+
+	public function output() {
+		$hooks_data = QM_Collectors::get( 'hooks' )->get_data();
+		$plugins_data = QM_Collectors::get( 'plugins' )->get_data();
+
+		$plugins = [];
+		foreach( $plugins_data['plugins'] as $name => $plugin ) {
+			$plugins[$name] = [];
+			$plugins[$name]['actions'] = [];
+
+			if ( isset( $plugin['load_time'] ) ) {
+				if ( $file_data = get_file_data( $plugin['file'],
+					[
+						'PluginName' => 'Plugin Name',
+						'PluginURI' => 'Plugin URI',
+						'Version' => 'Version',
+						'TextDomain' => 'Text Domain'
+					],
+					'plugin' ) ) {
+					$plugins[$name]['plugin_name'] = $file_data['PluginName'];
+					$plugins[$name]['plugin_uri'] = $file_data['PluginURI'];
+					$plugins[$name]['version'] = $file_data['Version'];
+					$plugins[$name]['text_domain'] = $file_data['TextDomain'];
+				}
+				$plugins[$name]['time'] = $plugin['load_time'];
+			}
+		}
+
+		foreach ( $plugins as $name => $plugin ) {
+			foreach ( $hooks_data['hooks'] as $hook )
+				foreach ( $hook['actions'] as $action )
+					if ( isset( $action['callback'] )
+						and isset( $action['callback']['component'] )
+						and $action['callback']['component']->context == $name
+						and isset( $action['time'] ) ) {
+						if ( ! isset( $plugins[$name]['time'] ) )
+							$plugins[$name]['time'] = 0;
+						$plugins[$name]['time'] += $action['time'];
+					}
+		}
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Name', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Name', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Text Domain', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach( $plugins as $name => $plugin ) {
+			printf( // WPCS: XSS ok.
+				'<tr data-qm-subject="%s">',
+				esc_attr( $name )
+			);
+			echo '<th scope="row">' . esc_html( $name ) . '</th>';
+			if ( $plugin['plugin_uri'] )
+				echo '<th scope="row"><a href="' . esc_html( $plugin['plugin_uri'] ) . '" target="_blank">' . esc_html( $plugin['plugin_name'] ) . '</a></th>';
+			else
+				echo '<th scope="row">' . esc_html( $plugin['plugin_name'] ) . '</th>';
+			echo '<th scope="row">' . esc_html( $plugin['version'] ) . '</th>';
+			echo '<th scope="row">' . esc_html( $plugin['text_domain'] ) . '</th>';
+			echo '<td>' . number_format_i18n( $plugin['time'], 4 ) . '</td>';
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+  	$name = __( 'Unknown', 'query-monitor' );
+
+		$menu[ $this->collector->id() ] = $this->menu( array(
+			'title' => esc_html( sprintf(
+				__( 'Plugins', 'query-monitor' ),
+				$name
+			) ),
+		) );
+
+		return $menu;
+
+	}
+
+	public function panel_menu( array $menu ) {
+		$id = $this->collector->id();
+		if ( isset( $menu[$id] ) ) {
+			$menu[$id]['title'] = __( 'Plugins', 'query-monitor' );
+
+			$menu[$id]['children'][] = array(
+				'id'    => $id . '-hooks',
+				'href'  => '#' . $id . '-hooks',
+				'title' => esc_html__( 'Hooks in Use', 'query-monitor' ),
+			);
+
+		}
+
+		return $menu;
+	}
+
+}
+
+class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Theme Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Plugins Hooks', 'query-monitor' );
+	}
+
+	public function output() {
+		$data = $this->collector->get_data();
+		$hooks_data = QM_Collectors::get( 'hooks' )->get_data();
+
+		$plugins = [];
+		foreach( $hooks_data['components'] as $component )
+			if ( preg_match( '/^' . __( 'Plugin', 'query-monitor' ) . ': (.*)/', $component, $matches ) ) {
+				$name = $matches[1];
+				$plugins[$name] = [];
+				$plugins[$name]['actions'] = [];
+
+				if ( isset( $data['plugins'][$name] )
+					and isset( $data['plugins'][$name]['load_time'] ) ) {
+					$plugins[$name]['actions']['']['hook'] = 'Load';
+					$plugins[$name]['actions']['']['time'] = $data['plugins'][$name]['load_time'];
+				}
+			}
+
+		foreach ( $plugins as $name => $component_name ) {
+			foreach ( $hooks_data['hooks'] as $hook )
+				foreach ( $hook['actions'] as $action )
+					if ( isset( $action['callback'] )
+						and isset( $action['callback']['component'] )
+						and $action['callback']['component']->context == $name
+						and isset( $action['time'] ) ) {
+						$plugins[$name]['actions'][$action['callback']['name']]['hook'] = $hook['name'];
+						if ( ! isset( $plugins[$name]['actions'][$action['callback']['name']]['time'] ) )
+							$plugins[$name]['actions'][$action['callback']['name']]['time'] = 0;
+						$plugins[$name]['actions'][$action['callback']['name']]['time'] += $action['time'];
+					}
+		}
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Name', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Hook', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Callback', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach( $plugins as $name => $plugin ) {
+			if ( ! empty( $plugins[$name]['actions'] ) ) {
+				$rowspan = count( $plugins[$name]['actions'] );
+			} else {
+				$rowspan = 1;
+			}
+
+			$first = true;
+
+			foreach ( $plugins[$name]['actions'] as $action_name => $action ) {
+				if ( $first ) {
+					printf( // WPCS: XSS ok.
+						'<tr data-qm-subject="%s">',
+						esc_attr( $name )
+					);
+					echo '<th scope="row" rowspan="' . intval( $rowspan ) . '">' . esc_html( $name ) . '</th>';
+
+					$first = false;
+				} else {
+					echo '<tr>';
+				}
+
+				echo '<td>' . esc_html( $action['hook'] ) . '</td>';
+				echo '<td>' . esc_html( $action_name ) . '</td>';
+				echo '<td>' . number_format_i18n( $action['time'], 4 ) . '</td>';
+				echo '</tr>';
+			}
+		}
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+}
+
+function register_qm_output_html_plugins( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'plugins' );
+	if ( $collector )
+		$output['plugins'] = new QM_Output_Html_Plugins( $collector );
+
+	$collector = QM_Collectors::get( 'plugins-hooks' );
+	if ( $collector )
+		$output['plugins-hooks'] = new QM_Output_Html_Plugins_Hooks( $collector );
+
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_plugins', 71, 2 );

--- a/output/html/plugins.php
+++ b/output/html/plugins.php
@@ -28,40 +28,45 @@ class QM_Output_Html_Plugins extends QM_Output_Html {
 		$hooks_data = QM_Collectors::get( 'hooks' )->get_data();
 		$plugins_data = QM_Collectors::get( 'plugins' )->get_data();
 
-		$plugins = [];
-		foreach( $plugins_data['plugins'] as $name => $plugin ) {
-			$plugins[$name] = [];
-			$plugins[$name]['actions'] = [];
+		$plugins = array();
+		foreach ( $plugins_data['plugins'] as $name => $plugin ) {
+			$plugins[ $name ] = array();
+			$plugins[ $name ]['actions'] = array();
 
 			if ( isset( $plugin['load_time'] ) ) {
-				if ( $file_data = get_file_data( $plugin['file'],
-					[
+				$file_data = get_file_data( $plugin['file'],
+					array(
 						'PluginName' => 'Plugin Name',
 						'PluginURI' => 'Plugin URI',
 						'Version' => 'Version',
-						'TextDomain' => 'Text Domain'
-					],
-					'plugin' ) ) {
-					$plugins[$name]['plugin_name'] = $file_data['PluginName'];
-					$plugins[$name]['plugin_uri'] = $file_data['PluginURI'];
-					$plugins[$name]['version'] = $file_data['Version'];
-					$plugins[$name]['text_domain'] = $file_data['TextDomain'];
+						'TextDomain' => 'Text Domain',
+					),
+					'plugin'
+				);
+				if ( $file_data ) {
+					$plugins[ $name ]['plugin_name'] = $file_data['PluginName'];
+					$plugins[ $name ]['plugin_uri'] = $file_data['PluginURI'];
+					$plugins[ $name ]['version'] = $file_data['Version'];
+					$plugins[ $name ]['text_domain'] = $file_data['TextDomain'];
 				}
-				$plugins[$name]['time'] = $plugin['load_time'];
+				$plugins[ $name ]['time'] = $plugin['load_time'];
 			}
 		}
 
 		foreach ( $plugins as $name => $plugin ) {
-			foreach ( $hooks_data['hooks'] as $hook )
-				foreach ( $hook['actions'] as $action )
+			foreach ( $hooks_data['hooks'] as $hook ) {
+				foreach ( $hook['actions'] as $action ) {
 					if ( isset( $action['callback'] )
-						and isset( $action['callback']['component'] )
-						and $action['callback']['component']->context == $name
-						and isset( $action['time'] ) ) {
-						if ( ! isset( $plugins[$name]['time'] ) )
-							$plugins[$name]['time'] = 0;
-						$plugins[$name]['time'] += $action['time'];
+						&& isset( $action['callback']['component'] )
+						&& $action['callback']['component']->context == $name
+						&& isset( $action['time'] ) ) {
+						if ( ! isset( $plugins[ $name ]['time'] ) ) {
+							$plugins[ $name ]['time'] = 0;
+						}
+						$plugins[ $name ]['time'] += $action['time'];
 					}
+				}
+			}
 		}
 
 		$this->before_tabular_output();
@@ -78,19 +83,20 @@ class QM_Output_Html_Plugins extends QM_Output_Html {
 
 		echo '<tbody>';
 
-		foreach( $plugins as $name => $plugin ) {
+		foreach ( $plugins as $name => $plugin ) {
 			printf( // WPCS: XSS ok.
 				'<tr data-qm-subject="%s">',
 				esc_attr( $name )
 			);
 			echo '<th scope="row">' . esc_html( $name ) . '</th>';
-			if ( $plugin['plugin_uri'] )
+			if ( $plugin['plugin_uri'] ) {
 				echo '<th scope="row"><a href="' . esc_html( $plugin['plugin_uri'] ) . '" target="_blank">' . esc_html( $plugin['plugin_name'] ) . '</a></th>';
-			else
+			} else {
 				echo '<th scope="row">' . esc_html( $plugin['plugin_name'] ) . '</th>';
+			}
 			echo '<th scope="row">' . esc_html( $plugin['version'] ) . '</th>';
 			echo '<th scope="row">' . esc_html( $plugin['text_domain'] ) . '</th>';
-			echo '<td>' . number_format_i18n( $plugin['time'], 4 ) . '</td>';
+			echo '<td>' . esc_html( number_format_i18n( $plugin['time'], 4 ) ) . '</td>';
 		}
 
 		echo '</tbody>';
@@ -102,7 +108,7 @@ class QM_Output_Html_Plugins extends QM_Output_Html {
 
 		$data = $this->collector->get_data();
 
-  	$name = __( 'Unknown', 'query-monitor' );
+		$name = __( 'Unknown', 'query-monitor' );
 
 		$menu[ $this->collector->id() ] = $this->menu( array(
 			'title' => esc_html( sprintf(
@@ -117,10 +123,10 @@ class QM_Output_Html_Plugins extends QM_Output_Html {
 
 	public function panel_menu( array $menu ) {
 		$id = $this->collector->id();
-		if ( isset( $menu[$id] ) ) {
-			$menu[$id]['title'] = __( 'Plugins', 'query-monitor' );
+		if ( isset( $menu[ $id ] ) ) {
+			$menu[ $id ]['title'] = __( 'Plugins', 'query-monitor' );
 
-			$menu[$id]['children'][] = array(
+			$menu[ $id ]['children'][] = array(
 				'id'    => $id . '-hooks',
 				'href'  => '#' . $id . '-hooks',
 				'title' => esc_html__( 'Hooks in Use', 'query-monitor' ),
@@ -150,32 +156,35 @@ class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
 		$data = $this->collector->get_data();
 		$hooks_data = QM_Collectors::get( 'hooks' )->get_data();
 
-		$plugins = [];
-		foreach( $hooks_data['components'] as $component )
+		$plugins = array();
+		foreach ( $hooks_data['components'] as $component ) {
 			if ( preg_match( '/^' . __( 'Plugin', 'query-monitor' ) . ': (.*)/', $component, $matches ) ) {
 				$name = $matches[1];
-				$plugins[$name] = [];
-				$plugins[$name]['actions'] = [];
+				$plugins[ $name ] = array();
+				$plugins[ $name ]['actions'] = array();
 
-				if ( isset( $data['plugins'][$name] )
-					and isset( $data['plugins'][$name]['load_time'] ) ) {
-					$plugins[$name]['actions']['']['hook'] = 'Load';
-					$plugins[$name]['actions']['']['time'] = $data['plugins'][$name]['load_time'];
+				if ( isset( $data['plugins'][ $name ] )
+					&& isset( $data['plugins'][ $name ]['load_time'] ) ) {
+					$plugins[ $name ]['actions']['']['hook'] = 'Load';
+					$plugins[ $name ]['actions']['']['time'] = $data['plugins'][ $name ]['load_time'];
 				}
 			}
+		}
 
 		foreach ( $plugins as $name => $component_name ) {
-			foreach ( $hooks_data['hooks'] as $hook )
-				foreach ( $hook['actions'] as $action )
+			foreach ( $hooks_data['hooks'] as $hook ) {
+				foreach ( $hook['actions'] as $action ) {
 					if ( isset( $action['callback'] )
-						and isset( $action['callback']['component'] )
-						and $action['callback']['component']->context == $name
-						and isset( $action['time'] ) ) {
-						$plugins[$name]['actions'][$action['callback']['name']]['hook'] = $hook['name'];
-						if ( ! isset( $plugins[$name]['actions'][$action['callback']['name']]['time'] ) )
-							$plugins[$name]['actions'][$action['callback']['name']]['time'] = 0;
-						$plugins[$name]['actions'][$action['callback']['name']]['time'] += $action['time'];
+						&& isset( $action['callback']['component'] )
+						&& $action['callback']['component']->context == $name
+						&& isset( $action['time'] ) ) {
+						$plugins[ $name ]['actions'][ $action['callback']['name'] ]['hook'] = $hook['name'];
+						if ( ! isset( $plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] ) )
+							$plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] = 0;
+						$plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] += $action['time'];
 					}
+				}
+			}
 		}
 
 		$this->before_tabular_output();
@@ -191,16 +200,16 @@ class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
 
 		echo '<tbody>';
 
-		foreach( $plugins as $name => $plugin ) {
-			if ( ! empty( $plugins[$name]['actions'] ) ) {
-				$rowspan = count( $plugins[$name]['actions'] );
+		foreach ( $plugins as $name => $plugin ) {
+			if ( ! empty( $plugins[ $name ]['actions'] ) ) {
+				$rowspan = count( $plugins[ $name ]['actions'] );
 			} else {
 				$rowspan = 1;
 			}
 
 			$first = true;
 
-			foreach ( $plugins[$name]['actions'] as $action_name => $action ) {
+			foreach ( $plugins[ $name ]['actions'] as $action_name => $action ) {
 				if ( $first ) {
 					printf( // WPCS: XSS ok.
 						'<tr data-qm-subject="%s">',
@@ -215,7 +224,7 @@ class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
 
 				echo '<td>' . esc_html( $action['hook'] ) . '</td>';
 				echo '<td>' . esc_html( $action_name ) . '</td>';
-				echo '<td>' . number_format_i18n( $action['time'], 4 ) . '</td>';
+				echo '<td>' . esc_html( number_format_i18n( $action['time'], 4 ) ) . '</td>';
 				echo '</tr>';
 			}
 		}
@@ -228,12 +237,14 @@ class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
 
 function register_qm_output_html_plugins( array $output, QM_Collectors $collectors ) {
 	$collector = QM_Collectors::get( 'plugins' );
-	if ( $collector )
+	if ( $collector ) {
 		$output['plugins'] = new QM_Output_Html_Plugins( $collector );
+	}
 
 	$collector = QM_Collectors::get( 'plugins-hooks' );
-	if ( $collector )
+	if ( $collector ) {
 		$output['plugins-hooks'] = new QM_Output_Html_Plugins_Hooks( $collector );
+	}
 
 	return $output;
 }

--- a/output/html/plugins.php
+++ b/output/html/plugins.php
@@ -179,8 +179,9 @@ class QM_Output_Html_Plugins_Hooks extends QM_Output_Html {
 						&& $action['callback']['component']->context == $name
 						&& isset( $action['time'] ) ) {
 						$plugins[ $name ]['actions'][ $action['callback']['name'] ]['hook'] = $hook['name'];
-						if ( ! isset( $plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] ) )
+						if ( ! isset( $plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] ) ) {
 							$plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] = 0;
+						}
 						$plugins[ $name ]['actions'][ $action['callback']['name'] ]['time'] += $action['time'];
 					}
 				}


### PR DESCRIPTION
Since two years, I miss a feature in Query Monitor: An overview of the plugins and their execution time.

It list all active plugins with the entiered execution time and a detailed list of each hook for all plugins.

Now, I implemented it and I hope you love too.