### PR TITLE
Add QM data to the REST API response when an envelope is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Currently this includes PHP errors and some overview information such as memory 
 
 The response from an authenticated WordPress REST API (v2 or later) request will contain various debugging information in its headers, as long as the authenticated user has permission to view Query Monitor's output.
 
-Currently this includes PHP errors and some overview information such as memory usage, but this will be built upon in future versions.
+Currently this includes PHP errors and overview information.
+
+To see more detailed information about a REST API request you need to perform [an enveloped request](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_envelope) which means appending `?_envelope` to the requested URL. In this case, Query Monitor will include debugging data in a `qm` property in the response. Currently this includes database queries (including information about duplicates and errors), HTTP API requests, and transient updates. More information may be added in a future version.
+
+By using the combination of the HTTP headers and the `qm` property in the response to an enveloped request you'll get good insight into the aspects of a request which have the greatest impact on performance.
 
 ## Admin Screen
 

--- a/classes/Collector.php
+++ b/classes/Collector.php
@@ -233,6 +233,10 @@ abstract class QM_Collector {
 		return ( 'query-monitor' !== $component->context );
 	}
 
+	public function filter_dupe_items( $items ) {
+		return ( count( $items ) > 1 );
+	}
+
 	public function process() {}
 
 	public function post_process() {}

--- a/collectors/db_dupes.php
+++ b/collectors/db_dupes.php
@@ -20,7 +20,7 @@ class QM_Collector_DB_Dupes extends QM_Collector {
 		}
 
 		// Filter out SQL queries that do not have dupes
-		$this->data['dupes'] = array_filter( $dbq->data['dupes'], array( $this, '_filter_dupe_queries' ) );
+		$this->data['dupes'] = array_filter( $dbq->data['dupes'], array( $this, 'filter_dupe_items' ) );
 
 		// Ignore dupes from `WP_Query->set_found_posts()`
 		unset( $this->data['dupes']['SELECT FOUND_ROWS()'] );
@@ -88,11 +88,6 @@ class QM_Collector_DB_Dupes extends QM_Collector {
 		}
 
 	}
