### PR TITLE
Count array elements outside the foreach loop

### DIFF
--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -512,12 +512,14 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		if ( isset( $data->dbs ) ) {
+			$count = count( $data->dbs );
+
 			foreach ( $data->dbs as $key => $db ) {
 
 				$title[] = sprintf(
 					/* translators: %s: A time in seconds with a decimal fraction. No space between value and unit symbol. */
 					'%s' . esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
-					( count( $data->dbs ) > 1 ? '&bull;&nbsp;&nbsp' : '' ),
+					( $count > 1 ? '&bull;&nbsp;&nbsp' : '' ),
 					number_format_i18n( $db->total_time, 2 )
 				);
 


### PR DESCRIPTION
This PR moves the counting of array elements outside the `foreach` loop.

Motivation: The loop does not alter the array, therefor the number of array elements is constant and it's sufficient to count elements once.