### PR TITLE
Make auto show/hide functionality opt-in

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -219,6 +219,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 					'off'        => wp_create_nonce( 'qm-auth-off' ),
 					'editor-set' => wp_create_nonce( 'qm-editor-set' ),
 				),
+				'auto_show'   => defined( 'QM_AUTO_SHOW' ) && QM_AUTO_SHOW ? 'on' : 'off',
 				'fatal_error' => __( 'PHP Fatal Error', 'query-monitor' ),
 			)
 		);
@@ -473,6 +474,10 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		echo '<div class="qm-boxed">';
 		$constants = array(
+			'QM_AUTO_SHOW'             => array(
+				'label'   => __( 'Automatically show Query Monitor\'s interface for new errors and timings.', 'query-monitor' ),
+				'default' => false,
+			),
 			'QM_DARK_MODE'             => array(
 				'label'   => __( 'Enable dark mode for Query Monitor\'s interface.', 'query-monitor' ),
 				'default' => false,


### PR DESCRIPTION
This is one possible approach for #620. It's a bit rough but seems to do the trick - hopefully I didn't miss anything.

When a panel has been pinned but is no longer present, it falls back to the overview panel.

To address the intended auto show/hide behavior, it introduces a new constant QM_AUTO_SHOW. When this constant is truthy, QM will automatically open if the php errors panel or timing panel is present (from my limited testing it seems like the logs panel is always present even if there are no logs to show - please let me know if this is incorrect).

I opted for the constant as it seemed like the simplest approach but wasn't sure if it was the ideal one. An alternative I considered was adding a section to the settings panel and storing the users preference in localstorage.

Let me know what you think, or if this is even something you are interested in changing.