### PR TITLE
language collector 'file' and 'line' sometimes missing

### DIFF
--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -168,8 +168,16 @@ class QM_Collector_Languages extends QM_DataCollector {
 
 		$found = file_exists( $mofile ) ? filesize( $mofile ) : false;
 
+		$caller = $trace->get_caller();
+		if( !isset( $caller['file'] ) && isset( $caller['calling_file'] ) ) {
+			$caller['file'] = $caller['calling_file'];
+		}
+		if( !isset( $caller['line'] ) && isset( $caller['calling_line'] ) ) {
+			$caller['line'] = $caller['calling_line'];
+		}
+
 		$this->data->languages[ $domain ][ $mofile ] = array(
-			'caller' => $trace->get_caller(),
+			'caller' => $caller,
 			'domain' => $domain,
 			'file' => $mofile,
 			'found' => $found,


### PR DESCRIPTION
in log_file_load() the $caller doesn't always have 'file' or 'line', I think when the function is filtered, or when we are in a hook.
In these cases, it has 'calling_file' and 'calling_line' instead, so we can copy those values to 'file' and 'line'.