### PR TITLE
Remove substring selector for filtering

### DIFF
--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -244,9 +244,9 @@ if ( window.jQuery ) {
 
 			if ( $(this).val() !== '' ) {
 				if ( hilite ) {
-					tr.filter('[data-qm-' + hilite + '*="' + val + '"]').addClass('qm-highlight');
+					tr.filter('[data-qm-' + hilite + '="' + val + '"]').addClass('qm-highlight');
 				}
-				tr.not('[data-qm-' + filter + '*="' + val + '"]').addClass('qm-hide-' + filter);
+				tr.not('[data-qm-' + filter + '="' + val + '"]').addClass('qm-hide-' + filter);
 				$(this).closest('th').addClass('qm-filtered');
 			} else {
 				$(this).closest('th').removeClass('qm-filtered');


### PR DESCRIPTION
👋 
We've extended Query Monitor and are using `build_filter()`. However, we are seeing that the substring selector for filtering will match groups that share the same string.

For example, in filtering `WP_Object_Cache`, you would see:
```
WP_Object_Cache
WP_Object_Cache_global
```

<img width="1212" alt="Screenshot 2023-02-17 at 2 02 56 PM" src="https://user-images.githubusercontent.com/16962021/219792717-b7250c33-f27a-4de6-a7ef-f2d1985f7f6d.png">

This PR fixes that:
<img width="1214" alt="Screenshot 2023-02-17 at 2 05 22 PM" src="https://user-images.githubusercontent.com/16962021/219793082-907282ab-cc21-484a-b673-abfebb099357.png">



Uncertain though if there's a use case to select the substring.