### PR TITLE
Implement explicit filtering of traces

### DIFF
--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -65,30 +65,11 @@ class QM_Backtrace {
 		$this->trace = ( null === $trace ) ? debug_backtrace( false ) : $trace;
 
 		$this->args = array_merge( array(
-			'ignore_current_filter' => true,
-			'ignore_frames'         => 0,
 			'ignore_class'          => array(),
 			'ignore_method'         => array(),
 			'ignore_func'           => array(),
 			'show_args'             => array(),
 		), $args );
-
-		$this->ignore( 1 ); # Self-awareness
-
-		/**
-		 * If error_handler() is in the trace, QM fails later when it tries
-		 * to get $lowest['file'] in get_filtered_trace()
-		 */
-		if ( 'error_handler' === $this->trace[0]['function'] ) {
-			$this->ignore( 1 );
-		}
-
-		if ( $this->args['ignore_frames'] ) {
-			$this->ignore( $this->args['ignore_frames'] );
-		}
-		if ( $this->args['ignore_current_filter'] ) {
-			$this->ignore_current_filter();
-		}
 
 		foreach ( $this->trace as $k => $frame ) {
 			if ( ! isset( $frame['args'] ) ) {

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -277,10 +277,10 @@ class QM_Backtrace {
 		}
 
 		$return = $frame;
-		$ignore_class = array_merge( self::$ignore_class, $this->args['ignore_class'] );
-		$ignore_method = array_merge( self::$ignore_method, $this->args['ignore_method'] );
-		$ignore_func = array_merge( self::$ignore_func, $this->args['ignore_func'] );
-		$ignore_hook = array_merge( self::$ignore_hook, $this->args['ignore_hook'] );
+		$ignore_class = array_filter( array_merge( self::$ignore_class, $this->args['ignore_class'] ) );
+		$ignore_method = array_filter( array_merge( self::$ignore_method, $this->args['ignore_method'] ) );
+		$ignore_func = array_filter( array_merge( self::$ignore_func, $this->args['ignore_func'] ) );
+		$ignore_hook = array_filter( array_merge( self::$ignore_hook, $this->args['ignore_hook'] ) );
 		$show_args = array_merge( self::$show_args, $this->args['show_args'] );
 
 		$hook_functions = array(

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -216,16 +216,6 @@ class QM_Backtrace {
 		return $this;
 	}
 
-	public function ignore_current_filter() {
-
-		if ( isset( $this->trace[2] ) && isset( $this->trace[2]['function'] ) ) {
-			if ( in_array( $this->trace[2]['function'], array( 'apply_filters', 'do_action' ), true ) ) {
-				$this->ignore( 3 ); # Ignore filter and action callbacks
-			}
-		}
-
-	}
-
 	public function filter_trace( array $frame ) {
 
 		if ( ! self::$filtered && function_exists( 'did_action' ) && did_action( 'plugins_loaded' ) ) {

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -161,27 +161,7 @@ class QM_Collector_Caps extends QM_Collector {
 				$name = '';
 			}
 
-			$trace          = $cap['trace']->get_trace();
 			$filtered_trace = $cap['trace']->get_display_trace();
-
-			$last = end( $filtered_trace );
-			if ( isset( $last['function'] ) && 'map_meta_cap' === $last['function'] ) {
-				array_shift( $filtered_trace ); // remove the map_meta_cap() call
-			}
-
-			array_shift( $filtered_trace ); // remove the WP_User->has_cap() call
-			array_shift( $filtered_trace ); // remove the *_user_can() call
-
-			if ( ! count( $filtered_trace ) ) {
-				$responsible_name = QM_Util::standard_dir( $trace[1]['file'], '' ) . ':' . $trace[1]['line'];
-
-				$responsible_item                 = $trace[1];
-				$responsible_item['display']      = $responsible_name;
-				$responsible_item['calling_file'] = $trace[1]['file'];
-				$responsible_item['calling_line'] = $trace[1]['line'];
-				array_unshift( $filtered_trace, $responsible_item );
-			}
-
 			$component = $cap['trace']->get_component();
 
 			$this->data['caps'][ $i ]['filtered_trace'] = $filtered_trace;

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -81,7 +81,11 @@ class QM_Collector_Caps extends QM_Collector {
 	 * @return bool[] Concerned user's capabilities.
 	 */
 	public function filter_user_has_cap( array $user_caps, array $caps, array $args ) {
-		$trace  = new QM_Backtrace();
+		$trace  = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
 		$result = true;
 
 		foreach ( $caps as $cap ) {
@@ -124,7 +128,11 @@ class QM_Collector_Caps extends QM_Collector {
 			return $required_caps;
 		}
 
-		$trace  = new QM_Backtrace();
+		$trace  = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
 		$result = ( ! in_array( 'do_not_allow', $required_caps, true ) );
 
 		array_unshift( $args, $user_id );

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -98,7 +98,11 @@ class QM_Collector_HTTP extends QM_Collector {
 	 * @return array        HTTP request arguments.
 	 */
 	public function filter_http_request_args( array $args, $url ) {
-		$trace = new QM_Backtrace();
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
 		if ( isset( $args['_qm_key'] ) ) {
 			// Something has triggered another HTTP request from within the `pre_http_request` filter
 			// (eg. WordPress Beta Tester does this). This allows for one level of nested queries.

--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -83,50 +83,28 @@ class QM_Collector_Languages extends QM_Collector {
 	 * @return bool
 	 */
 	public function log_file_load( $override, $domain, $mofile ) {
-
 		if ( 'query-monitor' === $domain && self::hide_qm() ) {
 			return $override;
 		}
 
-		$trace    = new QM_Backtrace();
-		$filtered = $trace->get_filtered_trace();
-		$caller   = array();
-
-		foreach ( $filtered as $i => $item ) {
-
-			if ( in_array( $item['function'], array(
-				'load_muplugin_textdomain',
-				'load_plugin_textdomain',
-				'load_theme_textdomain',
-				'load_child_theme_textdomain',
-				'load_default_textdomain',
-			), true ) ) {
-				$caller = $item;
-				$display = $i + 1;
-				if ( isset( $filtered[ $display ] ) ) {
-					$caller['display'] = $filtered[ $display ]['display'];
-				}
-				break;
-			}
-		}
-
-		if ( empty( $caller ) ) {
-			if ( isset( $filtered[1] ) ) {
-				$caller = $filtered[1];
-			} else {
-				$caller = $filtered[0];
-			}
-		}
-
-		if ( ! isset( $caller['file'] ) && isset( $filtered[0]['file'] ) && isset( $filtered[0]['line'] ) ) {
-			$caller['file'] = $filtered[0]['file'];
-			$caller['line'] = $filtered[0]['line'];
-		}
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+			'ignore_func' => array(
+				'load_textdomain' => ( 'default' !== $domain ),
+				'load_muplugin_textdomain' => true,
+				'load_plugin_textdomain' => true,
+				'load_theme_textdomain' => true,
+				'load_child_theme_textdomain' => true,
+				'load_default_textdomain' => true,
+			),
+		) );
 
 		$found = file_exists( $mofile ) ? filesize( $mofile ) : false;
 
 		$this->data['languages'][ $domain ][] = array(
-			'caller' => $caller,
+			'caller' => $trace->get_caller(),
 			'domain' => $domain,
 			'file'   => $mofile,
 			'found'  => $found,
@@ -148,14 +126,16 @@ class QM_Collector_Languages extends QM_Collector {
 	 * @return string|false Path to the translation file to load. False if there isn't one.
 	 */
 	public function log_script_file_load( $file, $handle, $domain ) {
-		$trace    = new QM_Backtrace();
-		$filtered = $trace->get_filtered_trace();
-		$caller   = $filtered[0];
+		$trace    = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
 
 		$found = ( $file && file_exists( $file ) ) ? filesize( $file ) : false;
 
 		$this->data['languages'][ $domain ][] = array(
-			'caller' => $caller,
+			'caller' => $trace->get_caller(),
 			'domain' => $domain,
 			'file'   => $file,
 			'found'  => $found,

--- a/collectors/logger.php
+++ b/collectors/logger.php
@@ -77,7 +77,9 @@ class QM_Collector_Logger extends QM_Collector {
 	protected function store( $level, $message, array $context = array() ) {
 		$type  = 'string';
 		$trace = new QM_Backtrace( array(
-			'ignore_frames' => 2,
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
 		) );
 
 		if ( is_wp_error( $message ) ) {

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -165,9 +165,7 @@ class QM_Collector_PHP_Errors extends QM_Collector {
 			return false;
 		}
 
-		$trace  = new QM_Backtrace( array(
-			'ignore_current_filter' => false,
-		) );
+		$trace  = new QM_Backtrace();
 		$caller = $trace->get_caller();
 		$key    = md5( $message . $file . $line . $caller['id'] );
 

--- a/collectors/redirects.php
+++ b/collectors/redirects.php
@@ -24,7 +24,14 @@ class QM_Collector_Redirects extends QM_Collector {
 			return $location;
 		}
 
-		$trace = new QM_Backtrace();
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+			'ignore_func' => array(
+				'wp_redirect' => true,
+			),
+		) );
 
 		$this->data['trace']    = $trace;
 		$this->data['location'] = $location;

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -123,9 +123,7 @@ class QM_Collector_Theme extends QM_Collector {
 	public function action_get_template_part( $slug, $name, $templates ) {
 		$data = compact( 'slug', 'name', 'templates' );
 
-		$data['trace'] = new QM_Backtrace( array(
-			'ignore_frames' => 4,
-		) );
+		$data['trace'] = new QM_Backtrace();
 
 		$this->data['requested_template_parts'][] = $data;
 	}

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -123,7 +123,13 @@ class QM_Collector_Theme extends QM_Collector {
 	public function action_get_template_part( $slug, $name, $templates ) {
 		$data = compact( 'slug', 'name', 'templates' );
 
-		$data['trace'] = new QM_Backtrace();
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
+
+		$data['caller'] = $trace->get_caller();
 
 		$this->data['requested_template_parts'][] = $data;
 	}
@@ -186,9 +192,6 @@ class QM_Collector_Theme extends QM_Collector {
 
 				foreach ( $this->data['requested_template_parts'] as $part ) {
 					$file = locate_template( $part['templates'] );
-
-					$part['caller'] = $part['trace']->get_caller();
-					unset( $part['trace'] );
 
 					if ( ! $file ) {
 						$this->data['unsuccessful_template_parts'][] = $part;

--- a/collectors/transients.php
+++ b/collectors/transients.php
@@ -34,9 +34,7 @@ class QM_Collector_Transients extends QM_Collector {
 	}
 
 	public function setted_transient( $transient, $type, $value, $expiration ) {
-		$trace = new QM_Backtrace( array(
-			'ignore_frames' => 1, # Ignore the action_setted_(site|blog)_transient method
-		) );
+		$trace = new QM_Backtrace();
 
 		$name = str_replace( array(
 			'_site_transient_',
@@ -66,9 +64,6 @@ class QM_Collector_Transients extends QM_Collector {
 
 		foreach ( $this->data['trans'] as $i => $transient ) {
 			$filtered_trace = $transient['trace']->get_display_trace();
-
-			array_shift( $filtered_trace ); // remove do_action('setted_(site_)?transient')
-			array_shift( $filtered_trace ); // remove set_(site_)?transient()
 
 			$component = $transient['trace']->get_component();
 

--- a/collectors/transients.php
+++ b/collectors/transients.php
@@ -34,7 +34,15 @@ class QM_Collector_Transients extends QM_Collector {
 	}
 
 	public function setted_transient( $transient, $type, $value, $expiration ) {
-		$trace = new QM_Backtrace();
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+			'ignore_func' => array(
+				'set_transient' => true,
+				'set_site_transient' => true,
+			),
+		) );
 
 		$name = str_replace( array(
 			'_site_transient_',

--- a/dispatchers/WP_Die.php
+++ b/dispatchers/WP_Die.php
@@ -25,9 +25,7 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 	}
 
 	public function filter_wp_die_handler( $handler ) {
-		$this->trace = new QM_Backtrace( array(
-			'ignore_frames' => 1,
-		) );
+		$this->trace = new QM_Backtrace();
 
 		return $handler;
 	}
@@ -42,9 +40,6 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 		$switched_locale = function_exists( 'switch_to_locale' ) && switch_to_locale( get_user_locale() );
 		$stack           = array();
 		$filtered_trace  = $this->trace->get_display_trace();
-
-		// Ignore the `apply_filters('wp_die_handler')` stack frame:
-		array_shift( $filtered_trace );
 
 		foreach ( $filtered_trace as $i => $item ) {
 			$stack[] = QM_Output_Html::output_filename( $item['display'], $item['file'], $item['line'] );

--- a/dispatchers/WP_Die.php
+++ b/dispatchers/WP_Die.php
@@ -25,7 +25,11 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 	}
 
 	public function filter_wp_die_handler( $handler ) {
-		$this->trace = new QM_Backtrace();
+		$this->trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_filter() => true,
+			),
+		) );
 
 		return $handler;
 	}
@@ -40,18 +44,11 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 		$switched_locale = function_exists( 'switch_to_locale' ) && switch_to_locale( get_user_locale() );
 		$stack           = array();
 		$filtered_trace  = $this->trace->get_display_trace();
+		$component       = $this->trace->get_component();
 
 		foreach ( $filtered_trace as $i => $item ) {
 			$stack[] = QM_Output_Html::output_filename( $item['display'], $item['file'], $item['line'] );
 		}
-
-		if ( isset( $filtered_trace[ $i - 1 ] ) ) {
-			$culprit = $filtered_trace[ $i - 1 ];
-		} else {
-			$culprit = $filtered_trace[ $i ];
-		}
-
-		$component = QM_Backtrace::get_frame_component( $culprit );
 
 		printf(
 			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -323,7 +323,6 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			$caller_name    = self::output_filename( $row['caller'], $caller['calling_file'], $caller['calling_line'] );
 			$stack          = array();
 			$filtered_trace = $row['trace']->get_display_trace();
-			array_shift( $filtered_trace );
 
 			foreach ( $filtered_trace as $frame ) {
 				$stack[] = self::output_filename( $frame['display'], $frame['calling_file'], $frame['calling_line'] );
@@ -338,7 +337,6 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 			$stack       = explode( ', ', $row['stack'] );
 			$stack       = array_reverse( $stack );
-			array_shift( $stack );
 			$stack       = array_map( function( $frame ) {
 				return '<code>' . esc_html( $frame ) . '</code>';
 			}, $stack );

--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -107,9 +107,7 @@ class QM_DB extends wpdb {
 			return $result;
 		}
 
-		$this->queries[ $i ]['trace'] = new QM_Backtrace( array(
-			'ignore_frames' => 1,
-		) );
+		$this->queries[ $i ]['trace'] = new QM_Backtrace();
 
 		if ( ! isset( $this->queries[ $i ][3] ) ) {
 			$this->queries[ $i ][3] = $this->time_start;


### PR DESCRIPTION
See #564.

Following on from #557.

This generally fixes all the juggling of frames in traces. Specifically it also fixes:

* Fixes #461
* Fixes #433
* Fixes #495

## Details

* Allows a `QM_Backtrace` instance to filter out actions and filters by their hook with the `ignore_hook` argument
* Removes the `ignore_frames` and `ignore_current_filter` arguments
   - This allows a plugin to safely support older versions of QM by simultaneously providing `ignore_frames`/`ignore_current_filter` as well as `ignore_hook`/`ignore_func`/etc
* Removes all of the janky internal stack trace juggling from QM

## TODO

* [x] Finish updating all existing instances of `QM_Backtrace`
* [x] Check there's no more stack trace juggling in the collectors or the outputters

cc @tillkruss 