### PR TITLE
Sync number of accepted args with the callback's expected args

### DIFF
--- a/classes/QueryMonitor.php
+++ b/classes/QueryMonitor.php
@@ -25,7 +25,7 @@ class QueryMonitor extends QM_Plugin {
 		add_filter( 'ure_capabilities_groups_tree', array( $this, 'filter_ure_groups' ) );
 		add_filter( 'network_admin_plugin_action_links_query-monitor/query-monitor.php', array( $this, 'filter_plugin_action_links' ) );
 		add_filter( 'plugin_action_links_query-monitor/query-monitor.php', array( $this, 'filter_plugin_action_links' ) );
-		add_filter( 'plugin_row_meta', array( $this, 'filter_plugin_row_meta' ), 10, 4 );
+		add_filter( 'plugin_row_meta', array( $this, 'filter_plugin_row_meta' ), 10, 2 );
 
 		# Load and register built-in collectors:
 		$collectors = array();


### PR DESCRIPTION
Fixes a phpstan error:

<img width="652" alt="Error: Callback expects 2 parameters, $accepted_args is set to 4." src="https://user-images.githubusercontent.com/617637/201037663-b82382b6-c685-410e-95f9-e087fb08c8c0.png">
