### PR TITLE
Try a more reliable approach to waiting for Selenium and the database during tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -94,9 +94,7 @@ jobs:
       run: npm run build
 
     - name: Start Docker environment
-      run: |
-        composer test:start
-        sleep 15
+      run: composer test:start
 
     - name: Log running Docker containers
       run: docker ps -a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,8 @@ jobs:
       run: npm run build
 
     - name: Setup
-      run: 'echo "VERSION=$(grep -Po ''\"version\": \"[0-9\\.]+\"'' package.json | grep -Po ''[0-9\\.]+'')" >> $GITHUB_ENV'
+      run: >
+        echo VERSION=$(node -p "require('./package.json').version") >> $GITHUB_ENV
 
     - name: Tag
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,9 +86,7 @@ jobs:
       run: npm run build
 
     - name: Start Docker environment
-      run: |
-        composer test:start
-        sleep 10
+      run: composer test:start
 
     - name: Log running Docker containers
       run: docker ps -a

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -6,9 +6,9 @@ set -eo pipefail
 
 # Prep:
 docker-compose --profile acceptance-tests up -d
-WP_PORT=`docker port qm-server | grep "[0-9]+$" -ohE | head -1`
-CHROME_PORT=`docker port qm-chrome | grep "[0-9]+$" -ohE | head -1`
-DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
+WP_PORT=`docker inspect --type=container --format='{{(index .NetworkSettings.Ports "80/tcp" 0).HostPort}}' qm-server`
+CHROME_PORT=`docker inspect --type=container --format='{{(index .NetworkSettings.Ports "4444/tcp" 0).HostPort}}' qm-chrome`
+DATABASE_PORT=`docker inspect --type=container --format='{{(index .NetworkSettings.Ports "3306/tcp" 0).HostPort}}' qm-database`
 WP_URL="http://host.docker.internal:${WP_PORT}"
 WP="docker-compose run --rm wpcli --url=${WP_URL}"
 

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -12,11 +12,16 @@ DATABASE_PORT=`docker inspect --type=container --format='{{(index .NetworkSettin
 WP_URL="http://host.docker.internal:${WP_PORT}"
 WP="docker-compose run --rm wpcli --url=${WP_URL}"
 
-# Wait for the web server and the database:
+# Wait for the web server:
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
-./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
 
-# Wait for Selenium
+# Wait for MariaDB:
+while ! docker container exec -it qm-database mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" | grep 'mysqld is alive' >/dev/null; do
+	echo 'Waiting for MariaDB...'
+	sleep 1
+done
+
+# Wait for Selenium:
 while ! curl -sSL "http://localhost:${CHROME_PORT}/wd/hub/status" 2>&1 | grep '"ready": true' >/dev/null; do
 	echo 'Waiting for Selenium...'
 	sleep 1

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -16,7 +16,7 @@ WP="docker-compose run --rm wpcli --url=${WP_URL}"
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database mysqladmin ping -uexampleuser -pexamplepass | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -16,10 +16,10 @@ WP="docker-compose run --rm wpcli --url=${WP_URL}"
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 
 # Debugging:
-docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
+docker-compose exec -T database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
+while ! docker-compose exec -T database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -12,8 +12,9 @@ DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
 WP_URL="http://host.docker.internal:${WP_PORT}"
 WP="docker-compose run --rm wpcli --url=${WP_URL}"
 
-# Wait for Selenium and the database:
+# Wait for Selenium, the web server, and the database:
 ./node_modules/.bin/wait-port -t 10000 $CHROME_PORT
+./node_modules/.bin/wait-port -t 10000 $WP_PORT
 ./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
 
 # Reset or install the test database:

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -16,10 +16,10 @@ WP="docker-compose run --rm wpcli --url=${WP_URL}"
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 
 # Debugging:
-docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"'
+docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -12,6 +12,10 @@ DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
 WP_URL="http://host.docker.internal:${WP_PORT}"
 WP="docker-compose run --rm wpcli --url=${WP_URL}"
 
+# Wait for Selenium and the database:
+./node_modules/.bin/wait-port -t 10000 $CHROME_PORT
+./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
+
 # Reset or install the test database:
 echo "Installing database..."
 $WP db reset --yes

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -15,8 +15,11 @@ WP="docker-compose run --rm wpcli --url=${WP_URL}"
 # Wait for the web server:
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 
+# Debugging:
+docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"'
+
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -16,7 +16,7 @@ WP="docker-compose run --rm wpcli --url=${WP_URL}"
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database mysqladmin ping -uexampleuser -pexamplepass | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -12,10 +12,15 @@ DATABASE_PORT=`docker inspect --type=container --format='{{(index .NetworkSettin
 WP_URL="http://host.docker.internal:${WP_PORT}"
 WP="docker-compose run --rm wpcli --url=${WP_URL}"
 
-# Wait for Selenium, the web server, and the database:
-./node_modules/.bin/wait-port -t 10000 $CHROME_PORT
+# Wait for the web server and the database:
 ./node_modules/.bin/wait-port -t 10000 $WP_PORT
 ./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
+
+# Wait for Selenium
+while ! curl -sSL "http://localhost:${CHROME_PORT}/wd/hub/status" 2>&1 | grep '"ready": true' >/dev/null; do
+	echo 'Waiting for Selenium...'
+	sleep 1
+done
 
 # Reset or install the test database:
 echo "Installing database..."

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -7,8 +7,11 @@ set -eo pipefail
 # Run the integration tests:
 echo "Running tests..."
 
