### PR TITLE
Strict_Type causes issue Uncaught Error: file_exists() expects parameter 1 to be a valid path, bool given

### DIFF
--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php
 /**
  * Language and locale collector.
  *


### PR DESCRIPTION
The addition (in 3.11.0) of `declare(strict_types = 1);` on line 1, causes an issue on the frontend, throwing 
` Fatal error: Uncaught Error: file_exists() expects parameter 1 to be a valid path, bool given
in .../plugins/query-monitor/collectors/languages.php on line 169`

Appears to be expecting a file_path but object given, throwing an error.