### PR TITLE
Add context labeling for toggle buttons

### DIFF
--- a/output/Html.php
+++ b/output/Html.php
@@ -392,6 +392,7 @@ abstract class QM_Output_Html extends QM_Output {
 	 * @return string Markup for the column sorter controls.
 	 */
 	protected static function build_toggler( $context ) {
+		// translators: context about what this button toggles.
 		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . sprintf( esc_attr__( 'View details for %s', 'query-monitor' ), strip_tags( $context ) ) . '"><span aria-hidden="true">+</span></button>';
 		return $out;
 	}

--- a/output/Html.php
+++ b/output/Html.php
@@ -367,7 +367,7 @@ abstract class QM_Output_Html extends QM_Output {
 	 */
 	protected function build_sorter( $heading = '' ) {
 		$out = '';
-		$out .= '<label class="qm-th">';
+		$out .= '<span class="qm-th">';
 		$out .= '<span class="qm-sort-heading">';
 
 		if ( '#' === $heading ) {
@@ -380,7 +380,7 @@ abstract class QM_Output_Html extends QM_Output {
 		$out .= '<button class="qm-sort-controls" aria-label="' . esc_attr__( 'Sort data by this column', 'query-monitor' ) . '">';
 		$out .= QueryMonitor::icon( 'arrow-down' );
 		$out .= '</button>';
-		$out .= '</label>';
+		$out .= '</span>';
 		return $out;
 	}
 

--- a/output/Html.php
+++ b/output/Html.php
@@ -367,7 +367,7 @@ abstract class QM_Output_Html extends QM_Output {
 	 */
 	protected function build_sorter( $heading = '' ) {
 		$out = '';
-		$out .= '<span class="qm-th">';
+		$out .= '<label class="qm-th">';
 		$out .= '<span class="qm-sort-heading">';
 
 		if ( '#' === $heading ) {
@@ -380,7 +380,7 @@ abstract class QM_Output_Html extends QM_Output {
 		$out .= '<button class="qm-sort-controls" aria-label="' . esc_attr__( 'Sort data by this column', 'query-monitor' ) . '">';
 		$out .= QueryMonitor::icon( 'arrow-down' );
 		$out .= '</button>';
-		$out .= '</span>';
+		$out .= '</label>';
 		return $out;
 	}
 

--- a/output/Html.php
+++ b/output/Html.php
@@ -387,10 +387,12 @@ abstract class QM_Output_Html extends QM_Output {
 	/**
 	 * Returns a toggle control. Safe for output.
 	 *
+	 * @param string $context Information to uniquely label the toggle button for screen readers.
+	 *
 	 * @return string Markup for the column sorter controls.
 	 */
-	protected static function build_toggler() {
-		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle more information', 'query-monitor' ) . '"><span aria-hidden="true">+</span></button>';
+	protected static function build_toggler( $context ) {
+		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . sprintf( esc_attr__( 'View details for %s', 'query-monitor' ), strip_tags( $context ) ) . '"><span aria-hidden="true">+</span></button>';
 		return $out;
 	}
 

--- a/output/Html.php
+++ b/output/Html.php
@@ -387,14 +387,24 @@ abstract class QM_Output_Html extends QM_Output {
 	/**
 	 * Returns a toggle control. Safe for output.
 	 *
-	 * @param string $context Information to uniquely label the toggle button for screen readers.
-	 *
+	 * @param string $context Optional. Information to uniquely label the toggle button for screen readers.
 	 * @return string Markup for the column sorter controls.
 	 */
-	protected static function build_toggler( $context ) {
-		// translators: context about what this button toggles.
-		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . sprintf( esc_attr__( 'View details for %s', 'query-monitor' ), strip_tags( $context ) ) . '"><span aria-hidden="true">+</span></button>';
-		return $out;
+	protected static function build_toggler( $context = '' ) {
+		if ( $context !== '' ) {
+			$label = sprintf(
+				/* translators: Context about what this button toggles */
+				__( 'Toggle more information for %s', 'query-monitor' ),
+				wp_strip_all_tags( $context )
+			);
+		} else {
+			$label = __( 'Toggle more information', 'query-monitor' );
+		}
+
+		return sprintf(
+			'<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="%s"><span aria-hidden="true">+</span></button>',
+			esc_attr( $label )
+		);
 	}
 
 	/**

--- a/output/html/block_editor.php
+++ b/output/html/block_editor.php
@@ -256,7 +256,7 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 					echo '</td>';
 				} else {
 					echo '<td class="qm-nowrap qm-ltr qm-has-toggle' . esc_attr( $class ) . '">';
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $block['callback']['name'] ); // WPCS: XSS ok;
 					echo '<ol>';
 					echo '<li>';
 					echo self::output_filename( $block['callback']['name'], $block['callback']['file'], $block['callback']['line'] ); // WPCS: XSS ok.
@@ -298,10 +298,11 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 		$inner_html = $block['innerHTML'];
 
 		if ( $block['size'] > 300 ) {
+			$sub_string = substr( $inner_html, 0, 200 );
 			echo '<td class="qm-ltr qm-has-toggle qm-row-block-html">';
-			echo self::build_toggler(); // WPCS: XSS ok;
+			echo self::build_toggler( $sub_string ); // WPCS: XSS ok;
 			echo '<div class="qm-inverse-toggled"><pre class="qm-pre-wrap"><code>';
-			echo esc_html( substr( $inner_html, 0, 200 ) ) . '&nbsp;&hellip;';
+			echo esc_html( $sub_string ) . '&nbsp;&hellip;';
 			echo '</code></pre></div>';
 			echo '<div class="qm-toggled"><pre class="qm-pre-wrap"><code>';
 			echo esc_html( $inner_html );

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -162,7 +162,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 				echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
 				if ( ! empty( $stack ) ) {
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $caller ); // WPCS: XSS ok;
 				}
 
 				echo '<ol>';

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -433,7 +433,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			echo '<td class="qm-row-caller qm-ltr qm-has-toggle qm-nowrap">';
 
 			if ( ! empty( $stack ) ) {
-				echo self::build_toggler(); // WPCS: XSS ok;
+				echo self::build_toggler( $caller_name ); // WPCS: XSS ok;
 			}
 
 			echo '<ol>';

--- a/output/html/environment.php
+++ b/output/html/environment.php
@@ -112,7 +112,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		echo '<td class="qm-has-toggle qm-ltr">';
 
 		echo esc_html( (string) $data->php['error_reporting'] );
-		echo self::build_toggler(); // WPCS: XSS ok;
+		echo self::build_toggler( __( 'Error Reporting', 'query-monitor' ) ); // WPCS: XSS ok;
 
 		echo '<div class="qm-toggled">';
 		echo "<ul class='qm-supplemental'><li>{$error_levels}</li></ul>"; // WPCS: XSS ok.
@@ -129,7 +129,7 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 			printf( // WPCS: XSS ok.
 				'<div class="qm-inner-toggle">%1$s %2$s</div>',
 				esc_html( number_format_i18n( count( $data->php['extensions'] ) ) ),
-				self::build_toggler()
+				self::build_toggler( __( 'Extensions', 'query-monitor' ) )
 			);
 
 			echo '<div class="qm-toggled">';

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -163,7 +163,7 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 							echo '</td>';
 						} else {
 							echo '<td class="qm-nowrap qm-ltr qm-has-toggle' . esc_attr( $class ) . '">';
-							echo self::build_toggler(); // WPCS: XSS ok;
+							echo self::build_toggler( $action['callback']['name'] ); // WPCS: XSS ok;
 							echo '<ol>';
 							echo '<li>';
 							echo self::output_filename( $action['callback']['name'], $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -185,7 +185,9 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				echo esc_html( $response );
 
 				if ( $show_toggle ) {
-					echo self::build_toggler(); // WPCS: XSS ok;
+					// translators: HTTP query method, queried URL, HTTP response.
+					$context = sprintf( __( '%1$s to %2$s with status %3$s', 'query-monitor' ), $row['args']['method'], $url, $response );
+					echo self::build_toggler( $context ); // WPCS: XSS ok;
 					echo '<ul class="qm-toggled">';
 				}
 
@@ -245,7 +247,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
 				if ( ! empty( $stack ) ) {
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $caller ); // WPCS: XSS ok;
 				}
 
 				echo '<ol>';

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -185,7 +185,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				echo esc_html( $response );
 
 				if ( $show_toggle ) {
-					// translators: HTTP query method, queried URL, HTTP response.
+					// translators: 1) HTTP query method, 2) queried URL, 3) HTTP response.
 					$context = sprintf( __( '%1$s to %2$s with status %3$s', 'query-monitor' ), $row['args']['method'], $url, $response );
 					echo self::build_toggler( $context ); // WPCS: XSS ok;
 					echo '<ul class="qm-toggled">';

--- a/output/html/languages.php
+++ b/output/html/languages.php
@@ -117,7 +117,7 @@ class QM_Output_Html_Languages extends QM_Output_Html {
 						echo '</td>';
 					} else {
 						echo '<td class="qm-nowrap qm-ltr qm-has-toggle">';
-						echo self::build_toggler(); // WPCS: XSS ok;
+						echo self::build_toggler( $mofile['caller']['display'] ); // WPCS: XSS ok;
 						echo '<ol>';
 						echo '<li>';
 						// undefined:

--- a/output/html/logger.php
+++ b/output/html/logger.php
@@ -145,7 +145,7 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 			echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
 			if ( ! empty( $stack ) ) {
-				echo self::build_toggler(); // WPCS: XSS ok;
+				echo self::build_toggler( $caller ); // WPCS: XSS ok;
 			}
 
 			echo '<ol>';

--- a/output/html/multisite.php
+++ b/output/html/multisite.php
@@ -122,7 +122,7 @@ class QM_Output_Html_Multisite extends QM_Output_Html {
 			echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
 			if ( ! empty( $stack ) ) {
-				echo self::build_toggler(); // WPCS: XSS ok;
+				echo self::build_toggler( $caller ); // WPCS: XSS ok;
 			}
 
 			echo '<ol>';

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -147,7 +147,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 					echo '<td class="qm-row-caller qm-row-stack qm-nowrap qm-ltr qm-has-toggle">';
 
 					if ( ! empty( $stack ) ) {
-						echo self::build_toggler(); // WPCS: XSS ok;
+						echo self::build_toggler( $error['filename'] ); // WPCS: XSS ok;
 					}
 
 					echo '<ol>';

--- a/output/html/timing.php
+++ b/output/html/timing.php
@@ -82,7 +82,7 @@ class QM_Output_Html_Timing extends QM_Output_Html {
 					echo '</td>';
 				} else {
 					echo '<td class="qm-ltr qm-has-toggle">';
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $row['function'] ); // WPCS: XSS ok;
 					echo '<ol>';
 					echo '<li>';
 					echo $file; // WPCS: XSS ok.
@@ -167,7 +167,7 @@ class QM_Output_Html_Timing extends QM_Output_Html {
 					echo '</td>';
 				} else {
 					echo '<td class="qm-ltr qm-has-toggle">';
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $row['function'] ); // WPCS: XSS ok;
 					echo '<ol>';
 					echo '<li>';
 					echo $file; // WPCS: XSS ok.

--- a/output/html/transients.php
+++ b/output/html/transients.php
@@ -100,7 +100,7 @@ class QM_Output_Html_Transients extends QM_Output_Html {
 				echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
 				if ( ! empty( $stack ) ) {
-					echo self::build_toggler(); // WPCS: XSS ok;
+					echo self::build_toggler( $caller ); // WPCS: XSS ok;
 				}
 
 				echo '<ol>';


### PR DESCRIPTION
All toggle buttons had the same text "Toggle more information", requiring screen reader users to explore the surrounding context on every button to determine context. Having immediate access to context makes locating information or verifying that you are toggling to correct data significantly faster.