### PR TITLE
(fix): correct time output in rest api

### DIFF
--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -76,7 +76,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		return array(
 			'total'   => $db->total_qs,
-			'time'    => number_format_i18n( $db->total_time, 4 ),
+			'time'    => round( $db->total_time, 4 ),
 			'queries' => $output,
 		);
 	}
@@ -86,7 +86,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		$output['i']    = ++$this->query_row;
 		$output['sql']  = $row['sql'];
-		$output['time'] = number_format_i18n( $row['ltime'], 4 );
+		$output['time'] = round( $row['ltime'], 4 );
 
 		if ( isset( $row['trace'] ) ) {
 			$stack = array();

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -76,7 +76,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		return array(
 			'total'   => $db->total_qs,
-			'time'    => (float) number_format_i18n( $db->total_time, 4 ),
+			'time'    => number_format_i18n( $db->total_time, 4 ),
 			'queries' => $output,
 		);
 	}
@@ -86,7 +86,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 
 		$output['i']    = ++$this->query_row;
 		$output['sql']  = $row['sql'];
-		$output['time'] = (float) number_format_i18n( $row['ltime'], 4 );
+		$output['time'] = number_format_i18n( $row['ltime'], 4 );
 
 		if ( isset( $row['trace'] ) ) {
 			$stack = array();


### PR DESCRIPTION
Hi,

In the output of Query Monitor in the Rest API, the `time` value is always 0 (zero):
![time-always-zero](https://user-images.githubusercontent.com/4084596/138237759-3a97dc34-9085-4837-9f80-fb29878442b1.png)

This is because we float a string. This might also be because my locale is Dutch, and the `number_format_i18n` is handled differently. However, when changing language and timezone to any other, the `time` value in the API remains zero.

After applying the fix below, the time value is restored.
![time-after-fix](https://user-images.githubusercontent.com/4084596/138238027-cb6d1caf-4e73-4afd-a86b-cc1eefddeedf.png)

