### PR TITLE
Add AMP compatibility

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -31,6 +31,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'shutdown',                   array( $this, 'dispatch' ), 0 );
 
 		add_action( 'wp_footer',                  array( $this, 'action_footer' ) );
+		add_action( 'amp_post_template_footer',   array( $this, 'action_footer' ) );
 		add_action( 'admin_footer',               array( $this, 'action_footer' ) );
 		add_action( 'login_footer',               array( $this, 'action_footer' ) );
 		add_action( 'embed_footer',               array( $this, 'action_footer' ) );
@@ -139,11 +140,16 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'enqueue_embed_scripts', array( $this, 'enqueue_assets' ), -9999 );
 
 		add_action( 'gp_head',                array( $this, 'manually_print_assets' ), 11 );
+		add_action( 'amp_post_template_head', array( $this, 'manually_print_assets' ));
 
 		parent::init();
 	}
 
 	public function manually_print_assets() {
+		if ( ! wp_script_is( 'query-monitor', 'registered' ) || ! wp_style_is( 'query-monitor', 'registered' ) ) {
+			// Ensure the script and style are registered.
+			$this->enqueue_assets();
+		}
 		wp_print_scripts( array(
 			'query-monitor',
 		) );

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -279,9 +279,9 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_filter(
 			'amp_dev_mode_element_xpaths',
 			function ( $expressions ) {
-				$expressions[] = '//script[ contains( text(), "var qm_number_format =" ) ]';
-				$expressions[] = '//script[ contains( text(), "var qm =" ) ]';
-				$expressions[] = '//script[ contains( text(), "query-monitor" ) ]';
+				$expressions[] = '//script[ @id = "query-monitor-js-extra" ]';
+				$expressions[] = '//script[ @id = "query-monitor-data" ]';
+				$expressions[] = '//script[ @id = "query-monitor-init" ]';
 				return $expressions;
 			}
 		);
@@ -380,7 +380,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		);
 
 		echo '<!-- Begin Query Monitor output -->' . "\n\n";
-		echo '<script type="text/javascript">' . "\n\n";
+		echo '<script id="query-monitor-data" type="text/javascript">' . "\n\n";
 		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
 		echo '</script>' . "\n\n";
 
@@ -638,7 +638,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '</div>'; // #qm-wrapper
 		echo '</div>'; // #query-monitor-main
 
