### PR TITLE
Disable db.php symlink

### DIFF
--- a/classes/Activation.php
+++ b/classes/Activation.php
@@ -30,8 +30,9 @@ class QM_Activation extends QM_Plugin {
 
 	public function activate( $sitewide = false ) {
 		$db = WP_CONTENT_DIR . '/db.php';
+		$create_symlink = defined( 'QM_DB_SYMLINK' ) ? QM_DB_SYMLINK : true;
 
-		if ( ! file_exists( $db ) && function_exists( 'symlink' ) ) {
+		if ( $create_symlink && ! file_exists( $db ) && function_exists( 'symlink' ) ) {
 			@symlink( $this->plugin_path( 'wp-content/db.php' ), $db ); // phpcs:ignore
 		}
 

--- a/classes/CLI.php
+++ b/classes/CLI.php
@@ -32,6 +32,11 @@ class QM_CLI extends QM_Plugin {
 			}
 		}
 
+		if ( defined( 'QM_DB_SYMLINK' ) && ! QM_DB_SYMLINK ) {
+			WP_CLI::warning( 'Creation of symlink prevented by QM_DB_SYMLINK constant.' );
+			exit( 0 );
+		}
+
 		if ( ! function_exists( 'symlink' ) ) {
 			WP_CLI::error( 'The symlink function is not available' );
 		}

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -176,6 +176,9 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 				if ( file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
 					/* translators: 1: Symlink file name, 2: URL to wiki page */
 					$message = __( 'Extended query information such as the component and affected rows is not available. A conflicting %1$s file is present. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
+				} else if ( defined( 'QM_DB_SYMLINK' ) && ! QM_DB_SYMLINK ) {
+					/* translators: 1: Symlink file name, 2: URL to wiki page */
+					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was prevented from symlinking its %1$s file into place by <code>QM_DB_SYMLINK</code> constant. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
 				} else {
 					/* translators: 1: Symlink file name, 2: URL to wiki page */
 					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was unable to symlink its %1$s file into place. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );


### PR DESCRIPTION
I run QM conditionally on production (by IP address), but the `db.php` file is put in place, meaning that all queries are run through QM's drop-in when not necessary. This PR introduced a constant to prevent symlinking, and updates messaging in various places.

If approved:
- [ ] Update wiki with information about constant.