### PR TITLE
Changes dispatch action priority from lowest to highest

### DIFF
--- a/dispatchers/AJAX.php
+++ b/dispatchers/AJAX.php
@@ -21,7 +21,7 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 	public function __construct( QM_Plugin $qm ) {
 		parent::__construct( $qm );
 
-		add_action( 'shutdown', array( $this, 'dispatch' ), 0 );
+		add_action( 'shutdown', array( $this, 'dispatch' ), PHP_INT_MAX );
 
 	}
 

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -26,7 +26,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'wp_ajax_qm_auth_off',        array( $this, 'ajax_off' ) );
 		add_action( 'wp_ajax_nopriv_qm_auth_off', array( $this, 'ajax_off' ) );
 
-		add_action( 'shutdown',                   array( $this, 'dispatch' ), 0 );
+		add_action( 'shutdown',                   array( $this, 'dispatch' ), PHP_INT_MAX );
 
 		add_action( 'wp_footer',                  array( $this, 'action_footer' ) );
 		add_action( 'admin_footer',               array( $this, 'action_footer' ) );


### PR DESCRIPTION
This enables us to catch also queries that happen during shutdown
actions. While in the current implementation these would happen only AFTER the dispatch.

Looking at the git history, there seems to be no indication of why the 0 priority (the first action to run) was chosen.

@johnbillion can you recall what was the reasoning behind that? Or do you have any concerns about changing the priority?