### PR TITLE
Strict_Type causes issue

### DIFF
--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -166,7 +166,7 @@ class QM_Collector_Languages extends QM_DataCollector {
 			),
 		) );
 
-		$found = file_exists( $mofile ) ? filesize( $mofile ) : false;
+		$found = ( is_string( $mofile ) ) && file_exists( $mofile ) ? filesize( $mofile ) : false;
 
 		$this->data->languages[ $domain ][ $mofile ] = array(
 			'caller' => $trace->get_caller(),

--- a/collectors/languages.php
+++ b/collectors/languages.php
@@ -139,7 +139,7 @@ class QM_Collector_Languages extends QM_DataCollector {
 	/**
 	 * Store log data.
 	 *
-	 * @param string $mofile Path to the MO file.
+	 * @param mixed $mofile Should be a string path to the MO file, could be anything.
 	 * @param string $domain Text domain.
 	 * @return string
 	 */
@@ -148,7 +148,7 @@ class QM_Collector_Languages extends QM_DataCollector {
 			return $mofile;
 		}
 
-		if ( isset( $this->data->languages[ $domain ][ $mofile ] ) ) {
+		if ( is_string( $mofile ) && isset( $this->data->languages[ $domain ][ $mofile ] ) ) {
 			return $mofile;
 		}
 
@@ -167,6 +167,10 @@ class QM_Collector_Languages extends QM_DataCollector {
 		) );
 
 		$found = ( is_string( $mofile ) ) && file_exists( $mofile ) ? filesize( $mofile ) : false;
+
+		if ( ! is_string( $mofile ) ) {
+			$mofile = gettype( $mofile );
+		}
 
 		$this->data->languages[ $domain ][ $mofile ] = array(
 			'caller' => $trace->get_caller(),


### PR DESCRIPTION
The addition (in 3.11.0) of `declare(strict_types = 1);` on line 1, causes an issue on the frontend, throwing
 `Fatal error: Uncaught Error: file_exists() expects parameter 1 to be a valid path, bool given in .../plugins/query-monitor/collectors/languages.php on line 169`

Appears to be expecting a string (file_path) but object/bool given, throwing an error.