### PR TITLE
Switch to a client side setting for dark mode

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,6 @@ module.exports = function (grunt) {
 	};
 
 	const sassFiles = {
-		'assets/query-monitor-dark.css': 'assets/query-monitor-dark.scss',
 		'assets/query-monitor.css': 'assets/query-monitor.scss'
 	};
 	const sassOptions = {

--- a/assets/_colours-dark.scss
+++ b/assets/_colours-dark.scss
@@ -30,59 +30,119 @@ $editor-sunglo:   #e06c75;
 $editor-olivine:  #98c379;
 
 // Main container
-$qm-container-fg: lighten( $light-grey, 15% ) !default;
-$qm-container-bg: $dark-grey !default;
-$qm-container-overflow: $base-grey !default;
+$qm-dark-container-fg: lighten( $light-grey, 15% ) !default;
+$qm-dark-container-bg: $dark-grey !default;
+$qm-dark-container-overflow: $base-grey !default;
 
 // Panels
-$qm-panel-border: $dark-silver !default;
-$qm-panel-fg: $qm-container-fg !default;
-$qm-panel-bg: $base-grey !default;
-$qm-panel-separator: $dark-silver !default;
+$qm-dark-panel-border: $dark-silver !default;
+$qm-dark-panel-fg: $qm-dark-container-fg !default;
+$qm-dark-panel-bg: $base-grey !default;
+$qm-dark-panel-separator: $dark-silver !default;
 
 // Panel menus
-$qm-panel-menu-border: $dark-grey !default;
-$qm-panel-menu-fg: lighten( $light-grey, 15% ) !default;
-$qm-panel-menu-bg: $base-grey !default;
-$qm-panel-menu-fg-hover: $light-grey !default;
-$qm-panel-menu-bg-hover: lighten( $dark-grey, 5% ) !default;
-$qm-panel-menu-fg-current: lighten( $light-grey, 15% ) !default;
-$qm-panel-menu-bg-current: $dark-grey !default;
-$qm-panel-menu-bg-current-focus: lighten( $qm-panel-menu-bg-current, 5% ) !default;
-$qm-panel-menu-fg-selected: #fff !default;
-$qm-panel-menu-bg-selected: #0073aa !default;
-$qm-panel-menu-bg-selected-focus: lighten( $qm-panel-menu-bg-selected, 5% ) !default;
-$qm-panel-menu-shadow: darken( $qm-panel-menu-bg-selected, 5% ) !default;
+$qm-dark-panel-menu-border: $dark-grey !default;
+$qm-dark-panel-menu-fg: lighten( $light-grey, 15% ) !default;
+$qm-dark-panel-menu-bg: $base-grey !default;
+$qm-dark-panel-menu-fg-hover: $light-grey !default;
+$qm-dark-panel-menu-bg-hover: lighten( $dark-grey, 5% ) !default;
+$qm-dark-panel-menu-fg-current: lighten( $light-grey, 15% ) !default;
+$qm-dark-panel-menu-bg-current: $dark-grey !default;
+$qm-dark-panel-menu-bg-current-focus: lighten( $qm-dark-panel-menu-bg-current, 5% ) !default;
+$qm-dark-panel-menu-fg-selected: #fff !default;
+$qm-dark-panel-menu-bg-selected: #0073aa !default;
+$qm-dark-panel-menu-bg-selected-focus: lighten( $qm-dark-panel-menu-bg-selected, 5% ) !default;
+$qm-dark-panel-menu-shadow: darken( $qm-dark-panel-menu-bg-selected, 5% ) !default;
 
 // Tables
-$qm-cell-border: $base-grey !default;
-$qm-cell-bg-hover: lighten( $dark-grey, 2% ) !default;
-$qm-cell-fg-highlight: $qm-container-fg !default;
-$qm-cell-bg-highlight: #57572a !default;
-$qm-cell-bg-stripe: $dark-grey !default;
-$qm-table-header-bg: $dark-grey !default;
-$qm-table-footer-bg: $dark-grey !default;
+$qm-dark-cell-border: $base-grey !default;
+$qm-dark-cell-bg-hover: lighten( $dark-grey, 2% ) !default;
+$qm-dark-cell-fg-highlight: $qm-dark-container-fg !default;
+$qm-dark-cell-bg-highlight: #57572a !default;
+$qm-dark-cell-bg-stripe: $dark-grey !default;
+$qm-dark-table-header-bg: $dark-grey !default;
+$qm-dark-table-footer-bg: $dark-grey !default;
 
 // Links and Buttons
-$qm-link-fg: $bright-blue !default;
-$qm-link-fg-hover: $light-blue !default;
-$qm-link-fg-active: lighten( $light-blue, 10% ) !default;
-$qm-button-fg: #fff !default;
-$qm-button-bg: #0085ba !default;
-$qm-button-fg-hover: $qm-button-fg !default;
-$qm-button-bg-hover: darken( $qm-button-bg, 3% ) !default;
-$qm-button-fg-active: $qm-button-fg !default;
-$qm-button-bg-active: darken( $qm-button-bg, 6% ) !default;
-$qm-title-button-fg: $light-grey !default;
-$qm-title-button-bg: transparent !default;
-$qm-title-button-fg-hover: $dark-grey !default;
-$qm-title-button-bg-hover: $light-grey !default;
-$qm-info-fg: #aaa !default;
+$qm-dark-link-fg: $bright-blue !default;
+$qm-dark-link-fg-hover: $light-blue !default;
+$qm-dark-link-fg-active: lighten( $light-blue, 10% ) !default;
+$qm-dark-button-fg: #fff !default;
+$qm-dark-button-bg: #0085ba !default;
+$qm-dark-button-fg-hover: $qm-dark-button-fg !default;
+$qm-dark-button-bg-hover: darken( $qm-dark-button-bg, 3% ) !default;
+$qm-dark-button-fg-active: $qm-dark-button-fg !default;
+$qm-dark-button-bg-active: darken( $qm-dark-button-bg, 6% ) !default;
+$qm-dark-title-button-fg: $light-grey !default;
+$qm-dark-title-button-bg: transparent !default;
+$qm-dark-title-button-fg-hover: $dark-grey !default;
+$qm-dark-title-button-bg-hover: $light-grey !default;
+$qm-dark-info-fg: #aaa !default;
 
 // Formatting
-$qm-warn-fg: #fff0f0 !default;
-$qm-warn-bg: #622 !default;
-$qm-warn-border: #ffd6d6 !default;
-$qm-nonselect-fg: #a6a !default;
-$qm-selection-fg: $dark-grey !default;
-$qm-selection-bg: #B9D6FB !default;
+$qm-dark-warn-fg: #fff0f0 !default;
+$qm-dark-warn-bg: #622 !default;
+$qm-dark-warn-border: #ffd6d6 !default;
+$qm-dark-nonselect-fg: #a6a !default;
+$qm-dark-selection-fg: $dark-grey !default;
+$qm-dark-selection-bg: #B9D6FB !default;
+
+$colours-dark: (
+	// Main container
+	'container-fg': $qm-dark-container-fg,
+	'container-bg': $qm-dark-container-bg,
+	'container-overflow': $qm-dark-container-overflow,
+
+	// Panels
+	'panel-border': $qm-dark-panel-border,
+	'panel-fg': $qm-dark-panel-fg,
+	'panel-bg': $qm-dark-panel-bg,
+	'panel-separator': $qm-dark-panel-separator,
+
+	// Panel menus
+	'panel-menu-border': $qm-dark-panel-menu-border,
+	'panel-menu-fg': $qm-dark-panel-menu-fg,
+	'panel-menu-bg': $qm-dark-panel-menu-bg,
+	'panel-menu-fg-hover': $qm-dark-panel-menu-fg-hover,
+	'panel-menu-bg-hover': $qm-dark-panel-menu-bg-hover,
+	'panel-menu-fg-current': $qm-dark-panel-menu-fg-current,
+	'panel-menu-bg-current': $qm-dark-panel-menu-bg-current,
+	'panel-menu-bg-current-focus': $qm-dark-panel-menu-bg-current-focus,
+	'panel-menu-fg-selected': $qm-dark-panel-menu-fg-selected,
+	'panel-menu-bg-selected': $qm-dark-panel-menu-bg-selected,
+	'panel-menu-bg-selected-focus': $qm-dark-panel-menu-bg-selected-focus,
+	'panel-menu-shadow': $qm-dark-panel-menu-shadow,
+
+	// Tables
+	'cell-border': $qm-dark-cell-border,
+	'cell-bg-hover': $qm-dark-cell-bg-hover,
+	'cell-fg-highlight': $qm-dark-cell-fg-highlight,
+	'cell-bg-highlight': $qm-dark-cell-bg-highlight,
+	'cell-bg-stripe': $qm-dark-cell-bg-stripe,
+	'table-header-bg': $qm-dark-table-header-bg,
+	'table-footer-bg': $qm-dark-table-footer-bg,
+
+	// Links and Buttons
+	'link-fg': $qm-dark-link-fg,
+	'link-fg-hover': $qm-dark-link-fg-hover,
+	'link-fg-active': $qm-dark-link-fg-active,
+	'button-fg': $qm-dark-button-fg,
+	'button-bg': $qm-dark-button-bg,
+	'button-fg-hover': $qm-dark-button-fg-hover,
+	'button-bg-hover': $qm-dark-button-bg-hover,
+	'button-fg-active': $qm-dark-button-fg-active,
+	'button-bg-active': $qm-dark-button-bg-active,
+	'title-button-fg': $qm-dark-title-button-fg,
+	'title-button-bg': $qm-dark-title-button-bg,
+	'title-button-fg-hover': $qm-dark-title-button-fg-hover,
+	'title-button-bg-hover': $qm-dark-title-button-bg-hover,
+	'info-fg': $qm-dark-info-fg,
+
+	// Formatting
+	'warn-fg': $qm-dark-warn-fg,
+	'warn-bg': $qm-dark-warn-bg,
+	'warn-border': $qm-dark-warn-border,
+	'nonselect-fg': $qm-dark-nonselect-fg,
+	'selection-fg': $qm-dark-selection-fg,
+	'selection-bg': $qm-dark-selection-bg,
+);

--- a/assets/_colours-dark.scss
+++ b/assets/_colours-dark.scss
@@ -59,6 +59,7 @@ $qm-dark-cell-border: $base-grey !default;
 $qm-dark-cell-bg-hover: lighten( $dark-grey, 2% ) !default;
 $qm-dark-cell-fg-highlight: $qm-dark-container-fg !default;
 $qm-dark-cell-bg-highlight: #57572a !default;
+$qm-dark-cell-bg-highlight-dark: darken( $qm-dark-cell-bg-highlight, 10% ) !default;
 $qm-dark-cell-bg-stripe: $dark-grey !default;
 $qm-dark-table-header-bg: $dark-grey !default;
 $qm-dark-table-footer-bg: $dark-grey !default;
@@ -82,6 +83,7 @@ $qm-dark-info-fg: #aaa !default;
 // Formatting
 $qm-dark-warn-fg: #fff0f0 !default;
 $qm-dark-warn-bg: #622 !default;
+$qm-dark-warn-bg-dark: lighten( $qm-dark-warn-bg, 1.5% ) !default;
 $qm-dark-warn-border: #ffd6d6 !default;
 $qm-dark-nonselect-fg: #a6a !default;
 $qm-dark-selection-fg: $dark-grey !default;
@@ -118,6 +120,7 @@ $colours-dark: (
 	'cell-bg-hover': $qm-dark-cell-bg-hover,
 	'cell-fg-highlight': $qm-dark-cell-fg-highlight,
 	'cell-bg-highlight': $qm-dark-cell-bg-highlight,
+	'cell-bg-highlight-dark': $qm-dark-cell-bg-highlight-dark,
 	'cell-bg-stripe': $qm-dark-cell-bg-stripe,
 	'table-header-bg': $qm-dark-table-header-bg,
 	'table-footer-bg': $qm-dark-table-footer-bg,
@@ -141,6 +144,7 @@ $colours-dark: (
 	// Formatting
 	'warn-fg': $qm-dark-warn-fg,
 	'warn-bg': $qm-dark-warn-bg,
+	'warn-bg-dark': $qm-dark-warn-bg-dark,
 	'warn-border': $qm-dark-warn-border,
 	'nonselect-fg': $qm-dark-nonselect-fg,
 	'selection-fg': $qm-dark-selection-fg,

--- a/assets/_colours-default.scss
+++ b/assets/_colours-default.scss
@@ -28,6 +28,7 @@ $qm-cell-border: #e0e0e0 !default;
 $qm-cell-bg-hover: #eef3fa !default;
 $qm-cell-fg-highlight: $qm-container-fg !default;
 $qm-cell-bg-highlight: #ffd !default;
+$qm-cell-bg-highlight-dark: darken( $qm-cell-bg-highlight, 10% ) !default;
 $qm-cell-bg-stripe: #f9f9f9 !default;
 $qm-table-header-bg: #fff !default;
 $qm-table-footer-bg: $qm-container-bg !default;
@@ -51,6 +52,7 @@ $qm-info-fg: #666 !default;
 // Formatting
 $qm-warn-fg: #900 !default;
 $qm-warn-bg: #fff0f0 !default;
+$qm-warn-bg-dark: darken( $qm-warn-bg, 1.5% ) !default;
 $qm-warn-border: #ffd6d6 !default;
 $qm-nonselect-fg: #a0a !default;
 $qm-selection-fg: $qm-container-fg !default;
@@ -87,6 +89,7 @@ $colours-default: (
 	'cell-bg-hover': $qm-cell-bg-hover,
 	'cell-fg-highlight': $qm-cell-fg-highlight,
 	'cell-bg-highlight': $qm-cell-bg-highlight,
+	'cell-bg-highlight-dark': $qm-cell-bg-highlight-dark,
 	'cell-bg-stripe': $qm-cell-bg-stripe,
 	'table-header-bg': $qm-table-header-bg,
 	'table-footer-bg': $qm-table-footer-bg,
@@ -110,6 +113,7 @@ $colours-default: (
 	// Formatting
 	'warn-fg': $qm-warn-fg,
 	'warn-bg': $qm-warn-bg,
+	'warn-bg-dark': $qm-warn-bg-dark,
 	'warn-border': $qm-warn-border,
 	'nonselect-fg': $qm-nonselect-fg,
 	'selection-fg': $qm-selection-fg,

--- a/assets/_colours-default.scss
+++ b/assets/_colours-default.scss
@@ -55,3 +55,63 @@ $qm-warn-border: #ffd6d6 !default;
 $qm-nonselect-fg: #a0a !default;
 $qm-selection-fg: $qm-container-fg !default;
 $qm-selection-bg: #B9D6FB !default;
+
+$colours-default: (
+	// Main container
+	'container-fg': $qm-container-fg,
+	'container-bg': $qm-container-bg,
+	'container-overflow': $qm-container-overflow,
+
+	// Panels
+	'panel-border': $qm-panel-border,
+	'panel-fg': $qm-panel-fg,
+	'panel-bg': $qm-panel-bg,
+	'panel-separator': $qm-panel-separator,
+
+	// Panel menus
+	'panel-menu-border': $qm-panel-menu-border,
+	'panel-menu-fg': $qm-panel-menu-fg,
+	'panel-menu-bg': $qm-panel-menu-bg,
+	'panel-menu-fg-hover': $qm-panel-menu-fg-hover,
+	'panel-menu-bg-hover': $qm-panel-menu-bg-hover,
+	'panel-menu-fg-current': $qm-panel-menu-fg-current,
+	'panel-menu-bg-current': $qm-panel-menu-bg-current,
+	'panel-menu-bg-current-focus': $qm-panel-menu-bg-current-focus,
+	'panel-menu-fg-selected': $qm-panel-menu-fg-selected,
+	'panel-menu-bg-selected': $qm-panel-menu-bg-selected,
+	'panel-menu-bg-selected-focus': $qm-panel-menu-bg-selected-focus,
+	'panel-menu-shadow': $qm-panel-menu-shadow,
+
+	// Tables
+	'cell-border': $qm-cell-border,
+	'cell-bg-hover': $qm-cell-bg-hover,
+	'cell-fg-highlight': $qm-cell-fg-highlight,
+	'cell-bg-highlight': $qm-cell-bg-highlight,
+	'cell-bg-stripe': $qm-cell-bg-stripe,
+	'table-header-bg': $qm-table-header-bg,
+	'table-footer-bg': $qm-table-footer-bg,
+
+	// Links and Buttons
+	'link-fg': $qm-link-fg,
+	'link-fg-hover': $qm-link-fg-hover,
+	'link-fg-active': $qm-link-fg-active,
+	'button-fg': $qm-button-fg,
+	'button-bg': $qm-button-bg,
+	'button-fg-hover': $qm-button-fg-hover,
+	'button-bg-hover': $qm-button-bg-hover,
+	'button-fg-active': $qm-button-fg-active,
+	'button-bg-active': $qm-button-bg-active,
+	'title-button-fg': $qm-title-button-fg,
+	'title-button-bg': $qm-title-button-bg,
+	'title-button-fg-hover': $qm-title-button-fg-hover,
+	'title-button-bg-hover': $qm-title-button-bg-hover,
+	'info-fg': $qm-info-fg,
+
+	// Formatting
+	'warn-fg': $qm-warn-fg,
+	'warn-bg': $qm-warn-bg,
+	'warn-border': $qm-warn-border,
+	'nonselect-fg': $qm-nonselect-fg,
+	'selection-fg': $qm-selection-fg,
+	'selection-bg': $qm-selection-bg,
+);

--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -387,10 +387,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		button:active *,
 		button:active {
+			/* @TODO */
 			background: #ccc !important;
 		}
 
 		button.qm-button-active {
+			/* @TODO */
 			color: #3879d9 !important;
 		}
 
@@ -814,12 +816,14 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm p.qm-true,
 	.qm span.qm-true,
 	.qm td.qm-true {
+		/* @TODO */
 		color: #282 !important;
 	}
 
 	.qm .qm-false code,
 	.qm span.qm-false,
 	.qm td.qm-false {
+		/* @TODO */
 		color: #999 !important;
 	}
 
@@ -962,6 +966,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody .qm-warn li,
 	.qm tbody .qm-warn .qm-info,
 	.qm tbody .qm-warn code {
+		/* @TODO */
 		background-color: transparent !important;
 		color: var( --qm-warn-fg ) !important;
 	}
@@ -982,8 +987,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm .qm-dashicons-yes {
+		/* @TODO */
 		background-color: #0a0 !important;
 		border-radius: 50% !important;
+		/* @TODO */
 		color: #fff !important;
 	}
 
@@ -1191,6 +1198,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm .qm-sortable-column .qm-sort-arrow {
+		/* @TODO */
 		color: #ccc !important;
 		display: block !important;
 		font-family: dashicons !important;
@@ -1392,8 +1400,11 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 #qm-fatal {
 	margin: 1em !important;
+	/* @TODO */
 	border: 2px solid #c00 !important;
+	/* @TODO */
 	box-shadow: 0 0 0 2px #fff;
+	/* @TODO */
 	background: #fff !important;
 	max-width: 700px !important;
 	clear: both !important;
@@ -1404,11 +1415,13 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		font-size: 12px !important;
 		font-weight: normal !important;
 		padding: 5px !important;
+		/* @TODO */
 		background: #f3f3f3 !important;
 		margin: 0 !important;
 	}
 
 	.dashicons {
+		/* @TODO */
 		color: #c00 !important;
 	}
 
@@ -1429,6 +1442,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm-info {
+		/* @TODO */
 		color: #666 !important;
 	}
 }

--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -469,9 +469,9 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		li button:active {
 			text-decoration: none !important;
-			background: $qm-panel-menu-bg-selected !important;
-			color: $qm-panel-menu-fg-selected !important;
-			text-shadow: 0 -1px 1px $qm-panel-menu-shadow, 1px 0 1px $qm-panel-menu-shadow, 0 1px 1px $qm-panel-menu-shadow, -1px 0 1px $qm-panel-menu-shadow !important;
+			background: var( --qm-panel-menu-bg-selected ) !important;
+			color: var( --qm-panel-menu-fg-selected ) !important;
+			text-shadow: 0 -1px 1px var( --qm-panel-menu-shadow ), 1px 0 1px var( --qm-panel-menu-shadow ), 0 1px 1px var( --qm-panel-menu-shadow ), -1px 0 1px var( --qm-panel-menu-shadow ) !important;
 		}
 
 		li.qm-current-menu {
@@ -504,9 +504,9 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		li button[aria-selected="true"] {
-			background: $qm-panel-menu-bg-selected !important;
-			color: $qm-panel-menu-fg-selected !important;
-			text-shadow: 0 -1px 1px $qm-panel-menu-shadow, 1px 0 1px $qm-panel-menu-shadow, 0 1px 1px $qm-panel-menu-shadow, -1px 0 1px $qm-panel-menu-shadow !important;
+			background: var( --qm-panel-menu-bg-selected ) !important;
+			color: var( --qm-panel-menu-fg-selected ) !important;
+			text-shadow: 0 -1px 1px var( --qm-panel-menu-shadow ), 1px 0 1px var( --qm-panel-menu-shadow ), 0 1px 1px var( --qm-panel-menu-shadow ), -1px 0 1px var( --qm-panel-menu-shadow ) !important;
 
 			&:focus {
 				background: var( --qm-panel-menu-bg-selected-focus ) !important;
@@ -1217,11 +1217,11 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 	.qm .qm-sorted-desc .qm-sort-arrow,
 	.qm .qm-sorted-asc .qm-sort-arrow {
-		color: $qm-container-fg !important;
+		color: var( --qm-container-fg ) !important;
 	}
 
 	.qm thead th.qm-sortable-column:hover .qm-sort-arrow {
-		color: $qm-panel-menu-bg-selected !important;
+		color: var( --qm-panel-menu-bg-selected ) !important;
 	}
 
 	.qm .qm-sortable-column.qm-sorted-asc .qm-sort-arrow::before {

--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -959,21 +959,20 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody tr.qm-odd td.qm-warn,
 	.qm tbody tr.qm-odd.qm-warn td,
 	.qm tbody tr.qm-odd.qm-warn th {
-		background-color: darken( $qm-warn-bg, 1.5% ) !important;
+		background-color: var( --qm-warn-bg-dark ) !important;
 	}
 
 	.qm-non-tabular .qm-warn code,
 	.qm tbody .qm-warn li,
 	.qm tbody .qm-warn .qm-info,
 	.qm tbody .qm-warn code {
-		/* @TODO */
 		background-color: transparent !important;
 		color: var( --qm-warn-fg ) !important;
 	}
 
 	.qm .qm-notice {
-		background: $qm-panel-menu-bg-current !important;
-		border: 1px solid darken( $qm-panel-menu-bg-current, 10% ) !important;
+		background: var( --qm-panel-menu-bg-current ) !important;
+		border: 1px solid var( --qm-panel-menu-bg-hover ) !important;
 		margin: 0 0 10px 0 !important;
 		padding: 10px 20px 0 !important;
 	}
@@ -1004,8 +1003,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody tr.qm-odd td.qm-highlight,
 	.qm tbody tr.qm-odd.qm-highlight th,
 	.qm tbody tr.qm-odd.qm-highlight td {
-		background-color: darken( $qm-cell-bg-highlight, 4% ) !important;
-		color: $qm-cell-fg-highlight !important;
+		background-color: var( --qm-cell-bg-highlight-dark ) !important;
+		color: var( --qm-cell-fg-highlight ) !important;
 	}
 
 	.qm tbody tr.qm-odd.qm-hovered th,

--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -1,3 +1,11 @@
+/* Functions */
+@function map-get-strict($map, $key) {
+	@if map-has-key($map, $key) {
+		@return map-get($map, $key);
+	} @else {
+		@error "Index '#{$key}' does not exist";
+	}
+}
 
 /* Fonts */
 $qm-font-default-face: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -20,6 +28,22 @@ $qm-menu-warning-bg-hover: darken( $qm-menu-warning-bg, 5% ) !default;
 $qm-menu-fg: #eee !default;
 $qm-menu-true-fg: #8c8 !default;
 $qm-menu-true-fg-hover: darken( $qm-menu-true-fg, 20% ) !default;
+
+// === Properties ===
+
+#query-monitor-main {
+	@each $var, $colour in $colours-default {
+		--qm-#{$var}: #{$colour};
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	#query-monitor-main {
+		@each $var, $colour in $colours-default {
+			--qm-#{$var}: #{ map-get-strict( $colours-dark, $var ) };
+		}
+	}
+}
 
 // === Admin Toolbar ===
 
@@ -148,7 +172,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	box-shadow: none !important;
 	box-sizing: border-box !important;
 	clear: both !important;
-	color: $qm-container-fg !important;
+	color: var( --qm-container-fg ) !important;
 	float: none !important;
 	font-family: $qm-font-default-face !important;
 	font-size: $qm-font-default-size !important;
@@ -211,8 +235,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	& {
 		@include global-reset;
 
-		background: $qm-panel-bg !important;
-		border-top: 1px solid $qm-panel-border !important;
+		background: var( --qm-panel-bg ) !important;
+		border-top: 1px solid var( --qm-panel-border ) !important;
 		bottom: 0 !important;
 		contain: layout paint;
 		direction: ltr !important;
@@ -226,8 +250,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	::selection {
-		background-color: $qm-selection-bg !important;
-		color: $qm-selection-fg !important;
+		background-color: var( --qm-selection-bg ) !important;
+		color: var( --qm-selection-fg ) !important;
 	}
 
 	strong,
@@ -261,7 +285,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		top: $qm-admin-toolbar-height !important;
 		left: unset !important;
 		border-top: 0 !important;
-		border-left: 1px solid $qm-panel-border !important;
+		border-left: 1px solid var( --qm-panel-border ) !important;
 
 		@include qm-narrow();
 
@@ -296,8 +320,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 	#qm-title {
 		align-items: center !important;
-		background: $qm-container-bg !important;
-		border-bottom: 1px solid $qm-panel-border !important;
+		background: var( --qm-container-bg ) !important;
+		border-bottom: 1px solid var( --qm-panel-border ) !important;
 		cursor: ns-resize !important;
 		display: flex !important;
 		flex-shrink: 0 !important;
@@ -344,8 +368,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		button {
-			background: $qm-title-button-bg !important;
-			color: $qm-title-button-fg !important;
+			background: var( --qm-title-button-bg ) !important;
+			color: var( --qm-title-button-fg ) !important;
 			cursor: pointer !important;
 			display: inline-block !important;
 			margin: 0 0 0 0px !important;
@@ -357,8 +381,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		button:hover *,
 		button:focus,
 		button:hover {
-			background: $qm-title-button-bg-hover !important;
-			color: $qm-title-button-fg-hover !important;
+			background: var( --qm-title-button-bg-hover ) !important;
+			color: var( --qm-title-button-fg-hover ) !important;
 		}
 
 		button:active *,
@@ -392,7 +416,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	#qm-panel-menu {
-		background: $qm-container-overflow !important;
+		background: var( --qm-container-overflow ) !important;
 		flex-shrink: 0 !important;
 		overflow-y: scroll !important;
 		overscroll-behavior: contain !important;
@@ -419,10 +443,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		li button {
-			background: $qm-panel-menu-bg !important;
-			border-bottom: 1px solid $qm-panel-menu-border !important;
-			border-right: 1px solid $qm-panel-border !important;
-			color: $qm-panel-menu-fg !important;
+			background: var( --qm-panel-menu-bg ) !important;
+			border-bottom: 1px solid var( --qm-panel-menu-border ) !important;
+			border-right: 1px solid var( --qm-panel-border ) !important;
+			color: var( --qm-panel-menu-fg ) !important;
 			cursor: pointer !important;
 			display: block !important;
 			padding: 6px 32px 6px 10px !important;
@@ -433,8 +457,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		li button:focus,
 		li button:hover {
-			background: $qm-panel-menu-bg-hover !important;
-			color: $qm-panel-menu-fg-hover !important;
+			background: var( --qm-panel-menu-bg-hover ) !important;
+			color: var( --qm-panel-menu-fg-hover ) !important;
 		}
 
 		li button:focus {
@@ -454,17 +478,17 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 			}
 
 			button {
-				background: $qm-panel-menu-bg-current !important;
-				color: $qm-panel-menu-fg-current !important;
+				background: var( --qm-panel-menu-bg-current ) !important;
+				color: var( --qm-panel-menu-fg-current ) !important;
 
 				&:focus {
-					background: $qm-panel-menu-bg-current-focus !important;
-					color: $qm-panel-menu-fg-current !important;
+					background: var( --qm-panel-menu-bg-current-focus ) !important;
+					color: var( --qm-panel-menu-fg-current ) !important;
 				}
 
 				&:hover {
-					background: $qm-panel-menu-bg-hover !important;
-					color: $qm-panel-menu-fg-hover !important;
+					background: var( --qm-panel-menu-bg-hover ) !important;
+					color: var( --qm-panel-menu-fg-hover ) !important;
 				}
 			}
 		}
@@ -483,18 +507,18 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 			text-shadow: 0 -1px 1px $qm-panel-menu-shadow, 1px 0 1px $qm-panel-menu-shadow, 0 1px 1px $qm-panel-menu-shadow, -1px 0 1px $qm-panel-menu-shadow !important;
 
 			&:focus {
-				background: $qm-panel-menu-bg-selected-focus !important;
-				color: $qm-panel-menu-fg-selected !important;
+				background: var( --qm-panel-menu-bg-selected-focus ) !important;
+				color: var( --qm-panel-menu-fg-selected ) !important;
 			}
 
 			&:hover {
-				background: $qm-panel-menu-bg-selected !important;
-				color: $qm-panel-menu-fg-selected !important;
+				background: var( --qm-panel-menu-bg-selected ) !important;
+				color: var( --qm-panel-menu-fg-selected ) !important;
 			}
 
 			&:after {
 				border: solid 8px transparent;
-				border-right-color: $qm-panel-bg;
+				border-right-color: var( --qm-panel-bg );
 				content: " ";
 				display: inline-block !important;
 				height: 0;
@@ -527,7 +551,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		flex-wrap: wrap !important;
 
 		&:not(#qm-broken) + .qm-boxed {
-			border-top: 1px solid $qm-panel-separator !important;
+			border-top: 1px solid var( --qm-panel-separator ) !important;
 			padding-top: 10px !important;
 		}
 	}
@@ -549,15 +573,15 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		table {
 			border: none !important;
 			border-collapse: collapse !important;
-			box-shadow: 0px 1px 0px 0px $qm-panel-border !important;
-			color: $qm-panel-fg !important;
+			box-shadow: 0px 1px 0px 0px var( --qm-panel-border ) !important;
+			color: var( --qm-panel-fg ) !important;
 			margin: 0 !important;
 			table-layout: auto !important;
 			width: 100% !important;
 		}
 
 		table + table {
-			border-top: 1px solid $qm-cell-border !important;
+			border-top: 1px solid var( --qm-cell-border ) !important;
 			margin-top: 5px !important;
 		}
 
@@ -569,7 +593,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		tbody td,
 		tfoot th,
 		tfoot td {
-			border: 1px solid $qm-cell-border !important;
+			border: 1px solid var( --qm-cell-border ) !important;
 			padding: 5px 5px 4px 5px !important;
 			vertical-align: top !important;
 		}
@@ -581,10 +605,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		thead th {
-			background: $qm-table-header-bg !important;
-			border: 1px solid $qm-cell-border !important;
+			background: var( --qm-table-header-bg ) !important;
+			border: 1px solid var( --qm-cell-border ) !important;
 			border-top: none !important;
-			box-shadow: 0px 1px 0px $qm-cell-border !important;
+			box-shadow: 0px 1px 0px var( --qm-cell-border ) !important;
 			padding: 5px !important;
 			position: -webkit-sticky !important;
 			position: sticky !important;
@@ -603,10 +627,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		tfoot tr td,
 		tfoot tr th {
-			background: $qm-table-footer-bg !important;
+			background: var( --qm-table-footer-bg ) !important;
 			border: none !important;
 			bottom: 0 !important;
-			box-shadow: inset 0px 1px 0px $qm-cell-border !important;
+			box-shadow: inset 0px 1px 0px var( --qm-cell-border ) !important;
 			position: -webkit-sticky !important;
 			position: sticky !important;
 		}
@@ -674,7 +698,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		.qm-has-inner .qm-toggled > table {
 			border-bottom: none !important;
-			border-top: 1px solid $qm-cell-border !important;
+			border-top: 1px solid var( --qm-cell-border ) !important;
 		}
 
 		td.qm-has-inner .qm-toggler,
@@ -689,7 +713,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm-concerns table {
-		border-top: 1px solid $qm-cell-border !important;
+		border-top: 1px solid var( --qm-cell-border ) !important;
 		margin-bottom: 20px !important;
 	}
 
@@ -717,14 +741,14 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		dt {
-			border-top: 1px solid $qm-panel-separator !important;
+			border-top: 1px solid var( --qm-panel-separator ) !important;
 			flex-grow: 0;
 			flex: 1 0 16em;
 			padding: 10px 10px 10px 0 !important;
 		}
 
 		dd {
-			border-top: 1px solid $qm-panel-separator !important;
+			border-top: 1px solid var( --qm-panel-separator ) !important;
 			flex: 1 0 calc(100% - 10px - 16em);
 			padding: 10px 0 !important;
 		}
@@ -736,7 +760,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 		.qm-boxed section,
 		.qm-boxed .qm-section {
-			border-right: 1px solid $qm-panel-separator !important;
+			border-right: 1px solid var( --qm-panel-separator ) !important;
 			margin: 0 20px 10px 0 !important;
 			padding: 10px 20px 10px 0 !important;
 
@@ -748,7 +772,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		}
 
 		table {
-			border-bottom-color: $qm-cell-border !important;
+			border-bottom-color: var( --qm-cell-border ) !important;
 		}
 	}
 
@@ -827,11 +851,11 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm td.qm-has-toggle p,
 	.qm .qm-nonselectsql code,
 	.qm .qm-nonselectsql {
-		color: $qm-nonselect-fg !important;
+		color: var( --qm-nonselect-fg ) !important;
 	}
 
 	.qm .qm-info {
-		color: $qm-info-fg !important;
+		color: var( --qm-info-fg ) !important;
 	}
 
 	.qm .qm-supplemental {
@@ -846,10 +870,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 	.qm button.qm-button,
 	.qm .qm-toggle {
-		background: $qm-button-bg !important;
-		border: 1px solid $qm-button-bg !important;
+		background: var( --qm-button-bg ) !important;
+		border: 1px solid var( --qm-button-bg ) !important;
 		border-radius: 3px !important;
-		color: $qm-button-fg !important;
+		color: var( --qm-button-fg ) !important;
 		cursor: pointer !important;
 		font-weight: normal !important;
 		text-shadow: none !important;
@@ -885,46 +909,46 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 
 	.qm button.qm-button:hover,
 	.qm .qm-toggle:hover {
-		background: $qm-button-bg-hover !important;
-		border-color: $qm-button-bg-hover !important;
-		color: $qm-button-fg-hover !important;
+		background: var( --qm-button-bg-hover ) !important;
+		border-color: var( --qm-button-bg-hover ) !important;
+		color: var( --qm-button-fg-hover ) !important;
 		text-decoration: none !important;
 	}
 
 	.qm button.qm-button:focus,
 	.qm .qm-toggle:focus {
-		background: $qm-button-bg-hover !important;
-		border-color: $qm-button-bg-hover !important;
-		color: $qm-button-fg-hover !important;
-		box-shadow: 0 0 0 1px #fff, 0 0 0 3px $qm-button-bg-hover !important;
+		background: var( --qm-button-bg-hover ) !important;
+		border-color: var( --qm-button-bg-hover ) !important;
+		color: var( --qm-button-fg-hover ) !important;
+		box-shadow: 0 0 0 1px #fff, 0 0 0 3px var( --qm-button-bg-hover ) !important;
 	}
 
 	.qm button.qm-button:active,
 	.qm .qm-toggle:active {
-		background: $qm-button-bg-active !important;
-		border-color: $qm-button-bg-active !important;
-		color: $qm-button-fg-active !important;
+		background: var( --qm-button-bg-active ) !important;
+		border-color: var( --qm-button-bg-active ) !important;
+		color: var( --qm-button-fg-active ) !important;
 		box-shadow: none !important;
 	}
 
 	.qm tbody tr.qm-odd td,
 	.qm tbody tr.qm-odd th {
-		background: $qm-cell-bg-stripe !important;
+		background: var( --qm-cell-bg-stripe ) !important;
 	}
 
 	.qm-non-tabular .qm-warn,
 	.qm thead tr .qm-warn,
 	.qm tbody tr .qm-warn {
-		background-color: $qm-warn-bg !important;
-		color: $qm-warn-fg !important;
+		background-color: var( --qm-warn-bg ) !important;
+		color: var( --qm-warn-fg ) !important;
 	}
 
 	.qm tbody tr th.qm-warn,
 	.qm tbody tr td.qm-warn,
 	.qm tbody tr.qm-warn td,
 	.qm tbody tr.qm-warn th {
-		background-color: $qm-warn-bg !important;
-		color: $qm-warn-fg !important;
+		background-color: var( --qm-warn-bg ) !important;
+		color: var( --qm-warn-fg ) !important;
 	}
 
 	.qm tbody tr.qm-odd th.qm-warn,
@@ -939,7 +963,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody .qm-warn .qm-info,
 	.qm tbody .qm-warn code {
 		background-color: transparent !important;
-		color: $qm-warn-fg !important;
+		color: var( --qm-warn-fg ) !important;
 	}
 
 	.qm .qm-notice {
@@ -966,8 +990,8 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody tr td.qm-highlight,
 	.qm tbody tr.qm-highlight th,
 	.qm tbody tr.qm-highlight td {
-		background-color: $qm-cell-bg-highlight !important;
-		color: $qm-cell-fg-highlight !important;
+		background-color: var( --qm-cell-bg-highlight ) !important;
+		color: var( --qm-cell-fg-highlight ) !important;
 	}
 
 	.qm tbody tr.qm-odd td.qm-highlight,
@@ -985,12 +1009,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody tr.qm-hovered td,
 	.qm tbody tr:hover th,
 	.qm tbody tr:hover td {
-		background: $qm-cell-bg-hover !important;
+		background: var( --qm-cell-bg-hover ) !important;
 	}
 
 	.qm thead th.qm-filtered select.qm-filter {
-		background-color: $qm-cell-bg-highlight !important;
-		color: $qm-cell-fg-highlight !important;
+		background-color: var( --qm-cell-bg-highlight ) !important;
+		color: var( --qm-cell-fg-highlight ) !important;
 	}
 
 	.qm button.qm-filter-trigger,
@@ -998,19 +1022,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm tbody .qm-warn a code,
 	.qm a code,
 	.qm a {
-		color: $qm-link-fg !important;
+		color: var( --qm-link-fg ) !important;
 		cursor: pointer !important;
 		text-decoration: none !important;
 
 		&:after,
 		&:focus,
 		&:hover {
-			color: $qm-link-fg-hover !important;
+			color: var( --qm-link-fg-hover ) !important;
 			text-decoration: underline !important;
 		}
 
 		&:active {
-			color: $qm-link-fg-active !important;
+			color: var( --qm-link-fg-active ) !important;
 			text-decoration: underline !important;
 		}
 	}
@@ -1077,7 +1101,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm label {
-		color: $qm-panel-fg !important;
+		color: var( --qm-panel-fg ) !important;
 		cursor: pointer !important;
 		font-size: 12px !important;
 		font-style: normal !important;
@@ -1108,9 +1132,9 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		-webkit-appearance: menulist !important;
 		-moz-appearance: menulist !important;
 		appearance: menulist !important;
-		background: $qm-table-header-bg !important;
+		background: var( --qm-table-header-bg ) !important;
 		border: none !important;
-		color: $qm-panel-fg !important;
+		color: var( --qm-panel-fg ) !important;
 		cursor: pointer !important;
 		display: block !important;
 		float: none !important;
@@ -1118,7 +1142,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		letter-spacing: -0.1px !important;
 		margin: 0 0 0 5px !important;
 		max-width: 12em !important;
-		outline: 1px solid $qm-panel-border !important;
+		outline: 1px solid var( --qm-panel-border ) !important;
 		padding: 0 !important;
 		width: auto !important;
 	}
@@ -1128,7 +1152,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	}
 
 	.qm select.qm-filter:hover {
-		background: $qm-cell-bg-hover !important;
+		background: var( --qm-cell-bg-hover ) !important;
 	}
 
 	.qm-hide,
@@ -1153,7 +1177,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		cursor: pointer !important;
 
 		&:hover {
-			background: $qm-container-bg !important;
+			background: var( --qm-container-bg ) !important;
 		}
 	}
 
@@ -1199,7 +1223,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm button:focus,
 	.qm a:focus,
 	.qm select:focus {
-		box-shadow: 0 0 0 1px #fff, 0 0 0 3px $qm-button-bg-hover !important;
+		box-shadow: 0 0 0 1px #fff, 0 0 0 3px var( --qm-button-bg-hover ) !important;
 	}
 
 	.qm button:active,
@@ -1244,7 +1268,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm.qm-debug-bar {
 		textarea,
 		pre {
-			border: 1px solid $qm-panel-separator !important;
+			border: 1px solid var( --qm-panel-separator ) !important;
 			margin: 4px 0 !important;
 			padding: 10px !important;
 		}
@@ -1346,7 +1370,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 		margin-bottom: 50px !important;
 
 		button.qm-filter-trigger {
-			color: $qm-container-fg !important;
+			color: var( --qm-container-fg ) !important;
 			cursor: text !important;
 
 			&:after {

--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -38,10 +38,16 @@ $qm-menu-true-fg-hover: darken( $qm-menu-true-fg, 20% ) !default;
 }
 
 @media (prefers-color-scheme: dark) {
-	#query-monitor-main {
+	#query-monitor-main[data-theme="auto"] {
 		@each $var, $colour in $colours-default {
 			--qm-#{$var}: #{ map-get-strict( $colours-dark, $var ) };
 		}
+	}
+}
+
+#query-monitor-main[data-theme="dark"] {
+	@each $var, $colour in $colours-default {
+		--qm-#{$var}: #{ map-get-strict( $colours-dark, $var ) };
 	}
 }
 

--- a/assets/query-monitor-dark.scss
+++ b/assets/query-monitor-dark.scss
@@ -1,8 +1,0 @@
-/**
- * The dark colour scheme for Query Monitor.
- *
- * @package query-monitor
- */
-
-@import "colours-dark";
-@import "styles";

--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -67,6 +67,12 @@ if ( window.jQuery ) {
 
 		container.removeClass('qm-no-js').addClass('qm-js');
 
+		var theme = localStorage.getItem( 'qm-theme' );
+		if ( theme ) {
+			container.attr('data-theme', theme);
+			$('.qm-theme-toggle[value="' + theme + '"]').prop('checked', true);
+		}
+
 		if ( $('#qm-fatal').length ) {
 			console.error(qm_l10n.fatal_error + ': ' + $('#qm-fatal').attr('data-qm-message') );
 
@@ -458,6 +464,11 @@ if ( window.jQuery ) {
 			});
 
 			e.preventDefault();
+		});
+
+		$('.qm-theme-toggle').on('click',function(e){
+			$('#query-monitor-main').attr('data-theme',$(this).val());
+			localStorage.setItem('qm-theme',$(this).val());
 		});
 
 		$.qm.tableSort({target: $('.qm-sortable')});

--- a/assets/query-monitor.scss
+++ b/assets/query-monitor.scss
@@ -1,8 +1,9 @@
 /**
- * The standard colour scheme for Query Monitor.
+ * All the styles for Query Monitor.
  *
  * @package query-monitor
  */
 
 @import "colours-default";
+@import "colours-dark";
 @import "styles";

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -226,17 +226,11 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			$deps = array();
 		}
 
-		$css = 'query-monitor';
-
-		if ( defined( 'QM_DARK_MODE' ) && QM_DARK_MODE ) {
-			$css .= '-dark';
-		}
-
 		wp_enqueue_style(
 			'query-monitor',
-			$this->qm->plugin_url( "assets/{$css}.css" ),
+			$this->qm->plugin_url( 'assets/query-monitor.css' ),
 			array( 'dashicons' ),
-			$this->qm->plugin_ver( "assets/{$css}.css" )
+			$this->qm->plugin_ver( 'assets/query-monitor.css' )
 		);
 		wp_enqueue_script(
 			'query-monitor',
@@ -563,10 +557,6 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		echo '<div class="qm-boxed">';
 		$constants = array(
-			'QM_DARK_MODE' => array(
-				'label' => __( 'Enable dark mode for Query Monitor\'s interface.', 'query-monitor' ),
-				'default' => false,
-			),
 			'QM_DB_EXPENSIVE' => array(
 				'label' => __( 'If an individual database query takes longer than this time to execute, it\'s considered "slow" and triggers a warning.', 'query-monitor' ),
 				'default' => 0.05,

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -406,7 +406,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
 		echo '</script>' . "\n\n";
 
-		echo '<div id="query-monitor-main" class="' . implode( ' ', array_map( 'esc_attr', $class ) ) . '" dir="ltr">';
+		echo '<div id="query-monitor-main" data-theme="auto" class="' . implode( ' ', array_map( 'esc_attr', $class ) ) . '" dir="ltr">';
 		echo '<div id="qm-side-resizer" class="qm-resizer"></div>';
 		echo '<div id="qm-title" class="qm-resizer">';
 		echo '<h1 class="qm-title-heading">' . esc_html__( 'Query Monitor', 'query-monitor' ) . '</h1>';
@@ -552,6 +552,19 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '<button class="qm-editor-button qm-button">' . esc_html__( 'Set editor cookie', 'query-monitor' ) . '</button>';
 		echo '</p>';
 		echo '<p id="qm-editor-save-status"><span class="dashicons dashicons-yes qm-dashicons-yes"></span> ' . esc_html__( 'Saved! Reload to apply changes.', 'query-monitor' ) . '</p>';
+		echo '</section>';
+
+		echo '<section>';
+		echo '<h3>' . esc_html__( 'Appearance', 'query-monitor' ) . '</h3>';
+
+		echo '<p>' . esc_html__( 'Your browser color scheme is respected by default. You can override it here.', 'query-monitor' ) . '</p>';
+
+		echo '<ul>';
+		echo '<li><label><input type="radio" class="qm-theme-toggle" name="qm-theme" value="auto" checked/>' . esc_html_x( 'Auto', 'colour scheme', 'query-monitor' ) . '</label></li>';
+		echo '<li><label><input type="radio" class="qm-theme-toggle" name="qm-theme" value="light"/>' . esc_html_x( 'Light', 'colour scheme', 'query-monitor' ) . '</label></li>';
+		echo '<li><label><input type="radio" class="qm-theme-toggle" name="qm-theme" value="dark"/>' . esc_html_x( 'Dark', 'colour scheme', 'query-monitor' ) . '</label></li>';
+		echo '</ul>';
+
 		echo '</section>';
 		echo '</div>';
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,9 +26,6 @@ parameters:
 	ignoreErrors:
 		# Uses func_get_args()
 		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
-		# These are false positives
-		- '#Instanceof between string and mysqli will always evaluate to false#'
-		- '#Call to function is_resource\(\) with string will always evaluate to false#'
 		# The `wpdb` class exposes its properties via `__get()`
 		- '#Access to private property wpdb::#'
 		- '#Access to protected property wpdb::#'


### PR DESCRIPTION
This replaces the `QM_DARK_MODE` constant with a client-side appearance setting, respecting `prefers-color-scheme: dark` by default.