### PR TITLE
WP_Error tracker

### DIFF
--- a/collectors/wp_errors.php
+++ b/collectors/wp_errors.php
@@ -13,7 +13,7 @@ class QM_Collector_WP_Errors extends QM_Collector {
 		parent::__construct();
 
 		add_action( 'wp_error_added', array( $this, 'action_wp_error_added' ), 10, 4 );
-		add_action( 'wp_error_checked', array( $this, 'action_wp_error_checked' ) );
+		add_action( 'is_wp_error_instance', array( $this, 'action_is_wp_error_instance' ) );
 	}
 
 	public function action_wp_error_added( $code, $message, $data, WP_Error $wp_error ) {
@@ -28,7 +28,7 @@ class QM_Collector_WP_Errors extends QM_Collector {
 		);
 	}
 
-	public function action_wp_error_checked( WP_Error $wp_error ) {
+	public function action_is_wp_error_instance( WP_Error $wp_error ) {
 		$id = spl_object_hash( $wp_error );
 
 		if ( ! isset( $this->data['checked'][ $id ] ) ) {

--- a/collectors/wp_errors.php
+++ b/collectors/wp_errors.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WP error collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_WP_Errors extends QM_Collector {
+
+	public $id = 'wp_errors';
+
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'wp_error_added', array( $this, 'action_wp_error_added' ), 10, 4 );
+		add_action( 'wp_error_checked', array( $this, 'action_wp_error_checked' ) );
+	}
+
+	public function action_wp_error_added( $code, $message, $data, WP_Error $wp_error ) {
+		$id = spl_object_hash( $wp_error );
+
+		$this->data['errors'][ $id ] = array(
+			'error' => $wp_error,
+			'trace' => new QM_Backtrace( array(
+				'ignore_current_filter' => false,
+				'ignore_frames'         => 6,
+			) ),
+		);
+	}
+
+	public function action_wp_error_checked( WP_Error $wp_error ) {
+		$id = spl_object_hash( $wp_error );
+
+		if ( ! isset( $this->data['checked'][ $id ] ) ) {
+			$this->data['checked'][ $id ] = array();
+		}
+
+		$this->data['checked'][ $id ][] = array(
+			'error' => $wp_error,
+			'trace' => new QM_Backtrace( array(
+				'ignore_current_filter' => false,
+				'ignore_frames'         => 5,
+			) ),
+		);
+	}
+}
+
+# Load early to catch early errors
+QM_Collectors::add( new QM_Collector_WP_Errors() );

--- a/output/html/wp_errors.php
+++ b/output/html/wp_errors.php
@@ -68,7 +68,26 @@ class QM_Output_Html_WP_Errors extends QM_Output_Html {
 
 			$caller = $trace->get_caller();
 
-			echo '<tr>';
+			$component = $trace->get_component();
+
+			$row_attr                      = array();
+			$row_attr['data-qm-component'] = $component->name;
+
+			if ( 'core' !== $component->context ) {
+				$row_attr['data-qm-component'] .= ' non-core';
+			}
+
+			$attr = '';
+
+			foreach ( $row_attr as $a => $v ) {
+				$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+			}
+
+			printf( // WPCS: XSS ok.
+				'<tr %s>',
+				$attr
+			);
+
 			echo '<td>' . esc_html( $wp_error->get_error_code() ) . '</td>';
 			echo '<td>' . esc_html( $wp_error->get_error_message() ) . '</td>';
 			echo '<td>';

--- a/output/html/wp_errors.php
+++ b/output/html/wp_errors.php
@@ -56,14 +56,10 @@ class QM_Output_Html_WP_Errors extends QM_Output_Html {
 		echo '<tbody>';
 
 		foreach ( $data['errors'] as $id => $error ) {
-			/**
-			 * @var WP_Error $wp_error
-			 */
+			/** @var WP_Error */
 			$wp_error = $error['error'];
 
-			/**
-			 * @var QM_Backtrace $trace
-			 */
+			/** @var QM_Backtrace */
 			$trace = $error['trace'];
 
 			$caller = $trace->get_caller();

--- a/output/html/wp_errors.php
+++ b/output/html/wp_errors.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * WP error output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_WP_Errors extends QM_Output_Html {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_WP_Errors Collector.
+	 */
+	protected $collector;
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 10 );
+	}
+
+	public function name() {
+		return __( 'WP Errors', 'query-monitor' );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['errors'] ) && empty( $data['checked'] ) ) {
+			return;
+		}
+
+		$components = array();
+
+		foreach ( $data['errors'] as $error ) {
+			$components[] = $error['trace']->get_component()->name;
+		}
+
+		$components = array_unique( $components );
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Error Code', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Error Message', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Error Source', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Trace', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $data['errors'] as $id => $error ) {
+			/**
+			 * @var WP_Error $wp_error
+			 */
+			$wp_error = $error['error'];
+
+			/**
+			 * @var QM_Backtrace $trace
+			 */
+			$trace = $error['trace'];
+
+			$caller = $trace->get_caller();
+
+			echo '<tr>';
+			echo '<td>' . esc_html( $wp_error->get_error_code() ) . '</td>';
+			echo '<td>' . esc_html( $wp_error->get_error_message() ) . '</td>';
+			echo '<td>';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo self::output_filename( $caller['display'], $caller['calling_file'], $caller['calling_line'] );
+			echo '</td>';
+			echo '<td>';
+
+			if ( isset( $data['checked'][ $id ] ) ) {
+				echo '<ol>';
+				foreach ( $data['checked'][ $id ] as $check ) {
+					$check_caller = $check['trace']->get_caller();
+					echo '<li>';
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo self::output_filename( $check_caller['display'], $check_caller['calling_file'], $check_caller['calling_line'] );
+					echo '</li>';
+				}
+				echo '</ol>';
+			} else {
+				echo 'No';
+			}
+
+			echo '</td>';
+			echo '<td>' . esc_html( $trace->get_component()->name ) . '</td>';
+			echo '</tr>';
+		}
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+		$title = __( 'WP Errors', 'query-monitor' );
+
+		$menu[ $this->collector->id() ] = $this->menu( array(
+			'title' => $title,
+		) );
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_wp_errors( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'wp_errors' );
+	if ( $collector ) {
+		$output['wp_errors'] = new QM_Output_Html_WP_Errors( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_wp_errors', 110, 2 );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,9 @@
 		<!-- @TODO remove this exclusion: -->
 		<exclude name="Squiz.Commenting" />
 
+		<!-- Exclude short description sniff so short `@var` notation can be used -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+
 		<!-- Not interested in whitespace issues at the moment -->
 		<exclude name="PEAR.Functions.FunctionCallSignature" />
 		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma" />

--- a/tests/phpunit/test-dispatcher-html.php
+++ b/tests/phpunit/test-dispatcher-html.php
@@ -94,6 +94,7 @@ class TestDispatcherHTML extends QM_UnitTestCase {
 			'rewrites'      => true,
 			'timing'        => false,
 			'transients'    => true,
+			'wp_errors'     => true,
 		);
 
 		$collectors = QM_Collectors::init();


### PR DESCRIPTION
This introduces a new panel which allows you to track the journey that a `WP_Error` object takes through the code.

Requires WordPress 5.6 (see https://core.trac.wordpress.org/ticket/40568).

The instantiation of the error is tracked (specifically, the addition of an error to a `WP_Error` object is tracked) and then any subsequent calls to `is_wp_error()` where that error object is passed through it.

I'm unsure if this panel is widely useful, but I have found it to be useful if a `WP_Error` instance "disappears" by, for example, being checked and then turned into `return false`. This panel allows for part of that investigation to be provided for you as you can see the journey that the error took until it disappeared.

This usage pattern of course shouldn't be encouraged, but it's what we have. Use exceptions!

The filtered stack trace is currently quite unreliable. I need to continue working on improvements to the filtering inside `QM_Backtrace`.

![wp-errors](https://user-images.githubusercontent.com/208434/99080239-50d53d00-25c1-11eb-9d6f-fbbf0d6eaf97.png)
