### PR TITLE
Fix errors caused by missing user or group IDs

### DIFF
--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -262,7 +262,10 @@ class QM_Collector_Environment extends QM_Collector {
 		if ( function_exists( 'posix_getpwuid' ) ) {
 			$u     = posix_getpwuid( posix_getuid() );
 			$g     = posix_getgrgid( $u['gid'] );
-			$php_u = $u['name'] . ':' . $g['name'];
+			
+			if ( ! empty( $u ) && ! empty( $g ) ) {
+				$php_u = $u['name'] . ':' . $g['name'];
+			}
 		}
 
 		if ( empty( $php_u ) && isset( $_ENV['APACHE_RUN_USER'] ) ) {

--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -262,7 +262,6 @@ class QM_Collector_Environment extends QM_Collector {
 		if ( function_exists( 'posix_getpwuid' ) ) {
 			$u     = posix_getpwuid( posix_getuid() );
 			$g     = posix_getgrgid( $u['gid'] );
-			
 			if ( ! empty( $u ) && ! empty( $g ) ) {
 				$php_u = $u['name'] . ':' . $g['name'];
 			}


### PR DESCRIPTION
Although `posix_getpwuid()` and `posix_getgrgid()` should return arrays, they sometimes return `false` if there a problem reading the user/group info from the filesystem. To avoid the "can't access index of a bool" error, check to make sure the results are truthy, and skip setting the user until we have better values later on.

Fixes #514.