### PR TITLE
Bring the dispatcher priority back to 9

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -46,7 +46,10 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'wp_ajax_qm_editor_set', array( $this, 'ajax_editor_set' ) );
 		add_action( 'wp_ajax_nopriv_qm_auth_off', array( $this, 'ajax_off' ) );
 
-		add_action( 'shutdown', array( $this, 'dispatch' ), PHP_INT_MAX );
+		// 9 is a magic number, it's the latest we can realistically use due to plugins
+		// which call `fastcgi_finish_request()` in a `shutdown` callback hooked on the
+		// default priority of 10, and QM needs to dispatch its output before those.
+		add_action( 'shutdown', array( $this, 'dispatch' ), 9 );
 
 		add_action( 'wp_footer', array( $this, 'action_footer' ) );
 		add_action( 'admin_footer', array( $this, 'action_footer' ) );


### PR DESCRIPTION
In #549 the priority of the `shutdown` handler was changed from 0 to `PHP_INT_MAX` so QM can collect as much data as possible during a request, including data from shutdown handlers in other plugins.

Unfortunately [quite a few popular plugins](https://wpdirectory.net/search/01GCHP0KAAZDZZBWJWY0QBKR6Q) call `fastcgi_finish_request()` inside a callback on the `shutdown` hook at the default priority of 10. This means the output is flushed before QM outputs its own output, resulting in the dreaded "QM output does not exist" error. Support forum report here: https://wordpress.org/support/topic/share-counts-and-query-monitor/

This means that for maximum compatibility QM needs to move its `shutdown` priority back down, and 9 seems sensible. This allows it to capture data from earlier callbacks on the `shutdown` hook but hopefully not get caught out by the aforementioned callbacks that call `fastcgi_finish_request()` on a priority of 10.

Ultimately this won't be a concern once #483 is implemented, but that's still quite a way off.

CC @pschoffer :(