### PR TITLE
Use the container database for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: ${{ matrix.php }}
-        extensions: mysqli, xmlwriter
+        extensions: xmlwriter
         coverage: none
       env:
         fail-fast: true
@@ -59,7 +59,6 @@ jobs:
         php --version
         php -m
         composer --version
-        mysql --version
         docker --version
         docker-compose --version
 
@@ -72,10 +71,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo systemctl start mysql.service
         composer install --prefer-dist
         composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }} || *"
-        mysqladmin -uroot -proot create wordpress_test
 
     - name: Run unit tests
       run: composer test:integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Start Docker environment
       run: |
-        docker-compose up database -d
+        docker-compose up -d database
 
     - name: Log running Docker containers
       run: docker ps -a

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,6 +60,15 @@ jobs:
         php -m
         composer --version
         mysql --version
+        docker --version
+        docker-compose --version
+
+    - name: Start Docker environment
+      run: |
+        docker-compose up database -d
+
+    - name: Log running Docker containers
+      run: docker ps -a
 
     - name: Install dependencies
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you discover a security issue in Query Monitor, please report it to [the secu
 
 ## Setting up Locally
 
-You can clone this repo and activate it like a normal WordPress plugin, but you'll need to install the developer dependencies in order to build the assets and to run the tests.
+You can clone this repo and activate it like a normal WordPress plugin, but you'll need to install the developer dependencies in order to build the assets and you'll need to have Docker Desktop installed to run the tests.
 
 ### Prerequisites
 
@@ -32,8 +32,6 @@ You can clone this repo and activate it like a normal WordPress plugin, but you'
 2. Install the Node dependencies:
 
        npm install
-
-3. If you want to run the tests locally, check the MySQL database credentials in the `tests/.env` file and amend them as necessary.
 
 ## Building the Assets
 

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -4,7 +4,7 @@
 # -o pipefail Produce a failure return code if any command errors
 set -eo pipefail
 
-# Shorthand:
+# Prep:
 WP_PORT=`docker port query-monitor-wordpress | grep "[0-9]+$" -ohE | head -1`
 CHROME_PORT=`docker port query-monitor-chrome | grep "[0-9]+$" -ohE | head -1`
 DATABASE_PORT=`docker port query-monitor-database | grep "[0-9]+$" -ohE | head -1`

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# -e          Exit immediately if a pipeline returns a non-zero status
+# -o pipefail Produce a failure return code if any command errors
+set -eo pipefail
+
+# Prep:
+DATABASE_PORT=`docker port query-monitor-database | grep "[0-9]+$" -ohE | head -1`
+
+# Run the integration tests:
+echo "Running tests..."
+TEST_SITE_DATABASE_PORT=$DATABASE_PORT \
+	./vendor/bin/codecept run integration --env singlesite --skip-group ms-required "$1"
+
+TEST_SITE_DATABASE_PORT=$DATABASE_PORT \
+	./vendor/bin/codecept run integration --env multisite --skip-group ms-excluded "$1"

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -14,4 +14,4 @@ extensions:
       destination:
         default: tests/wordpress/wp-content/plugins
 params:
-  - tests/.env
+  - env

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,7 @@
 			"phpstan analyze"
 		],
 		"test:integration": [
-			"codecept run integration --env singlesite --skip-group ms-required",
-			"codecept run integration --env multisite --skip-group ms-excluded"
+			"bin/integration-tests.sh"
 		],
 		"test:start": [
 			"[[ `uname -m` = \"arm64\" ]] && export CHROME_IMAGE=\"seleniarm/standalone-chromium\"; docker-compose up -d"

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
 			"[[ `uname -m` = \"arm64\" ]] && export CHROME_IMAGE=\"seleniarm/standalone-chromium\"; docker-compose up -d"
 		],
 		"test:acceptance": [
-			"bin/test.sh"
+			"bin/acceptance-tests.sh"
 		],
 		"test:stop": [
 			"[[ `uname -m` = \"arm64\" ]] && export CHROME_IMAGE=\"seleniarm/standalone-chromium\"; docker-compose down"

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,6 @@
 		"wordpress-install-dir": "tests/wordpress"
 	},
 	"scripts": {
-		"post-update-cmd": [
-			"@php -r \"! file_exists( 'tests/.env' ) && copy( 'tests/.env.dist', 'tests/.env' );\""
-		],
 		"test": [
 			"@test:cs",
 			"@test:phpstan",

--- a/tests/.env.dist
+++ b/tests/.env.dist
@@ -1,4 +1,0 @@
-WP_TESTS_DB_NAME="wordpress_test"
-WP_TESTS_DB_USER="root"
-WP_TESTS_DB_PASS="root"
-WP_TESTS_DB_HOST="localhost"

--- a/tests/integration.suite.yml
+++ b/tests/integration.suite.yml
@@ -9,10 +9,10 @@ modules:
   config:
     WPLoader:
       wpRootFolder: 'tests/wordpress'
-      dbName: '%WP_TESTS_DB_NAME%'
-      dbHost: '%WP_TESTS_DB_HOST%'
-      dbUser: '%WP_TESTS_DB_USER%'
-      dbPassword: '%WP_TESTS_DB_PASS%'
+      dbName: exampledb
+      dbHost: '127.0.0.1:%TEST_SITE_DATABASE_PORT%'
+      dbUser: exampleuser
+      dbPassword: examplepass
       configFile: tests/integration/includes/bootstrap.php
       tablePrefix: wp_
       plugins: ['query-monitor/query-monitor.php']


### PR DESCRIPTION
This removes the need for a local MySQL installation and database