### PR TITLE
Add Wordpress memory usage statistic to Overview panel

### DIFF
--- a/collectors/overview.php
+++ b/collectors/overview.php
@@ -49,6 +49,16 @@ class QM_Collector_Overview extends QM_Collector {
 			$this->data['memory_usage'] = 0;
 		}
 
+		$this->data['wp_memory_limit'] = trim(WP_MEMORY_LIMIT); // Pull the config value
+		$this->data['wp_memory_limit'] = preg_replace('/[^0-9]/', '', $this->data['wp_memory_limit']); // Remove the trailing MB
+		$this->data['wp_memory_limit'] = $this->data['wp_memory_limit'] * 1024 * 1024; // Convert from MB to Bytes
+
+		if ( $this->data['wp_memory_limit'] > 0 ) {
+			$this->data['wp_memory_usage'] = ( 100 / $this->data['wp_memory_limit'] ) * $this->data['memory'];
+		} else {
+			$this->data['wp_memory_usage'] = 0;
+		}
+
 		$this->data['display_time_usage_warning']   = ( $this->data['time_usage'] >= 75 );
 		$this->data['display_memory_usage_warning'] = ( $this->data['memory_usage'] >= 75 );
 

--- a/collectors/overview.php
+++ b/collectors/overview.php
@@ -49,9 +49,7 @@ class QM_Collector_Overview extends QM_Collector {
 			$this->data['memory_usage'] = 0;
 		}
 
-		$this->data['wp_memory_limit'] = trim(WP_MEMORY_LIMIT); // Pull the config value
-		$this->data['wp_memory_limit'] = preg_replace('/[^0-9]/', '', $this->data['wp_memory_limit']); // Remove the trailing MB
-		$this->data['wp_memory_limit'] = $this->data['wp_memory_limit'] * 1024 * 1024; // Convert from MB to Bytes
+		$this->data['wp_memory_limit'] = QM_Util::convert_hr_to_bytes( trim( WP_MEMORY_LIMIT ) ); // Pull the config value
 
 		if ( $this->data['wp_memory_limit'] > 0 ) {
 			$this->data['wp_memory_usage'] = ( 100 / $this->data['wp_memory_limit'] ) * $this->data['memory'];

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -157,15 +157,6 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 					number_format_i18n( $data['wp_memory_limit'] / 1024 )
 				) );
 				echo '</span>';
-			} else {
-				echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
-				printf(
-				/* translators: 1: Name of the PHP directive, 2: Value of the PHP directive */
-					esc_html__( 'No WordPress memory limit. The %1$s PHP configuration directive is set to %2$s.', 'query-monitor' ),
-					'<code>memory_limit</code>',
-					'0'
-				);
-				echo '</span>';
 			}
 		}
 

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -128,7 +128,7 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 				}
 				echo esc_html( sprintf(
 					/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
-					__( '%1$s%% of %2$s kB limit', 'query-monitor' ),
+					__( '%1$s%% of %2$s kB server limit', 'query-monitor' ),
 					number_format_i18n( $data['memory_usage'], 1 ),
 					number_format_i18n( $data['memory_limit'] / 1024 )
 				) );
@@ -138,6 +138,30 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 				printf(
 					/* translators: 1: Name of the PHP directive, 2: Value of the PHP directive */
 					esc_html__( 'No memory limit. The %1$s PHP configuration directive is set to %2$s.', 'query-monitor' ),
+					'<code>memory_limit</code>',
+					'0'
+				);
+				echo '</span>';
+			}
+
+			if ( $data['wp_memory_limit'] > 0 ) {
+				if ( $data['display_memory_usage_warning'] ) {
+					echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				} else {
+					echo '<br><span class="qm-info">';
+				}
+				echo esc_html( sprintf(
+				/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
+					__( '%1$s%% of %2$s kB WordPress limit', 'query-monitor' ),
+					number_format_i18n( $data['wp_memory_usage'], 1 ),
+					number_format_i18n( $data['wp_memory_limit'] / 1024 )
+				) );
+				echo '</span>';
+			} else {
+				echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				printf(
+				/* translators: 1: Name of the PHP directive, 2: Value of the PHP directive */
+					esc_html__( 'No WordPress memory limit. The %1$s PHP configuration directive is set to %2$s.', 'query-monitor' ),
 					'<code>memory_limit</code>',
 					'0'
 				);


### PR DESCRIPTION
This is just a nice to have that I wanted for myself. All this PR does is add a calculation for how much of the `WP_MEMORY_LIMIT` the site is using. Here is a screenshot of how it looks

<img width="239" alt="image" src="https://user-images.githubusercontent.com/7349882/111334054-9fffad00-8649-11eb-96ee-a43e1aef3b8a.png">
