### PR TITLE
Introduce plugin version constant

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -33,6 +33,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'QM_VERSION', '3.8.0' );
+
 $qm_dir = dirname( __FILE__ );
 
 require_once "{$qm_dir}/classes/Plugin.php";


### PR DESCRIPTION
It's rather tedious to read the current QM version, since it may be installed as a MU-plugin as well, so relying on `query-monitor/query-monitor.php` isn't an option.

Updating the constant obviously need to be part of the version release process.

```php
$qmVersion = null;
$qm = QueryMonitor::init();

if (isset($qm->file) && is_readable($qm->file)) {
    $qm = get_file_data($qm->file, false, false);
    $qmVersion = $qm['Version'];
}
```