-
-	public function _filter_dupe_queries( $queries ) {
-		return ( count( $queries ) > 1 );
-	}
-
 }
 
 function register_qm_collector_db_dupes( array $collectors, QueryMonitor $qm ) {

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -259,10 +259,6 @@ class QM_Collector_HTTP extends QM_Collector {
 			$http['ltime'] = ( $http['end'] - $http['start'] );
 
 			if ( isset( $http['info'] ) ) {
-				if ( isset( $http['info']['total_time'] ) ) {
-					$http['ltime'] = $http['info']['total_time'];
-				}
-
 				if ( ! empty( $http['info']['url'] ) ) {
 					if ( rtrim( $http['url'], '/' ) !== rtrim( $http['info']['url'], '/' ) ) {
 						$http['redirected_to'] = $http['info']['url'];

--- a/dispatchers/REST_Envelope.php
+++ b/dispatchers/REST_Envelope.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * REST API enveloped request dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_REST_Envelope extends QM_Dispatcher {
+
+	public $id = 'rest_envelope';
+
+	public function __construct( QM_Plugin $qm ) {
+		parent::__construct( $qm );
+
+		add_filter( 'rest_envelope_response', array( $this, 'filter_rest_envelope_response' ), 999, 2 );
+	}
+
+	/**
+	 * Filters the enveloped form of a REST API response to add QM's data.
+	 *
+	 * @param array            $envelope Envelope data.
+	 * @param WP_REST_Response $response Original response data.
+	 * @return array Envelope data.
+	 */
+	public function filter_rest_envelope_response( array $envelope, WP_REST_Response $response ) {
+		if ( ! $this->should_dispatch() ) {
+			return $envelope;
+		}
+
+		$data = array();
+
+		$this->before_output();
+
+		/* @var QM_Output_Raw[] */
+		foreach ( $this->get_outputters( 'raw' ) as $id => $output ) {
+			$data[ $id ] = $output->output();
+		}
+
+		$this->after_output();
+
+		$envelope['qm'] = $data;
+
+		return $envelope;
+	}
+
+	protected function before_output() {
+		require_once $this->qm->plugin_path( 'output/Raw.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/raw/*.php' ) ) as $file ) {
+			include_once $file;
+		}
+	}
+
+	public function is_active() {
+		if ( ! self::user_can_view() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+}
+
+function register_qm_dispatcher_rest_envelope( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['rest_envelope'] = new QM_Dispatcher_REST_Envelope( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_rest_envelope', 10, 2 );

--- a/output/Raw.php
+++ b/output/Raw.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Abstract output class for raw output encoded as JSON.
+ *
+ * @package query-monitor
+ */
+
+abstract class QM_Output_Raw extends QM_Output {
+
+	public function output() {
+		return $this->get_output();
+	}
+
+}

--- a/output/raw/cache.php
+++ b/output/raw/cache.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Raw cache output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Cache extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Cache Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Object Cache', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array(
+			'hit_percentage' => null,
+			'hits'           => null,
+			'misses'         => null,
+		);
+		$data = $this->collector->get_data();
+
+		if ( isset( $data['stats'] ) && isset( $data['cache_hit_percentage'] ) ) {
+			$output['hit_percentage'] = (float) number_format_i18n( $data['cache_hit_percentage'], 1 );
+			$output['hits'] = (int) number_format_i18n( $data['stats']['cache_hits'], 0 );
+			$output['misses'] = (int) number_format_i18n( $data['stats']['cache_misses'], 0 );
+		}
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_cache( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'cache' );
+	if ( $collector ) {
+		$output['cache'] = new QM_Output_Raw_Cache( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_cache', 30, 2 );

--- a/output/raw/conditionals.php
+++ b/output/raw/conditionals.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Raw conditionals output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Conditionals extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Conditionals Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Conditionals', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$data = $this->collector->get_data();
+
+		return $data['conds']['true'];
+	}
+}
+
+function register_qm_output_raw_conditionals( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'conditionals' );
+	if ( $collector ) {
+		$output['conditionals'] = new QM_Output_Raw_Conditionals( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_conditionals', 20, 2 );

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -50,7 +50,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		return array(
 			'total'   => $db->total_qs,
-			'time'    => number_format_i18n( $db->total_time, 4 ),
+			'time'    => (float) number_format_i18n( $db->total_time, 4 ),
 			'queries' => $output,
 		);
 	}
@@ -60,7 +60,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		$output['i']    = ++$this->query_row;
 		$output['sql']  = $row['sql'];
-		$output['time'] = number_format_i18n( $row['ltime'], 4 );
+		$output['time'] = (float) number_format_i18n( $row['ltime'], 4 );
 
 		if ( isset( $row['trace'] ) ) {
 			$stack          = array();

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -89,17 +89,15 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 		$output['time'] = (float) number_format_i18n( $row['ltime'], 4 );
 
 		if ( isset( $row['trace'] ) ) {
-			$stack          = array();
+			$stack = array();
 			$filtered_trace = $row['trace']->get_display_trace();
-			array_shift( $filtered_trace );
 
 			foreach ( $filtered_trace as $item ) {
 				$stack[] = $item['display'];
 			}
 		} else {
-			$stack       = explode( ', ', $row['stack'] );
-			$stack       = array_reverse( $stack );
-			array_shift( $stack );
+			$stack = explode( ', ', $row['stack'] );
+			$stack = array_reverse( $stack );
 		}
 
 		$output['stack'] = $stack;

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Raw database query output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_DB_Queries Collector.
+	 */
+	protected $collector;
+
+	public $query_row = 0;
+
+	public function name() {
+		return __( 'Database Queries', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['dbs'] ) ) {
+			return $output;
+		}
+
+		foreach ( $data['dbs'] as $name => $db ) {
+			$output[ $name ] = $this->output_queries( $name, $db, $data );
+		}
+
+		return $output;
+	}
+
+	protected function output_queries( $name, stdClass $db, array $data ) {
+		$this->query_row = 0;
+
+		$output = array();
+
+		if ( empty( $db->rows ) ) {
+			return $output;
+		}
+
+		foreach ( $db->rows as $row ) {
+			$output[] = $this->output_query_row( $row );
+		}
+
+		return $output;
+	}
+
+	protected function output_query_row( array $row ) {
+		$output = array();
+
+		$output['i']    = ++$this->query_row;
+		$output['sql']  = $row['sql'];
+		$output['time'] = number_format_i18n( $row['ltime'], 4 );
+
+		if ( isset( $row['trace'] ) ) {
+			$stack          = array();
+			$filtered_trace = $row['trace']->get_display_trace();
+			array_shift( $filtered_trace );
+
+			foreach ( $filtered_trace as $item ) {
+				$stack[] = $item['display'];
+			}
+		} else {
+			$stack       = explode( ', ', $row['stack'] );
+			$stack       = array_reverse( $stack );
+			array_shift( $stack );
+		}
+
+		$output['stack'] = $stack;
+		$output['result']  = $row['result'];
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_db_queries( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'db_queries' );
+	if ( $collector ) {
+		$output['db_queries'] = new QM_Output_Raw_DB_Queries( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_db_queries', 20, 2 );

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -44,9 +44,17 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 		}
 
 		if ( ! empty( $data['dupes'] ) ) {
+			$dupes = $data['dupes'];
+
+			// Filter out SQL queries that do not have dupes
+			$dupes = array_filter( $dupes, array( $this->collector, 'filter_dupe_items' ) );
+
+			// Ignore dupes from `WP_Query->set_found_posts()`
+			unset( $dupes['SELECT FOUND_ROWS()'] );
+
 			$output['dupes'] = array(
-				'total' => count( $data['dupes'] ),
-				'queries' => $data['dupes'],
+				'total' => count( $dupes ),
+				'queries' => $dupes,
 			);
 		}
 

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -35,6 +35,14 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 		}
 
 		$output['dbs'] = $dbs;
+
+		if ( ! empty( $data['dupes'] ) ) {
+			$output['dupes'] = array(
+				'total' => count( $data['dupes'] ),
+				'queries' => $data['dupes'],
+			);
+		}
+
 		return $output;
 	}
 

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -28,10 +28,13 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 			return $output;
 		}
 
+		$dbs = array();
+
 		foreach ( $data['dbs'] as $name => $db ) {
-			$output[ $name ] = $this->output_queries( $name, $db, $data );
+			$dbs[ $name ] = $this->output_queries( $name, $db, $data );
 		}
 
+		$output['dbs'] = $dbs;
 		return $output;
 	}
 

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -36,6 +36,13 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		$output['dbs'] = $dbs;
 
+		if ( ! empty( $data['errors'] ) ) {
+			$output['errors'] = array(
+				'total' => count( $data['errors'] ),
+				'errors' => $data['errors'],
+			);
+		}
+
 		if ( ! empty( $data['dupes'] ) ) {
 			$output['dupes'] = array(
 				'total' => count( $data['dupes'] ),

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -48,7 +48,11 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 			$output[] = $this->output_query_row( $row );
 		}
 
-		return $output;
+		return array(
+			'total'   => $db->total_qs,
+			'time'    => number_format_i18n( $db->total_time, 4 ),
+			'queries' => $output,
+		);
 	}
 
 	protected function output_query_row( array $row ) {

--- a/output/raw/http.php
+++ b/output/raw/http.php
@@ -49,6 +49,8 @@ class QM_Output_Raw_HTTP extends QM_Output_Raw {
 			);
 		}
 
+		$output['total'] = count( $requests );
+		$output['time'] = (float) number_format_i18n( $data['ltime'], 4 );
 		$output['requests'] = $requests;
 
 		return $output;

--- a/output/raw/http.php
+++ b/output/raw/http.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Raw HTTP API request output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_HTTP extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_HTTP Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'HTTP API Calls', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['http'] ) ) {
+			return $output;
+		}
+
+		$requests = array();
+
+		foreach ( $data['http'] as $http ) {
+			$stack = array();
+
+			if ( isset( $http['trace'] ) ) {
+				$filtered_trace = $http['trace']->get_display_trace();
+				array_shift( $filtered_trace );
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$requests[] = array(
+				'url' => $http['url'],
+				'method' => $http['args']['method'],
+				'response' => $http['response']['response'],
+				'time' => (float) number_format_i18n( $http['end'] - $http['start'], 4 ),
+				'stack' => $stack,
+			);
+		}
+
+		$output['requests'] = $requests;
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_http( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'http' );
+	if ( $collector ) {
+		$output['http'] = new QM_Output_Raw_HTTP( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_http', 30, 2 );

--- a/output/raw/http.php
+++ b/output/raw/http.php
@@ -33,7 +33,6 @@ class QM_Output_Raw_HTTP extends QM_Output_Raw {
 
 			if ( isset( $http['trace'] ) ) {
 				$filtered_trace = $http['trace']->get_display_trace();
-				array_shift( $filtered_trace );
 
 				foreach ( $filtered_trace as $item ) {
 					$stack[] = $item['display'];

--- a/output/raw/logger.php
+++ b/output/raw/logger.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Raw logger output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Logger extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Logger Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Logs', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['logs'] ) ) {
+			return $output;
+		}
+
+		foreach ( $data['logs'] as $log ) {
+			$stack = array();
+
+			if ( isset( $log['trace'] ) ) {
+				$filtered_trace = $log['trace']->get_display_trace();
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$output[ $log['level'] ][] = array(
+				'message' => $log['message'],
+				'stack' => $stack,
+			);
+		}
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_logger( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'logger' );
+	if ( $collector ) {
+		$output['logger'] = new QM_Output_Raw_Logger( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_logger', 30, 2 );

--- a/output/raw/transients.php
+++ b/output/raw/transients.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Raw transients output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Transients extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Transients Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Transients', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['trans'] ) ) {
+			return $output;
+		}
+
+		$transients = array();
+
+		foreach ( $data['trans'] as $transient ) {
+			$stack = array();
+
+			if ( isset( $transient['filtered_trace'] ) ) {
+				$filtered_trace = $transient['filtered_trace'];
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$transients[] = array(
+				'name' => $transient['name'],
+				'type' => $transient['type'],
+				'size' => $transient['size_formatted'],
+				'expiration' => $transient['expiration'],
+				'stack' => $stack,
+			);
+		}
+
+		$output['total'] = count( $transients );
+		$output['transients'] = $transients;
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_transients( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'transients' );
+	if ( $collector ) {
+		$output['transients'] = new QM_Output_Raw_Transients( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_transients', 30, 2 );


### PR DESCRIPTION
When a REST API request is made with `?_envelope` it provides an opportunity for QM to attach debugging data to the response in a way that it can't with a non-enveloped response, because an extra property can be added to the enveloping object.

In the long term QM will move away from dumping all of its data in the response and instead switch to including a reference in a header that the client side component uses to fetch the data from storage, but this is useful in the interim.

Status:

* [X] Database queries
* [X] Duplicate queries
* [X] Query errors
* [X] HTTP API requests
* [x] Transients set
* [x] Conditionals
* [x] Figure out the `array_shift()` for stack traces
* [x] Cache overview
* [x] Logger