-		echo '<script type="text/javascript">' . "\n\n";
+		echo '<script id="query-monitor-init" type="text/javascript">' . "\n\n";
 		?>
 		window.addEventListener('load', function() {
 			if ( ( 'undefined' === typeof QM_i18n ) || ( 'undefined' === typeof jQuery ) || ! window.jQuery ) {

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -279,7 +279,11 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_filter(
 			'amp_dev_mode_element_xpaths',
 			function ( $expressions ) {
-				$expressions[] = '//script[ @id = "query-monitor-js-extra" ]';
+				if ( version_compare( get_bloginfo( 'version' ), '5.5', '>=' ) ) {
+					$expressions[] = '//script[ @id = "query-monitor-js-extra" ]';
+				} else {
+					$expressions[] = '//script[ contains( text(), "var qm_number_format =" ) ]';
+				}
 				$expressions[] = '//script[ @id = "query-monitor-data" ]';
 				$expressions[] = '//script[ @id = "query-monitor-init" ]';
 				return $expressions;

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -278,7 +278,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 	private function filter_amp_dev_mode_element_xpaths() {
 		add_filter(
 			'amp_dev_mode_element_xpaths',
-			static function ( $expressions ) {
+			function ( $expressions ) {
 				$expressions[] = '//script[ contains( text(), "var qm_number_format =" ) ]';
 				$expressions[] = '//script[ contains( text(), "var qm =" ) ]';
 				$expressions[] = '//script[ contains( text(), "query-monitor" ) ]';

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -225,7 +225,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			add_filter(
 				'style_loader_tag',
 				function ( $tag, $handle ) {
-					if ( in_array( $handle, [ 'query-monitor', 'dashicons' ], true ) ) {
+					if ( in_array( $handle, array( 'query-monitor', 'dashicons' ), true ) ) {
 						$tag = preg_replace( '/(?<=<link\s)/', ' data-ampdevmode ', $tag );
 					}
 					return $tag;
@@ -237,7 +237,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			add_filter(
 				'script_loader_tag',
 				function ( $tag, $handle ) {
-					if ( in_array( $handle, [ 'query-monitor', 'jquery-core' ], true ) ) {
+					if ( in_array( $handle, array( 'query-monitor', 'jquery-core' ), true ) ) {
 						$tag = preg_replace( '/(?<=<script\s)/', ' data-ampdevmode ', $tag );
 					}
 					return $tag;

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -67,6 +67,11 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 	return;
 }
 
+if ( isset( $_GET['amp_validate'] ) ) {
+	# Prevent loading QM during AMP validation requests since it conflicts with the AMP plugin's own reflection routines.
+	return;
+}
+
 foreach ( array( 'QueryMonitor', 'Backtrace', 'Collectors', 'Collector', 'Dispatchers', 'Dispatcher', 'Hook', 'Output', 'Timer' ) as $qm_class ) {
 	require_once "{$qm_dir}/classes/{$qm_class}.php";
 }


### PR DESCRIPTION
This PR is revisiting one I previously closed (https://github.com/johnbillion/query-monitor/pull/332) which prevented Query Monitor from doing anything on AMP pages. This is no longer necessary now that AMP Dev Mode is a thing: Query Monitor's full functionality can exist on AMP pages. This follows up on a discussion that we had with @schlessera around a table during the WordFest Party at WCUS 2019.

----

When the official AMP plugin is active on a site, the functionality provided by Query Monitor is broken on AMP pages. For example, when looking at an AMP page and AMP Developer Tools is enabled, the Admin Bar shows AMP validation errors being reported and that the AMP CSS limit is close to being breached:

> ![image](https://user-images.githubusercontent.com/134745/91799327-b11c2b80-ebdb-11ea-99d3-99a4ddd0d669.png)

When clicking the Query Monitor admin bar menu item, nothing happens:

> ![image](https://user-images.githubusercontent.com/134745/91799417-ddd04300-ebdb-11ea-8468-5d89b09813be.png)

This is expected because the invalid AMP markup is being removed by the plugin, which is indicated by the raising of validation errors. Clicking to validate the URL to show the validation results shows 5 `script` elements that are getting removed due to being invalid AMP (which doesn't permit custom scripts in the traditional way):

![image](https://user-images.githubusercontent.com/134745/91799905-dc534a80-ebdc-11ea-8dc0-a1e18c48a434.png)

The last two inline scripts lack attribution detection from the AMP plugin, but the penultimate inline script is coming from `QM_Dispatcher_Html::before_output()` which prints `var qm = {...}`, and the last inline script is the `load` event handler on the `window` that is also printed in the same method.

The validation errors for these scripts can be avoided by [designating them as being part of AMP Dev Mode](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/). This allows for AMP-invalid scripts (and other elements) from being sanitized when a page is in AMP Dev Mode which happens by default when the user is logged-in and the Admin Bar is showing. Designating elements to be exempted from sanitization is done by adding the `data-ampdevmode` attribute. This can either be done during template rendering, such as via the `script_loader_tag` filter, or afterward during post-processing via the `amp_dev_mode_element_xpaths` filter.

When those are added, no more validation errors are reported:

![image](https://user-images.githubusercontent.com/134745/91800855-a31bda00-ebde-11ea-8d8a-2aff770b8d3b.png)

In addition to designating invalid scripts as being part of AMP Dev Mode, this should also be done for stylesheets that are related to those scripts which only appear in Dev Mode. This will prevent validation errors due to going over the CSS limit but it will also prevent required CSS rules from being removed during tree shaking. So this PR also designates `query-monitor` and `dashicons` as also being part of AMP Dev Mode so that they are omitted from the AMP plugin's CSS processing. Notice how the CSS usage is decreased:

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/91802973-b54a4800-ebdf-11ea-9d52-33d3fdfa356b.png) | ![after](https://user-images.githubusercontent.com/134745/91803068-bc715600-ebdf-11ea-93de-e7095e371eea.png)

Another key difference to point out here is that before Query Monitor is showing up as the source for various stylesheets that it is definitely not responsible for registering: `wp-block-library-theme`, `wp-block-library`, and `amp-default`. This is prevented in this PR with the addition of this bit of code in `query-monitor.php`:

```php
if ( isset( $_GET['amp_validate'] ) ) {
	# Prevent loading QM during AMP validation requests since it conflicts with the AMP plugin's own reflection routines.
	return;
}
```

I couldn't determine a better place for this logic. The condition isn't particularly robust either, but I was unsure of how else to validate it being a valid AMP validation request so early. (One idea could be to check if `hash_equals( $_GET['amp_validate'], wp_hash( self::VALIDATE_QUERY_VAR . wp_nonce_tick(), 'nonce' ) )` but this would require loading `pluggable.php` too early.)

When clicking “Validate URL” in the AMP plugin, a loopback request is initiated in which the `amp_validate` query param is added to indicate that an AMP validation request is being made. See [logic](https://github.com/ampproject/amp-wp/blob/c9dba91d9eb0e825b8374aef1e9902c1dad9e600/includes/validation/class-amp-validation-manager.php#L2114-L2139) in `AMP_Validation_Manager::validate_url()`. As part of a validation request, the AMP plugin adds similar logic that Query Monitor adds to determine which theme/plugin is responsible for a given asset being added to the page. Apparently Query Monitor's source attribution logic is confusing the AMP plugin's source attribute logic, since they probably do similar things. Since it doesn't make sense for Query Monitor to be running during the loopback request for AMP validation, to me it seems the logical course of action is to just prevent Query Monitor from running during such requests. 

So, after the changes in this PR, Query Monitor's functionality works properly on the frontend on AMP pages:

![image](https://user-images.githubusercontent.com/134745/91810164-4ae6d700-ebe2-11ea-861c-ed1cf88c26c0.png)

WIth bf5f446, Query Monitor is also successfully integrated with the legacy AMP post templates:

![image](https://user-images.githubusercontent.com/134745/91813555-c13a0800-ebe7-11ea-96ad-39e177a52707.png)
