### PR TITLE
Fix WP-CLI error message

### DIFF
--- a/classes/CLI.php
+++ b/classes/CLI.php
@@ -28,7 +28,7 @@ class QM_CLI extends QM_Plugin {
 				WP_CLI::success( "Query Monitor's wp-content/db.php is already in place" );
 				exit( 0 );
 			} else {
-				WP_CLI::error( 'Unknown wp-content/db.php already is already in place' );
+				WP_CLI::error( 'Unknown wp-content/db.php is already in place' );
 			}
 		}
 


### PR DESCRIPTION
I noticed an extra word in a WP-CLI error message. This pull request simply removes the extra word.