### PR TITLE
Composer Installers 2.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=7.2.0",
-		"composer/installers": "~1.0"
+		"composer/installers": "~1.0 || ~2.0"
 	},
 	"require-dev": {
 		"codeception/module-asserts": "^1.0",


### PR DESCRIPTION
Allow composer to choose which version is most appropriate instead of forcing 1.x