### PR TITLE
Refine details shown when a block theme or FSE is in use

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -638,16 +638,18 @@ class QM_Util {
 	}
 
 	/**
-	 * Returns the site editor URL for a given template part name.
+	 * Returns the site editor URL for a given template or template part name.
 	 *
-	 * @param string $template_part The site template part name, for example `twentytwentytwo//header-small-dark`.
-	 * @return string The admin URL for editing the site template part.
+	 * @param string $template The site template name, for example `twentytwentytwo//header-small-dark`.
+	 * @param string $type     The template type, either 'wp_template_part' or 'wp_template'.
+	 * @return string The admin URL for editing the site template.
 	 */
-	public static function get_site_editor_url( string $template_part ): string {
+	public static function get_site_editor_url( string $template, string $type = 'wp_template_part' ): string {
 		return add_query_arg(
 			array(
-				'postType' => 'wp_template_part',
-				'postId' => urlencode( $template_part ),
+				'canvas' => 'view',
+				'postType' => $type,
+				'postId' => urlencode( $template ),
 			),
 			admin_url( 'site-editor.php' )
 		);

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -333,8 +333,14 @@ class QM_Collector_Theme extends QM_DataCollector {
 		if ( self::wp_is_block_theme() ) {
 			$block_theme_folders = self::wp_get_block_theme_folders();
 			foreach ( $templates as $template ) {
-				$this->data->template_hierarchy[] = $block_theme_folders['wp_template'] . '/' . str_replace( '.php', '.html', $template );
-				$this->data->template_hierarchy[] = $template;
+				if ( str_ends_with( $template, '.php' ) ) {
+					// Standard PHP template, inject the HTML version:
+					$this->data->template_hierarchy[] = $block_theme_folders['wp_template'] . '/' . str_replace( '.php', '.html', $template );
+					$this->data->template_hierarchy[] = $template;
+				} else {
+					// Block theme custom template (eg. from `customTemplates` in theme.json), doesn't have a suffix:
+					$this->data->template_hierarchy[] = $block_theme_folders['wp_template'] . '/' . $template . '.html';
+				}
 			}
 		} else {
 			$this->data->template_hierarchy = array_merge( $this->data->template_hierarchy, $templates );

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -559,6 +559,16 @@ class QM_Collector_Theme extends QM_DataCollector {
 
 		$this->data->theme_folders = self::wp_get_block_theme_folders();
 
+		$stylesheet_theme_json = $stylesheet_directory . '/theme.json';
+		$template_theme_json = $template_directory . '/theme.json';
+
+		if ( is_readable( $stylesheet_theme_json ) ) {
+			$this->data->stylesheet_theme_json = $stylesheet_theme_json;
+		}
+
+		if ( is_readable( $template_theme_json ) ) {
+			$this->data->template_theme_json = $template_theme_json;
+		}
 
 		if ( isset( $this->data->body_class ) ) {
 			asort( $this->data->body_class );

--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -330,7 +330,15 @@ class QM_Collector_Theme extends QM_DataCollector {
 			}
 		}
 
-		$this->data->template_hierarchy = array_merge( $this->data->template_hierarchy, $templates );
+		if ( self::wp_is_block_theme() ) {
+			$block_theme_folders = self::wp_get_block_theme_folders();
+			foreach ( $templates as $template ) {
+				$this->data->template_hierarchy[] = $block_theme_folders['wp_template'] . '/' . str_replace( '.php', '.html', $template );
+				$this->data->template_hierarchy[] = $template;
+			}
+		} else {
+			$this->data->template_hierarchy = array_merge( $this->data->template_hierarchy, $templates );
+		}
 
 		return $templates;
 	}
@@ -518,6 +526,26 @@ class QM_Collector_Theme extends QM_DataCollector {
 
 	}
 
+	/**
+	 * @return bool
+	 */
+	protected static function wp_is_block_theme() {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	protected static function wp_get_block_theme_folders() {
+		if ( ! function_exists( 'get_block_theme_folders' ) ) {
+			return array(
+				'wp_template'      => 'templates',
+				'wp_template_part' => 'parts',
+			);
+		}
+
+		return get_block_theme_folders();
+	}
 }
 
 /**

--- a/data/theme.php
+++ b/data/theme.php
@@ -12,6 +12,21 @@ class QM_Data_Theme extends QM_Data {
 	public $is_child_theme;
 
 	/**
+	 * @var WP_Block_Template
+	 */
+	public $block_template;
+
+	/**
+	 * @var array<string, string>
+	 */
+	public $theme_dirs;
+
+	/**
+	 * @var array<string, string>
+	 */
+	public $theme_folders;
+
+	/**
 	 * @var bool
 	 */
 	public $has_template_part_action;

--- a/data/theme.php
+++ b/data/theme.php
@@ -22,7 +22,7 @@ class QM_Data_Theme extends QM_Data {
 	public $template_theme_json;
 
 	/**
-	 * @var WP_Block_Template
+	 * @var WP_Block_Template|null
 	 */
 	public $block_template;
 

--- a/data/theme.php
+++ b/data/theme.php
@@ -12,6 +12,16 @@ class QM_Data_Theme extends QM_Data {
 	public $is_child_theme;
 
 	/**
+	 * @var string
+	 */
+	public $stylesheet_theme_json;
+
+	/**
+	 * @var string
+	 */
+	public $template_theme_json;
+
+	/**
 	 * @var WP_Block_Template
 	 */
 	public $block_template;

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -48,9 +48,37 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 		echo '<h3>' . esc_html__( 'Theme', 'query-monitor' ) . '</h3>';
 		echo '<p>' . esc_html( $data->stylesheet ) . '</p>';
 
+		if ( self::has_clickable_links() ) {
+			echo '<p>';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo self::output_filename( 'style.css', sprintf( '%s/style.css', $data->theme_dirs[ $data->stylesheet ] ), 0, true );
+			echo '</p>';
+
+			if ( $data->stylesheet_theme_json ) {
+				echo '<p>';
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo self::output_filename( 'theme.json', $data->stylesheet_theme_json, 0, true );
+				echo '</p>';
+			}
+		}
+
 		if ( $data->is_child_theme ) {
 			echo '<h3>' . esc_html__( 'Parent Theme', 'query-monitor' ) . '</h3>';
 			echo '<p>' . esc_html( $data->template ) . '</p>';
+
+			if ( self::has_clickable_links() ) {
+				echo '<p>';
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo self::output_filename( 'style.css', sprintf( '%s/style.css', $data->theme_dirs[ $data->template ] ), 0, true );
+				echo '</p>';
+
+				if ( $data->template_theme_json ) {
+					echo '<p>';
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo self::output_filename( 'theme.json', $data->template_theme_json, 0, true );
+					echo '</p>';
+				}
+			}
 		}
 
 		echo '</section>';

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -74,6 +74,37 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 			echo '<p><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></p>';
 		}
 
+		if ( ! empty( $data->block_template ) ) {
+			echo '<h3>' . esc_html__( 'Block Template', 'query-monitor' ) . '</h3>';
+
+			if ( $data->block_template->wp_id ) {
+				echo '<p>';
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo self::build_link(
+					QM_Util::get_site_editor_url( $data->block_template->id, 'wp_template' ),
+					esc_html( $data->block_template->id )
+				);
+				echo '</p>';
+			} else {
+				if ( self::has_clickable_links() ) {
+					$file = sprintf(
+						'%s/%s/%s.html',
+						$data->theme_dirs[ $data->block_template->theme ],
+						$data->theme_folders[ $data->block_template->type ],
+						$data->block_template->slug
+					);
+				} else {
+					$file = '';
+				}
+
+				echo '<p class="qm-ltr">' . self::output_filename( sprintf(
+					'%s/%s.html',
+					$data->theme_folders[ $data->block_template->type ],
+					$data->block_template->slug
+				), $file, 0, true ) . '</p>'; // WPCS: XSS ok.
+			}
+		}
+
 		if ( ! empty( $data->template_hierarchy ) ) {
 			echo '<h3>' . esc_html__( 'Template Hierarchy', 'query-monitor' ) . '</h3>';
 			echo '<ol class="qm-ltr"><li>' . implode( '</li><li>', array_map( 'esc_html', $data->template_hierarchy ) ) . '</li></ol>';

--- a/output/html/theme.php
+++ b/output/html/theme.php
@@ -56,24 +56,6 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 		echo '</section>';
 
 		echo '<section>';
-		echo '<h3>' . esc_html__( 'Template File', 'query-monitor' ) . '</h3>';
-
-		if ( ! empty( $data->template_path ) ) {
-			if ( $data->is_child_theme ) {
-				$display = $data->theme_template_file;
-			} else {
-				$display = $data->template_file;
-			}
-			if ( self::has_clickable_links() ) {
-				$file = $data->template_path;
-			} else {
-				$file = '';
-			}
-			echo '<p class="qm-ltr">' . self::output_filename( $display, $file, 0, true ) . '</p>'; // WPCS: XSS ok.
-		} else {
-			echo '<p><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></p>';
-		}
-
 		if ( ! empty( $data->block_template ) ) {
 			echo '<h3>' . esc_html__( 'Block Template', 'query-monitor' ) . '</h3>';
 
@@ -102,6 +84,24 @@ class QM_Output_Html_Theme extends QM_Output_Html {
 					$data->theme_folders[ $data->block_template->type ],
 					$data->block_template->slug
 				), $file, 0, true ) . '</p>'; // WPCS: XSS ok.
+			}
+		} else {
+			echo '<h3>' . esc_html__( 'Template File', 'query-monitor' ) . '</h3>';
+
+			if ( ! empty( $data->template_path ) ) {
+				if ( $data->is_child_theme ) {
+					$display = $data->theme_template_file;
+				} else {
+					$display = $data->template_file;
+				}
+				if ( self::has_clickable_links() ) {
+					$file = $data->template_path;
+				} else {
+					$file = '';
+				}
+				echo '<p class="qm-ltr">' . self::output_filename( $display, $file, 0, true ) . '</p>'; // WPCS: XSS ok.
+			} else {
+				echo '<p><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></p>';
 			}
 		}
 


### PR DESCRIPTION
This further refines the information shown in the Theme panel when a block theme or FSE is in use.

* Updates the template hierarchy to include corresponding `.html` templates
* Adds a "Block Template" section that shows the `.html` or `wp_template` template used for the request