### PR TITLE
Fix PHP Warning 'Header may not contain NUL bytes' on QM_Output_Headers

### DIFF
--- a/output/Headers.php
+++ b/output/Headers.php
@@ -15,11 +15,14 @@ abstract class QM_Output_Headers extends QM_Output {
 		$id = $this->collector->id;
 
 		foreach ( $this->get_output() as $key => $value ) {
-			if ( is_scalar( $value ) ) {
-				header( sprintf( 'X-QM-%s-%s: %s', $id, $key, $value ) );
-			} else {
-				header( sprintf( 'X-QM-%s-%s: %s', $id, $key, json_encode( $value ) ) );
+			if ( ! is_scalar( $value ) ) {
+				$value = json_encode( $value );
 			}
+
+			# Remove illegal characters (Header may not contain NUL bytes)
+			$value = str_replace( chr( 0 ), '', $value );
+
+			header( sprintf( 'X-QM-%s-%s: %s', $id, $key, $value ) );
 		}
 
 	}


### PR DESCRIPTION
Hello John,

This PR fixes a PHP Warning on the Headers outputter :

- When **wp_redirect()** is called from an anonymous class
- Then trace is collected by the redirect collector
- Then trace display contains NUL bytes, because [PHP appends a `'\0'` at the end of anonymous class names](https://github.com/php/php-src/blob/PHP-8.0.16/Zend/zend_compile.c#L7308)
- Then we have following PHP Warning: `Header may not contain NUL bytes`

Tested on PHP 8.0

To reproduce, just copy/paste the folllowing code in the functions.php theme file:

```php
add_action('template_redirect', 'test_redirect_from_anonymous_class');

function test_redirect_from_anonymous_class() {
    $foo = new class ('bar')
    {
        public function redirect()
        {
            wp_redirect('https://example.com/');
        }
    };

    (new $foo())->redirect();
    die;
}
```

This PR fixes only the Headers outputter, ensuring they never contain NUL bytes.

It could be usefull to apply the same logic on the `QM_Backtrace` class also, in case other outputters have issues dealing with NUL bytes (they won't be printed anyway, so they can be safely removed from the trace display)

Bests regards,
Pierre