### PR TITLE
Update minimum required WP version.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,7 +53,7 @@
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_supported_version" value="3.7" />
+			<property name="minimum_supported_version" value="4.9" />
 		</properties>
 	</rule>
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 # Query Monitor
 Contributors: johnbillion
 Tags: debug, debug-bar, debugging, development, developer, performance, profiler, queries, query monitor, rest-api
-Requires at least: 4.3
+Requires at least: 4.9
 Tested up to: 6.0
 Stable tag: 3.10.1
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 # Query Monitor
 Contributors: johnbillion
 Tags: debug, debug-bar, debugging, development, developer, performance, profiler, queries, query monitor, rest-api
-Requires at least: 3.7
+Requires at least: 4.3
 Tested up to: 6.0
 Stable tag: 3.10.1
 License: GPLv2 or later


### PR DESCRIPTION
The function `get_language_attributes()` is unavailable prior to version 4.3.

This causes a fatal error on previous version of WP.

![Screen Shot 2022-10-19 at 9 41 00 am](https://user-images.githubusercontent.com/519727/196558587-ed3520d8-74a4-4813-ba10-0e7642c99aa3.png)

Screenshot from WP 4.2