### PR TITLE
Handle unexpected SQL in QM_Util::get_query_type method

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -503,7 +503,7 @@ class QM_Util {
 		}
 
 		$words = preg_split( '/\b/', trim( $sql ), 2, PREG_SPLIT_NO_EMPTY );
-		$type = __( 'Unknown', 'query-monitor' );
+		$type = 'Unknown';
 		if ( isset( $words[0] ) ) {
 			$type = strtoupper( $words[0] );
 		}

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -503,7 +503,10 @@ class QM_Util {
 		}
 
 		$words = preg_split( '/\b/', trim( $sql ), 2, PREG_SPLIT_NO_EMPTY );
-		$type = strtoupper( $words[0] );
+		$type = __( 'Unknown', 'query-monitor' );
+		if ( isset( $words[0] ) ) {
+			$type = strtoupper( $words[0] );
+		}
 
 		return $type;
 	}

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -341,8 +341,13 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		}
 
 		$stime = number_format_i18n( $row['ltime'], 4 );
+		$sql = $row['sql'];
 
-		$sql = self::format_sql( $row['sql'] );
+		if ( 'Unknown' === $row['type'] ) {
+			$sql = "<code>{$sql}</code>";
+		} else {
+			$sql = self::format_sql( $row['sql'] );
+		}
 
 		if ( 'SELECT' !== $row['type'] ) {
 			$sql = "<span class='qm-nonselectsql'>{$sql}</span>";


### PR DESCRIPTION
Resolves https://github.com/johnbillion/query-monitor/issues/638

Checks that `$words[0]` exists, and if not fallsback to the string "Unknown".