### PR TITLE
Use composer v2 for release builds

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -56,6 +56,7 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: 8.0
+        tools: composer:v2
         coverage: none
       env:
         fail-fast: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: 8.0
+        tools: composer:v2
         coverage: none
       env:
         fail-fast: true

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,6 +47,7 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: '8.0'
+        tools: composer:v2
         coverage: none
       env:
         fail-fast: true

--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -19,6 +19,7 @@ jobs:
         uses: shivammathur/setup-php@2.7.0
         with:
           php-version: 8.0
+          tools: composer:v2
           coverage: none
         env:
           fail-fast: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,6 +52,7 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: ${{ matrix.php }}
+        tools: composer:v2
         extensions: xmlwriter
         coverage: none
       env:


### PR DESCRIPTION
By specifying the `composer:v2` tool in the setup-php action we can ensure composer v2 and not v1 is used, which should avoid the PHP warning with some sites in the current release