### PR TITLE
Use unit symbol for seconds

### DIFF
--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -520,7 +520,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 					number_format_i18n( $db->total_time, 2 )
 				);
 
-				/* translators: %s: Number of database queries. Note the space between value and unit. */
+				/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
 				$text = _n( '%s Q', '%s Q', $db->total_qs, 'query-monitor' );
 
 				// Avoid a potentially blank translation for the plural form.
@@ -535,7 +535,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 				);
 			}
 		} elseif ( isset( $data['total_qs'] ) ) {
-			/* translators: %s: Number of database queries. Note the space between value and unit. */
+			/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
 			$text = _n( '%s Q', '%s Q', $data['total_qs'], 'query-monitor' );
 
 			// Avoid a potentially blank translation for the plural form.

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -529,10 +529,10 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 					$text = '%s Q';
 				}
 
-				$title[] = sprintf(
+				$title[] = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', sprintf(
 					esc_html( $text ),
 					number_format_i18n( $db->total_qs )
-				);
+				) );
 			}
 		} elseif ( isset( $data['total_qs'] ) ) {
 			/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
@@ -544,14 +544,10 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 				$text = '%s Q';
 			}
 
-			$title[] = sprintf(
+			$title[] = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', sprintf(
 				esc_html( $text ),
 				number_format_i18n( $data['total_qs'] )
-			);
-		}
-
-		foreach ( $title as &$t ) {
-			$t = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $t );
+			) );
 		}
 
 		$title = array_merge( $existing, $title );

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -512,17 +512,10 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		if ( isset( $data['dbs'] ) ) {
 			foreach ( $data['dbs'] as $key => $db ) {
-				/* translators: %s: Time in seconds. Note the space between value and unit. */
-				$text = _n( '%s S', '%s S', $db->total_time, 'query-monitor' );
-
-				// Avoid a potentially blank translation for the plural form.
-				// @see https://meta.trac.wordpress.org/ticket/5377
-				if ( '' === $text ) {
-					$text = '%s S';
-				}
 
 				$title[] = sprintf(
-					esc_html( '%s' . $text ),
+					/* translators: %s: A time in seconds with a decimal fraction. No space between value and unit symbol. */
+					'%s' . esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
 					( count( $data['dbs'] ) > 1 ? '&bull;&nbsp;&nbsp' : '' ),
 					number_format_i18n( $db->total_time, 2 )
 				);

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -389,15 +389,11 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 			esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
 			number_format_i18n( $data['time_taken'], 2 )
 		);
-		$title[] = sprintf(
+		$title[] = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', sprintf(
 			/* translators: %s: Memory usage in megabytes with a decimal fraction. Note the space between value and unit symbol. */
 			esc_html__( '%s MB', 'query-monitor' ),
 			$memory
-		);
-
-		foreach ( $title as &$t ) {
-			$t = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $t );
-		}
+		) );
 
 		$title = array_merge( $existing, $title );
 

--- a/output/html/overview.php
+++ b/output/html/overview.php
@@ -385,12 +385,12 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 		}
 
 		$title[] = sprintf(
-			/* translators: %s: Time in seconds with a decimal fraction. Note the space between value and unit. */
-			esc_html__( '%s S', 'query-monitor' ),
+			/* translators: %s: A time in seconds with a decimal fraction. No space between value and unit symbol. */
+			esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
 			number_format_i18n( $data['time_taken'], 2 )
 		);
 		$title[] = sprintf(
-			/* translators: %s: Memory usage in megabytes with a decimal fraction. Note the space between value and unit. */
+			/* translators: %s: Memory usage in megabytes with a decimal fraction. Note the space between value and unit symbol. */
 			esc_html__( '%s MB', 'query-monitor' ),
 			$memory
 		);


### PR DESCRIPTION
This PR replaces the translatable string 'S' (for seconds) in the admin bar with the [SI](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf/2d2b50bf-f2b4-9661-f402-5f9d66e4b507?version=1.10&t=1632138671693) unit symbol (s) that does not have a plural form. Motivation: "floating-point values usually represent physical entities for which singular and plural don’t clearly apply." - [GNU gettext manual](https://www.gnu.org/software/gettext/manual/gettext.html#Additional-functions-for-plural-forms)

By also removing the space between the value and the unit symbol and using the existing translatable string _x( '%ss', 'Time in seconds', 'query-monitor' ) one can avoid the need for new translations. The space gets stripped anyway [here](https://github.com/johnbillion/query-monitor/blob/b477463fcc26ad8f1ea410484f340e7f589a0f6a/output/html/db_queries.php#L561) and [here](https://github.com/johnbillion/query-monitor/blob/b477463fcc26ad8f1ea410484f340e7f589a0f6a/output/html/overview.php#L399).

This also fixes the PHP 8.1 deprecation notice "Implicit conversion from float [some floating-point number] to int loses precision in wp-includes/pomo/plural-forms.php on line 243" and on lines 246 and 247 that originates from https://github.com/johnbillion/query-monitor/blob/b477463fcc26ad8f1ea410484f340e7f589a0f6a/output/html/db_queries.php#L516

I found no other instance in the code where uppercase S is used to denote seconds, it's always lowercase s.

There is also a space in `'%s MB'` and in `'%s Q'` that gets stripped. I left those strings unchanged so existing translations still apply. If at some point the spaces are removed, I'd also go for using `'%dQ'` [here](https://github.com/johnbillion/query-monitor/blob/b477463fcc26ad8f1ea410484f340e7f589a0f6a/output/html/db_queries.php#L531-L537) and [here](https://github.com/johnbillion/query-monitor/blob/b477463fcc26ad8f1ea410484f340e7f589a0f6a/output/html/db_queries.php#L546-L552).