+# Debugging:
+docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"'
+
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -7,6 +7,10 @@ set -eo pipefail
 # Run the integration tests:
 echo "Running tests..."
 
+# Wait for the database:
+DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
+./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
+
 # Why are these sent to /dev/null? See https://github.com/docker/compose/issues/8833
 docker-compose exec \
 	-T \

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -8,10 +8,10 @@ set -eo pipefail
 echo "Running tests..."
 
 # Debugging:
-docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
+docker-compose exec -T database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
+while ! docker-compose exec -T database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -8,10 +8,10 @@ set -eo pipefail
 echo "Running tests..."
 
 # Debugging:
-docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"'
+docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent'
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --silent' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 echo "Running tests..."
 
 # Wait for the database:
-DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
+DATABASE_PORT=`docker inspect --type=container --format='{{(index .NetworkSettings.Ports "3306/tcp" 0).HostPort}}' qm-database`
 ./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
 
 # Why are these sent to /dev/null? See https://github.com/docker/compose/issues/8833

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 echo "Running tests..."
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database mysqladmin ping -uexampleuser -pexamplepass | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database /bin/bash -c 'mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}"' | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 echo "Running tests..."
 
 # Wait for MariaDB:
-while ! docker container exec -it qm-database mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" | grep 'mysqld is alive' >/dev/null; do
+while ! docker container exec -it qm-database mysqladmin ping -uexampleuser -pexamplepass | grep 'mysqld is alive' >/dev/null; do
 	echo 'Waiting for MariaDB...'
 	sleep 1
 done

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -7,9 +7,11 @@ set -eo pipefail
 # Run the integration tests:
 echo "Running tests..."
 
-# Wait for the database:
-DATABASE_PORT=`docker inspect --type=container --format='{{(index .NetworkSettings.Ports "3306/tcp" 0).HostPort}}' qm-database`
-./node_modules/.bin/wait-port -t 10000 $DATABASE_PORT
+# Wait for MariaDB:
+while ! docker container exec -it qm-database mysqladmin ping -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" | grep 'mysqld is alive' >/dev/null; do
+	echo 'Waiting for MariaDB...'
+	sleep 1
+done
 
 # Why are these sent to /dev/null? See https://github.com/docker/compose/issues/8833
 docker-compose exec \

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -15,11 +15,11 @@ DATABASE_PORT=`docker port qm-database | grep "[0-9]+$" -ohE | head -1`
 docker-compose exec \
 	-T \
 	--workdir /var/www/html/wp-content/plugins/query-monitor php \
-	./vendor/bin/codecept run integration --env singlesite --skip-group ms-required "$1" \
+	./vendor/bin/codecept run integration --env singlesite --skip-group ms-required --debug "$1" \
 	< /dev/null
 
 docker-compose exec \
 	-T \
 	--workdir /var/www/html/wp-content/plugins/query-monitor php \
-	./vendor/bin/codecept run integration --env multisite --skip-group ms-excluded "$1" \
+	./vendor/bin/codecept run integration --env multisite --skip-group ms-excluded --debug "$1" \
 	< /dev/null

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
 				"replace-in-file": "^5",
 				"sass": "^1",
 				"semver": "^7",
-				"version-bump-prompt": "^6.1.0"
+				"version-bump-prompt": "^6.1.0",
+				"wait-port": "^1.0.4"
 			},
 			"engines": {
 				"node": ">=18"
@@ -644,6 +645,15 @@
 				"node": ">=4.0.0"
 			}
 		},
+		"node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -662,6 +672,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/decamelize": {
@@ -1274,6 +1301,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
 		"node_modules/mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -1829,6 +1862,23 @@
 			},
 			"bin": {
 				"bump": "bump.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/wait-port": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.0.4.tgz",
+			"integrity": "sha512-w8Ftna3h6XSFWWc2JC5gZEgp64nz8bnaTp5cvzbJSZ53j+omktWTDdwXxEF0jM8YveviLgFWvNGrSvRHnkyHyw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"commander": "^9.3.0",
+				"debug": "^4.3.4"
+			},
+			"bin": {
+				"wait-port": "bin/wait-port.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -2561,6 +2611,12 @@
 				"typical": "^4.0.0"
 			}
 		},
+		"commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2576,6 +2632,15 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -3041,6 +3106,12 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
 		"mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -3434,6 +3505,17 @@
 			"dev": true,
 			"requires": {
 				"@jsdevtools/version-bump-prompt": "6.1.0"
+			}
+		},
+		"wait-port": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.0.4.tgz",
+			"integrity": "sha512-w8Ftna3h6XSFWWc2JC5gZEgp64nz8bnaTp5cvzbJSZ53j+omktWTDdwXxEF0jM8YveviLgFWvNGrSvRHnkyHyw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.2",
+				"commander": "^9.3.0",
+				"debug": "^4.3.4"
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"replace-in-file": "^5",
 		"sass": "^1",
 		"semver": "^7",
-		"version-bump-prompt": "^6.1.0"
+		"version-bump-prompt": "^6.1.0",
+		"wait-port": "^1.0.4"
 	},
 	"scripts": {
 		"bump:patch": "bump patch --commit 'Version %s.' query-monitor.php package.json readme.txt wp-content/db.php",


### PR DESCRIPTION
The acceptance tests, and to a lesser degree the integration tests, are flakey during the CI runs because sometimes the Chrome container or the MariaDB container isn't ready when the tests start.

The workflows sleep for 10 seconds after starting the containers in an attempt to mitigate this, but that's not ideal and not reliable.

This PR attempts to correctly wait until the corresponding service is fully ready and healthy before running the tests