### PR TITLE
Add `qm/component_type/{$type}` filter

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -252,7 +252,7 @@ class QM_Util {
 			case 'unknown':
 			default:
 				$name = __( 'Unknown', 'query-monitor' );
-				
+
 				/**
 				 * Filters the type of a custom or unknown component.
 				 *

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -252,6 +252,20 @@ class QM_Util {
 			case 'unknown':
 			default:
 				$name = __( 'Unknown', 'query-monitor' );
+				
+				/**
+				 * Filters the type of a custom or unknown component.
+				 *
+				 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
+				 *
+				 * @since 3.8.1
+				 *
+				 * @param string $type The component type.
+				 * @param string $file The full file path for the file within the component.
+				 * @param string $name The component name.
+				 * @param string $content The context for the component.
+				 */
+				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $name, $content );
 
 				/**
 				 * Filters the name of a custom or unknown component.

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -258,11 +258,17 @@ class QM_Util {
 				 *
 				 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
 				 *
+				 * See also the corresponding filters:
+				 *
+				 *  - `qm/component_dirs`
+				 *  - `qm/component_name/{$type}`
+				 *  - `qm/component_context/{$type}`
+				 *
 				 * @since 3.8.1
 				 *
-				 * @param string $type The component type.
-				 * @param string $file The full file path for the file within the component.
-				 * @param string $name The component name.
+				 * @param string $type    The component type.
+				 * @param string $file    The full file path for the file within the component.
+				 * @param string $name    The component name.
 				 * @param string $context The context for the component.
 				 */
 				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $name, $context );
@@ -275,6 +281,7 @@ class QM_Util {
 				 * See also the corresponding filters:
 				 *
 				 *  - `qm/component_dirs`
+				 *  - `qm/component_type/{$type}`
 				 *  - `qm/component_context/{$type}`
 				 *
 				 * @since 3.6.0
@@ -293,6 +300,7 @@ class QM_Util {
 				 * See also the corresponding filters:
 				 *
 				 *  - `qm/component_dirs`
+				 *  - `qm/component_type/{$type}`
 				 *  - `qm/component_name/{$type}`
 				 *
 				 * @since 3.8.0

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -263,9 +263,9 @@ class QM_Util {
 				 * @param string $type The component type.
 				 * @param string $file The full file path for the file within the component.
 				 * @param string $name The component name.
-				 * @param string $content The context for the component.
+				 * @param string $context The context for the component.
 				 */
-				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $name, $content );
+				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $name, $context );
 
 				/**
 				 * Filters the name of a custom or unknown component.


### PR DESCRIPTION
When using symlinked (mu-)plugins, there is currently no way to filter the component name, context and type.

The `qm/component_dirs` filter is called very early and the result is cached without a plugin able to modify this later on.

The only other approach would be to apply the `qm/component_dirs` for every `get_file_dirs()` call.