### PR TITLE
Let inactive styles meet minimum WCAG contrast

### DIFF
--- a/assets/_styles.scss
+++ b/assets/_styles.scss
@@ -864,7 +864,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	.qm span.qm-false,
 	.qm td.qm-false {
 		/* @TODO */
-		color: #999 !important;
+		color: #767676 !important;
 	}
 
 	.qm .qm-num,


### PR DESCRIPTION
Inactive states, such as the false conditionals, routinely fail WCAG contrast tests. Shifting this color down to #767676 will allow those tests to pass.