### PR TITLE
Implement a class autoloader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /bin export-ignore
 /node_modules export-ignore
 /tests export-ignore
-/vendor export-ignore
 
 # Files
 /.gitattributes export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,20 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Install PHP
+      uses: shivammathur/setup-php@2.7.0
+      with:
+        php-version: 8.0
+        coverage: none
+      env:
+        fail-fast: true
+
       # @TODO need to cache the npm dependencies
     - name: Install Dependencies
       run: npm install
+
+    - name: Generate autoload file
+      run: composer dump-autoload --no-dev
 
     - name: Build Assets
       run: npm run build
@@ -32,6 +43,7 @@ jobs:
         git config user.email github-actions@github.com
         git checkout -b "release-$VERSION"
         git add -f assets/*
+        git add -f vendor/*
         git commit -m "Release $VERSION"
         git tag "$VERSION"
         git push --tags

--- a/classes/PHP.php
+++ b/classes/PHP.php
@@ -10,7 +10,7 @@ class QM_PHP {
 	/**
 	 * @var string
 	 */
-	public static $minimum_version = '5.3.6';
+	public static $minimum_version = '5.6.20';
 
 	/**
 	 * @return bool

--- a/classes/debug_bar.php
+++ b/classes/debug_bar.php
@@ -43,8 +43,6 @@ class Debug_Bar {
 	 * @return void
 	 */
 	public function init_panels() {
-		require_once 'debug_bar_panel.php';
-
 		/**
 		 * Filters the debug bar panel list. This mimics the same filter called in the Debug Bar plugin.
 		 *

--- a/collectors/debug_bar.php
+++ b/collectors/debug_bar.php
@@ -66,14 +66,11 @@ function register_qm_collectors_debug_bar() {
 
 	global $debug_bar;
 
-	if ( class_exists( 'Debug_Bar' ) || qm_debug_bar_being_activated() ) {
+	if ( class_exists( 'Debug_Bar', false ) || qm_debug_bar_being_activated() ) {
 		return;
 	}
 
 	$collectors = QM_Collectors::init();
-	$qm = QueryMonitor::init();
-
-	require_once $qm->plugin_path( 'classes/debug_bar.php' );
 
 	$debug_bar = new Debug_Bar();
 	$redundant = array(

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -320,8 +320,6 @@ class QM_Collector_PHP_Errors extends QM_Collector {
 			wp_load_translations_early();
 		}
 
-		require_once dirname( __DIR__ ) . '/output/Html.php';
-
 		// This hides the subsequent message from the fatal error handler in core. It cannot be
 		// disabled by a plugin so we'll just hide its output.
 		echo '<style type="text/css"> .wp-die-message { display: none; } </style>';

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,12 @@
 		]
 	},
 	"autoload": {
+		"classmap": [
+			"classes",
+			"output"
+		]
+	},
+	"autoload-dev": {
 		"psr-4": {
 			"QM\\Tests\\": "tests/integration"
 		}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.6",
+		"php": ">=5.6.20",
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {

--- a/dispatchers/AJAX.php
+++ b/dispatchers/AJAX.php
@@ -62,9 +62,6 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 	 * @return void
 	 */
 	protected function before_output() {
-
-		require_once $this->qm->plugin_path( 'output/Headers.php' );
-
 		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
 			require_once $file;
 		}

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -337,9 +337,6 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 	 * @return void
 	 */
 	protected function before_output() {
-
-		require_once $this->qm->plugin_path( 'output/Html.php' );
-
 		foreach ( glob( $this->qm->plugin_path( 'output/html/*.php' ) ) as $file ) {
 			require_once $file;
 		}

--- a/dispatchers/REST.php
+++ b/dispatchers/REST.php
@@ -51,9 +51,6 @@ class QM_Dispatcher_REST extends QM_Dispatcher {
 	 * @return void
 	 */
 	protected function before_output() {
-
-		require_once $this->qm->plugin_path( 'output/Headers.php' );
-
 		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
 			include_once $file;
 		}

--- a/dispatchers/REST_Envelope.php
+++ b/dispatchers/REST_Envelope.php
@@ -47,8 +47,6 @@ class QM_Dispatcher_REST_Envelope extends QM_Dispatcher {
 	 * @return void
 	 */
 	protected function before_output() {
-		require_once $this->qm->plugin_path( 'output/Raw.php' );
-
 		foreach ( glob( $this->qm->plugin_path( 'output/raw/*.php' ) ) as $file ) {
 			include_once $file;
 		}

--- a/dispatchers/Redirect.php
+++ b/dispatchers/Redirect.php
@@ -50,9 +50,6 @@ class QM_Dispatcher_Redirect extends QM_Dispatcher {
 	 * @return void
 	 */
 	protected function before_output() {
-
-		require_once $this->qm->plugin_path( 'output/Headers.php' );
-
 		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
 			require_once $file;
 		}

--- a/dispatchers/WP_Die.php
+++ b/dispatchers/WP_Die.php
@@ -51,8 +51,6 @@ class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 			return;
 		}
 
-		require_once $this->qm->plugin_path( 'output/Html.php' );
-
 		$switched_locale = self::switch_to_locale( get_user_locale() );
 		$stack = array();
 		$filtered_trace = $this->trace->get_filtered_trace();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Query Monitor">
 
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 	<arg name="extensions" value="php"/>
 
 	<exclude-pattern>*/build/*</exclude-pattern>

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -37,6 +37,7 @@ define( 'QM_VERSION', '3.9.0' );
 
 $qm_dir = dirname( __FILE__ );
 
+// This must be required before vendor/autoload.php so QM can serve its own message about PHP compatibility.
 require_once "{$qm_dir}/classes/PHP.php";
 
 if ( ! QM_PHP::version_met() ) {
@@ -44,15 +45,11 @@ if ( ! QM_PHP::version_met() ) {
 	return;
 }
 
-# No autoloaders for us. See https://github.com/johnbillion/query-monitor/issues/7
-foreach ( array( 'Plugin', 'Activation', 'Util', 'QM' ) as $qm_class ) {
-	require_once "{$qm_dir}/classes/{$qm_class}.php";
-}
+require_once "{$qm_dir}/vendor/autoload.php";
 
 QM_Activation::init( __FILE__ );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once "{$qm_dir}/classes/CLI.php";
 	QM_CLI::init( __FILE__ );
 }
 
@@ -71,13 +68,6 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 	return;
 }
 
-foreach ( array( 'QueryMonitor', 'Backtrace', 'Collectors', 'Collector', 'Dispatchers', 'Dispatcher', 'Hook', 'Output', 'Timer' ) as $qm_class ) {
-	require_once "{$qm_dir}/classes/{$qm_class}.php";
-}
-
-unset(
-	$qm_dir,
-	$qm_class
-);
+unset( $qm_dir );
 
 QueryMonitor::init( __FILE__ )->set_up();

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -16,7 +16,7 @@
  * Author URI:   https://querymonitor.com/
  * Text Domain:  query-monitor
  * Domain Path:  /languages/
- * Requires PHP: 5.3.6
+ * Requires PHP: 5.6.20
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 3.7
 Tested up to: 5.9
 Stable tag: 3.9.0
 License: GPLv2 or later
-Requires PHP: 5.3
+Requires PHP: 5.6
 Donate link: https://johnblackbourn.com/donations/
 
 Query Monitor is the developer tools panel for WordPress.

--- a/tests/phpstan/stubs.php
+++ b/tests/phpstan/stubs.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname( __DIR__, 2 ) . '/classes/Backtrace.php';
-
 // QM constants:
 
 define( 'QM_COOKIE', '' );

--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -42,7 +42,7 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 	return;
 }
 
-# No autoloaders for us. See https://github.com/johnbillion/query-monitor/issues/7
+// This must be required before vendor/autoload.php so QM can serve its own message about PHP compatibility.
 $qm_dir = dirname( dirname( __FILE__ ) );
 $qm_php = "{$qm_dir}/classes/PHP.php";
 
@@ -55,11 +55,11 @@ if ( ! QM_PHP::version_met() ) {
 	return;
 }
 
-$backtrace = "{$qm_dir}/classes/Backtrace.php";
-if ( ! is_readable( $backtrace ) ) {
+require_once "{$qm_dir}/vendor/autoload.php";
+
+if ( ! class_exists( 'QM_Backtrace' ) ) {
 	return;
 }
-require_once $backtrace;
 
 if ( ! defined( 'SAVEQUERIES' ) ) {
 	define( 'SAVEQUERIES', true );


### PR DESCRIPTION
QM has traditionally not used a class autoloader due to mysterious issues relating to opcode caching and PHP 4 style constructors. See #7 and tickets linked from there.

The lack of a class autoloader is a hindrance to making further structural changes. Let's fix that.

In due course I'll namespace the classes via PSR-4 but for now I'll use a class map as I don't want to deal with back compat issues right now.