### PR TITLE
Remove support for multiple instances of `wpdb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Here's an example of Query Monitor's output. This is the panel showing aggregate
  * Filter queries by component (WordPress core, Plugin X, Plugin Y, theme)
  * Filter queries by calling function
  * View aggregate query information grouped by component, calling function, and type
- * Super advanced: Supports multiple instances of wpdb (more info in the FAQ)
 
 Filtering queries by component or calling function makes it easy to see which plugins, themes, or functions on your site are making the most (or the slowest) database queries.
 
@@ -348,14 +347,7 @@ Please note that information about database queries and the environment is somew
 
 ## I'm using multiple instances of `wpdb`. How do I get my additional instances to show up in Query Monitor?
 
-You'll need to hook into the `qm/collect/db_objects` filter and add an item to the array containing your `wpdb` instance. For example:
-
-    add_filter( 'qm/collect/db_objects', function( $objects ) {
-        $objects['my_db'] = $GLOBALS['my_db'];
-        return $objects;
-    } );
-
-Your `wpdb` instance will then show up as a separate panel, and the query time and query count will show up separately in the admin toolbar menu. Aggregate information (queries by caller and component) will not be separated.
+This feature was removed from Query Monitor in version 3.12 as it was rarely used and considerably increased the maintenance burden of Query Monitor itself. Feel free to continue using Query Monitor 3.11 if you need to make use of this feature.
 
 ## Can I click on stack traces to open the file in my editor?
 

--- a/collectors/db_dupes.php
+++ b/collectors/db_dupes.php
@@ -55,9 +55,9 @@ class QM_Collector_DB_Dupes extends QM_DataCollector {
 			// Loop over each query
 			foreach ( $query_ids as $query_id ) {
 
-				if ( isset( $dbq_data->dbs['$wpdb']->rows[ $query_id ]['trace'] ) ) {
+				if ( isset( $dbq_data->wpdb->rows[ $query_id ]['trace'] ) ) {
 					/** @var QM_Backtrace */
-					$trace = $dbq_data->dbs['$wpdb']->rows[ $query_id ]['trace'];
+					$trace = $dbq_data->wpdb->rows[ $query_id ]['trace'];
 					$stack = array_column( $trace->get_filtered_trace(), 'id' );
 					$component = $trace->get_component();
 
@@ -69,7 +69,7 @@ class QM_Collector_DB_Dupes extends QM_DataCollector {
 					}
 				} else {
 					/** @var array<int, string> */
-					$stack = $dbq_data->dbs['$wpdb']->rows[ $query_id ]['stack'];
+					$stack = $dbq_data->wpdb->rows[ $query_id ]['stack'];
 				}
 
 				// Populate the caller counts for this query
@@ -84,9 +84,9 @@ class QM_Collector_DB_Dupes extends QM_DataCollector {
 
 				// Populate the time for this query
 				if ( isset( $times[ $sql ] ) ) {
-					$times[ $sql ] += $dbq->data->dbs['$wpdb']->rows[ $query_id ]['ltime'];
+					$times[ $sql ] += $dbq->data->wpdb->rows[ $query_id ]['ltime'];
 				} else {
-					$times[ $sql ] = $dbq->data->dbs['$wpdb']->rows[ $query_id ]['ltime'];
+					$times[ $sql ] = $dbq->data->wpdb->rows[ $query_id ]['ltime'];
 				}
 			}
 

--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -92,61 +92,56 @@ class QM_Collector_Environment extends QM_DataCollector {
 		$dbq = QM_Collectors::get( 'db_queries' );
 
 		if ( $dbq ) {
-
-			foreach ( $dbq->db_objects as $id => $db ) {
-
-				if ( method_exists( $db, 'db_version' ) ) {
-					$server = $db->db_version();
-					// query_cache_* deprecated since MySQL 5.7.20
-					if ( version_compare( $server, '5.7.20', '>=' ) ) {
-						unset( $mysql_vars['query_cache_limit'], $mysql_vars['query_cache_size'], $mysql_vars['query_cache_type'] );
-					}
+			if ( method_exists( $dbq->wpdb, 'db_version' ) ) {
+				$server = $dbq->wpdb->db_version();
+				// query_cache_* deprecated since MySQL 5.7.20
+				if ( version_compare( $server, '5.7.20', '>=' ) ) {
+					unset( $mysql_vars['query_cache_limit'], $mysql_vars['query_cache_size'], $mysql_vars['query_cache_type'] );
 				}
-
-				/** @var array<int, stdClass>|null */
-				$variables = $db->get_results( "
-					SHOW VARIABLES
-					WHERE Variable_name IN ( '" . implode( "', '", array_keys( $mysql_vars ) ) . "' )
-				" );
-
-				/** @var mysqli|false|null $dbh */
-				$dbh = $db->dbh;
-
-				if ( is_object( $dbh ) ) {
-					# mysqli or PDO
-					$extension = get_class( $dbh );
-				} else {
-					# Who knows?
-					$extension = null;
-				}
-
-				$client = mysqli_get_client_version();
-
-				if ( $client ) {
-					$client_version = implode( '.', QM_Util::get_client_version( $client ) );
-					$client_version = sprintf( '%s (%s)', $client, $client_version );
-				} else {
-					$client_version = null;
-				}
-
-				$server_version = self::get_server_version( $db );
-
-				$info = array(
-					'server-version' => $server_version,
-					'extension' => $extension,
-					'client-version' => $client_version,
-					'user' => $db->dbuser,
-					'host' => $db->dbhost,
-					'database' => $db->dbname,
-				);
-
-				$this->data->db[ $id ] = array(
-					'info' => $info,
-					'vars' => $mysql_vars,
-					'variables' => $variables ?: array(),
-				);
-
 			}
+
+			/** @var array<int, stdClass>|null */
+			$variables = $dbq->wpdb->get_results( "
+				SHOW VARIABLES
+				WHERE Variable_name IN ( '" . implode( "', '", array_keys( $mysql_vars ) ) . "' )
+			" );
+
+			/** @var mysqli|false|null $dbh */
+			$dbh = $dbq->wpdb->dbh;
+
+			if ( is_object( $dbh ) ) {
+				# mysqli or PDO
+				$extension = get_class( $dbh );
+			} else {
+				# Who knows?
+				$extension = null;
+			}
+
+			$client = mysqli_get_client_version();
+
+			if ( $client ) {
+				$client_version = implode( '.', QM_Util::get_client_version( $client ) );
+				$client_version = sprintf( '%s (%s)', $client, $client_version );
+			} else {
+				$client_version = null;
+			}
+
+			$server_version = self::get_server_version( $dbq->wpdb );
+
+			$info = array(
+				'server-version' => $server_version,
+				'extension' => $extension,
+				'client-version' => $client_version,
+				'user' => $dbq->wpdb->dbuser,
+				'host' => $dbq->wpdb->dbhost,
+				'database' => $dbq->wpdb->dbname,
+			);
+
+			$this->data->db = array(
+				'info' => $info,
+				'vars' => $mysql_vars,
+				'variables' => $variables ?: array(),
+			);
 		}
 
 		$php_data = array(

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -27,9 +27,9 @@ class QM_Data_DB_Queries extends QM_Data {
 	public $expensive;
 
 	/**
-	 * @var ?array<string, stdClass>
+	 * @var stdClass
 	 */
-	public $dbs;
+	public $wpdb;
 
 	/**
 	 * @var array<string, array<string, mixed>>

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -7,7 +7,7 @@
 
 class QM_Data_DB_Queries extends QM_Data {
 	/**
-	 * @var ?int
+	 * @var int
 	 */
 	public $total_qs;
 
@@ -22,18 +22,18 @@ class QM_Data_DB_Queries extends QM_Data {
 	public $errors;
 
 	/**
-	 * @var array<int, array<string, mixed>>
+	 * @var ?array<int, array<string, mixed>>
 	 */
 	public $expensive;
 
 	/**
-	 * @var stdClass
+	 * @var ?stdClass
 	 */
 	public $wpdb;
 
 	/**
-	 * @var array<string, array<string, mixed>>
-	 * @phpstan-var array<string, array{
+	 * @var ?array<string, array<string, mixed>>
+	 * @phpstan-var ?array<string, array{
 	 *   caller: string,
 	 *   ltime: float,
 	 *   types: array<string, int>,
@@ -42,7 +42,7 @@ class QM_Data_DB_Queries extends QM_Data {
 	public $times = array();
 
 	/**
-	 * @var array<string, array<int, int>>
+	 * @var ?array<string, array<int, int>>
 	 */
 	public $dupes;
 }

--- a/data/environment.php
+++ b/data/environment.php
@@ -24,8 +24,8 @@ class QM_Data_Environment extends QM_Data {
 
 	/**
 	 * @TODO data class
-	 * @var ?array<string, array<string, mixed>>
-	 * @phpstan-var ?array<string, array{
+	 * @var array<string, mixed>
+	 * @phpstan-var array{
 	 *   info: array{
 	 *     server-version: string,
 	 *     extension: string|null,
@@ -36,7 +36,7 @@ class QM_Data_Environment extends QM_Data {
 	 *   },
 	 *   vars: array<string, bool|string>,
 	 *   variables: list<stdClass>,
-	 * }>
+	 * }
 	 */
 	public $db;
 

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -127,7 +127,7 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 			/** @var QM_Data_DB_Queries $dbq_data */
 			$dbq_data = $dbq->get_data();
 			if ( ! empty( $dbq_data->times ) ) {
-				$menu['qm-db_queries-$wpdb']['children'][] = $this->menu( array(
+				$menu['qm-db_queries']['children'][] = $this->menu( array(
 					'title' => esc_html__( 'Queries by Caller', 'query-monitor' ),
 				) );
 			}

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -123,7 +123,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 			/** @var QM_Data_DB_Queries $dbq_data */
 			$dbq_data = $dbq->get_data();
 			if ( ! empty( $dbq_data->component_times ) ) {
-				$menu['qm-db_queries-$wpdb']['children'][] = $this->menu( array(
+				$menu['qm-db_queries']['children'][] = $this->menu( array(
 					'title' => esc_html__( 'Queries by Component', 'query-monitor' ),
 				) );
 			}

--- a/output/html/db_dupes.php
+++ b/output/html/db_dupes.php
@@ -168,7 +168,7 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 	public function panel_menu( array $menu ) {
 		$id = $this->collector->id();
 		if ( isset( $menu[ $id ] ) ) {
-			$menu['qm-db_queries-$wpdb']['children'][] = $menu[ $id ];
+			$menu['qm-db_queries']['children'][] = $menu[ $id ];
 			unset( $menu[ $id ] );
 		}
 

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -45,7 +45,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		/** @var QM_Data_DB_Queries $data */
 		$data = $this->collector->get_data();
 
-		if ( empty( $data->dbs ) ) {
+		if ( empty( $data->wpdb ) ) {
 			$this->output_empty_queries();
 			return;
 		}
@@ -58,10 +58,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			$this->output_expensive_queries( $data->expensive );
 		}
 
-		foreach ( $data->dbs as $name => $db ) {
-			$this->output_queries( $name, $db, $data );
-		}
-
+		$this->output_queries( $data->wpdb, $data );
 	}
 
 	/**
@@ -158,12 +155,11 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 	}
 
 	/**
-	 * @param string $name
 	 * @param stdClass $db
 	 * @param QM_Data_DB_Queries $data
 	 * @return void
 	 */
-	protected function output_queries( $name, stdClass $db, QM_Data_DB_Queries $data ) {
+	protected function output_queries( stdClass $db, QM_Data_DB_Queries $data ) {
 		$this->query_row = 0;
 		$span = 4;
 
@@ -174,19 +170,8 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			$span++;
 		}
 
-		$panel_id = sprintf(
-			'%s-%s',
-			$this->collector->id(),
-			sanitize_title_with_dashes( $name )
-		);
-		$panel_name = sprintf(
-			/* translators: %s: Name of database controller */
-			__( '%s Queries', 'query-monitor' ),
-			$name
-		);
-
 		if ( ! empty( $db->rows ) ) {
-			$this->before_tabular_output( $panel_id, $panel_name );
+			$this->before_tabular_output();
 
 			echo '<thead>';
 
@@ -200,7 +185,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 			 *
 			 * @param bool $show_prompt Whether to show the prompt.
 			 */
-			if ( apply_filters( 'qm/show_extended_query_prompt', true ) && ! $db->has_trace && ( '$wpdb' === $name ) ) {
+			if ( apply_filters( 'qm/show_extended_query_prompt', true ) && ! $db->has_trace ) {
 				echo '<tr>';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo '<th colspan="' . intval( $span ) . '" class="qm-warn">' . QueryMonitor::icon( 'warning' );
@@ -316,7 +301,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 			$this->after_tabular_output();
 		} else {
-			$this->before_non_tabular_output( $panel_id, $panel_name );
+			$this->before_non_tabular_output();
 
 			$notice = __( 'No queries! Nice work.', 'query-monitor' );
 			echo $this->build_notice( $notice ); // WPCS: XSS ok.
@@ -511,32 +496,26 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		/** @var QM_Data_DB_Queries $data */
 		$data = $this->collector->get_data();
 
-		if ( isset( $data->dbs ) ) {
-			$count = count( $data->dbs );
+		if ( isset( $data->wpdb ) ) {
+			$title[] = sprintf(
+				/* translators: %s: A time in seconds with a decimal fraction. No space between value and unit symbol. */
+				esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
+				number_format_i18n( $data->wpdb->total_time, 2 )
+			);
 
-			foreach ( $data->dbs as $key => $db ) {
+			/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
+			$text = _n( '%s Q', '%s Q', $data->wpdb->total_qs, 'query-monitor' );
 
-				$title[] = sprintf(
-					/* translators: %s: A time in seconds with a decimal fraction. No space between value and unit symbol. */
-					'%s' . esc_html_x( '%ss', 'Time in seconds', 'query-monitor' ),
-					( $count > 1 ? '&bull;&nbsp;&nbsp' : '' ),
-					number_format_i18n( $db->total_time, 2 )
-				);
-
-				/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
-				$text = _n( '%s Q', '%s Q', $db->total_qs, 'query-monitor' );
-
-				// Avoid a potentially blank translation for the plural form.
-				// @see https://meta.trac.wordpress.org/ticket/5377
-				if ( '' === $text ) {
-					$text = '%s Q';
-				}
-
-				$title[] = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', sprintf(
-					esc_html( $text ),
-					number_format_i18n( $db->total_qs )
-				) );
+			// Avoid a potentially blank translation for the plural form.
+			// @see https://meta.trac.wordpress.org/ticket/5377
+			if ( '' === $text ) {
+				$text = '%s Q';
 			}
+
+			$title[] = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', sprintf(
+				esc_html( $text ),
+				number_format_i18n( $data->wpdb->total_qs )
+			) );
 		} elseif ( isset( $data->total_qs ) ) {
 			/* translators: %s: Number of database queries. Note the space between value and unit symbol. */
 			$text = _n( '%s Q', '%s Q', $data->total_qs, 'query-monitor' );
@@ -584,27 +563,11 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		$errors = $this->collector->get_errors();
 		$expensive = $this->collector->get_expensive();
 
-		if ( isset( $data->dbs ) && count( $data->dbs ) > 1 ) {
-			foreach ( $data->dbs as $name => $db ) {
-				$name_attr = sanitize_title_with_dashes( $name );
-				$id = $this->collector->id() . '-' . $name_attr;
-				$menu[ $id ] = $this->menu( array(
-					'id' => esc_attr( sprintf( 'query-monitor-%s-db-%s', $this->collector->id(), $name_attr ) ),
-					'title' => esc_html( sprintf(
-						/* translators: %s: Name of database controller */
-						__( 'Database Queries: %s', 'query-monitor' ),
-						$name
-					) ),
-					'href' => esc_attr( sprintf( '#%s-%s', $this->collector->id(), $name_attr ) ),
-				) );
-			}
-		} else {
-			$id = $this->collector->id() . '-$wpdb';
-			$menu[ $id ] = $this->menu( array(
-				'title' => esc_html__( 'Database Queries', 'query-monitor' ),
-				'href' => esc_attr( sprintf( '#%s-wpdb', $this->collector->id() ) ),
-			) );
-		}
+		$id = $this->collector->id();
+		$menu[ $id ] = $this->menu( array(
+			'title' => esc_html__( 'Database Queries', 'query-monitor' ),
+			// 'href' => esc_attr( sprintf( '#%s', $this->collector->id() ) ),
+		) );
 
 		if ( $errors ) {
 			$id = $this->collector->id() . '-errors';
@@ -646,7 +609,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		foreach ( array( 'errors', 'expensive' ) as $sub ) {
 			$id = $this->collector->id() . '-' . $sub;
 			if ( isset( $menu[ $id ] ) ) {
-				$menu['qm-db_queries-$wpdb']['children'][] = $menu[ $id ];
+				$menu['qm-db_queries']['children'][] = $menu[ $id ];
 				unset( $menu[ $id ] );
 			}
 		}

--- a/output/html/environment.php
+++ b/output/html/environment.php
@@ -146,80 +146,68 @@ class QM_Output_Html_Environment extends QM_Output_Html {
 		echo '</section>';
 
 		if ( isset( $data->db ) ) {
+			echo '<section>';
+			echo '<h3>' . esc_html__( 'Database', 'query-monitor' ) . '</h3>';
 
-			foreach ( $data->db as $id => $db ) {
+			echo '<table>';
+			echo '<tbody>';
 
-				if ( 1 === count( $data->db ) ) {
-					$name = __( 'Database', 'query-monitor' );
+			$info = array(
+				'server-version' => __( 'Server Version', 'query-monitor' ),
+				'extension' => __( 'Extension', 'query-monitor' ),
+				'client-version' => __( 'Client Version', 'query-monitor' ),
+				'user' => __( 'User', 'query-monitor' ),
+				'host' => __( 'Host', 'query-monitor' ),
+				'database' => __( 'Database', 'query-monitor' ),
+			);
+
+			foreach ( $info as $field => $label ) {
+
+				echo '<tr>';
+				echo '<th scope="row">' . esc_html( $label ) . '</th>';
+
+				if ( ! isset( $data->db['info'][ $field ] ) ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo '<td><span class="qm-warn">' . QueryMonitor::icon( 'warning' ) . esc_html__( 'Unknown', 'query-monitor' ) . '</span></td>';
 				} else {
-					/* translators: %s: Name of database controller */
-					$name = sprintf( __( 'Database: %s', 'query-monitor' ), $id );
+					echo '<td>' . esc_html( $data->db['info'][ $field ] ) . '</td>';
 				}
 
-				echo '<section>';
-				echo '<h3>' . esc_html( $name ) . '</h3>';
-
-				echo '<table>';
-				echo '<tbody>';
-
-				$info = array(
-					'server-version' => __( 'Server Version', 'query-monitor' ),
-					'extension' => __( 'Extension', 'query-monitor' ),
-					'client-version' => __( 'Client Version', 'query-monitor' ),
-					'user' => __( 'User', 'query-monitor' ),
-					'host' => __( 'Host', 'query-monitor' ),
-					'database' => __( 'Database', 'query-monitor' ),
-				);
-
-				foreach ( $info as $field => $label ) {
-
-					echo '<tr>';
-					echo '<th scope="row">' . esc_html( $label ) . '</th>';
-
-					if ( ! isset( $db['info'][ $field ] ) ) {
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo '<td><span class="qm-warn">' . QueryMonitor::icon( 'warning' ) . esc_html__( 'Unknown', 'query-monitor' ) . '</span></td>';
-					} else {
-						echo '<td>' . esc_html( $db['info'][ $field ] ) . '</td>';
-					}
-
-					echo '</tr>';
-
-				}
-
-				foreach ( $db['variables'] as $setting ) {
-
-					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$key = (string) $setting->Variable_name;
-					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$val = (string) $setting->Value;
-
-					$append = '';
-
-					if ( is_numeric( $val ) && ( $val >= ( 1024 * 1024 ) ) ) {
-						$append .= sprintf(
-							'&nbsp;<span class="qm-info">(~%s)</span>',
-							esc_html( (string) size_format( $val ) )
-						);
-					}
-
-					echo '<tr>';
-
-					echo '<th scope="row">' . esc_html( $key ) . '</th>';
-					echo '<td>';
-					echo esc_html( $val );
-					echo $append; // WPCS: XSS ok.
-					echo '</td>';
-
-					echo '</tr>';
-				}
-
-				echo '</tbody>';
-				echo '</table>';
-
-				echo '</section>';
+				echo '</tr>';
 
 			}
+
+			foreach ( $data->db['variables'] as $setting ) {
+
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$key = (string) $setting->Variable_name;
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$val = (string) $setting->Value;
+
+				$append = '';
+
+				if ( is_numeric( $val ) && ( $val >= ( 1024 * 1024 ) ) ) {
+					$append .= sprintf(
+						'&nbsp;<span class="qm-info">(~%s)</span>',
+						esc_html( (string) size_format( $val ) )
+					);
+				}
+
+				echo '<tr>';
+
+				echo '<th scope="row">' . esc_html( $key ) . '</th>';
+				echo '<td>';
+				echo esc_html( $val );
+				echo $append; // WPCS: XSS ok.
+				echo '</td>';
+
+				echo '</tr>';
+			}
+
+			echo '</tbody>';
+			echo '</table>';
+
+			echo '</section>';
 		}
 
 		echo '<section>';

--- a/output/html/request.php
+++ b/output/html/request.php
@@ -102,7 +102,7 @@ class QM_Output_Html_Request extends QM_Output_Html {
 
 		if ( $db_queries ) {
 			$db_queries_data = $db_queries->get_data();
-			if ( ! empty( $db_queries_data->dbs['$wpdb']->has_main_query ) ) {
+			if ( ! empty( $db_queries_data->wpdb->has_main_query ) ) {
 				echo '<p>';
 				echo self::build_filter_trigger( 'db_queries-wpdb', 'caller', 'qm-main-query', esc_html__( 'View Main Query', 'query-monitor' ) ); // WPCS: XSS ok;
 				echo '</p>';

--- a/output/raw/db_queries.php
+++ b/output/raw/db_queries.php
@@ -34,17 +34,11 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 		/** @var QM_Data_DB_Queries $data */
 		$data = $this->collector->get_data();
 
-		if ( empty( $data->dbs ) ) {
+		if ( empty( $data->wpdb ) ) {
 			return $output;
 		}
 
-		$dbs = array();
-
-		foreach ( $data->dbs as $name => $db ) {
-			$dbs[ $name ] = $this->output_queries( $name, $db, $data );
-		}
-
-		$output['dbs'] = $dbs;
+		$output['wpdb'] = $this->output_queries( $data->wpdb );
 
 		if ( ! empty( $data->errors ) ) {
 			$output['errors'] = array(
@@ -72,9 +66,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 	}
 
 	/**
-	 * @param string $name
 	 * @param stdClass $db
-	 * @param QM_Data_DB_Queries $data
 	 * @return array
 	 * @phpstan-return array{
 	 *   total: int,
@@ -82,7 +74,7 @@ class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
 	 *   queries: mixed[],
 	 * }|array{}
 	 */
-	protected function output_queries( $name, stdClass $db, QM_Data_DB_Queries $data ) {
+	protected function output_queries( stdClass $db ) {
 		$this->query_row = 0;
 
 		$output = array();

--- a/readme.txt
+++ b/readme.txt
@@ -120,14 +120,7 @@ Please note that information about database queries and the environment is somew
 
 ### I'm using multiple instances of `wpdb`. How do I get my additional instances to show up in Query Monitor?
 
-You'll need to hook into the `qm/collect/db_objects` filter and add an item to the array containing your `wpdb` instance. For example:
-
-    add_filter( 'qm/collect/db_objects', function( $objects ) {
-        $objects['my_db'] = $GLOBALS['my_db'];
-        return $objects;
-    } );
-
-Your `wpdb` instance will then show up as a separate panel, and the query time and query count will show up separately in the admin toolbar menu. Aggregate information (queries by caller and component) will not be separated.
+This feature was removed from Query Monitor in version 3.12 as it was rarely used and considerably increased the maintenance burden of Query Monitor itself. Feel free to continue using Query Monitor 3.11 if you need to make use of this feature.
 
 ### Can I click on stack traces to open the file in my editor?
 


### PR DESCRIPTION
This feature is little used, I've not used it myself in the last 8 years. As nifty as it is, it contributes significantly to the maintenance burden of QM itself and slows down my ability to work on the front end rendering tasks. Maybe it'll reappear in the future, but it's unlikely.