### PR TITLE
Check QM_VERSION Constant Before Defining

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -33,7 +33,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'QM_VERSION', '3.12.0' );
+if ( ! defined( 'QM_VERSION' ) ) {
+	define( 'QM_VERSION', '3.12.0' );
+}
 
 $qm_dir = dirname( __FILE__ );
 


### PR DESCRIPTION
On WordPress VIP platform, the query-monitor plugin is part of the [VIP Go mu-plugins](https://github.com/Automattic/vip-go-mu-plugins/). Therefore, it will throw an error if the query-monitor plugin is also installed and activated in the `/plugins` directory.

This PR fixes the issue by defining the constant only if it is not yet defined.

![Screenshot 2023-03-21 at 14 11 38](https://user-images.githubusercontent.com/75835774/226633063-f3edb396-2c84-429d-9ca0-e91e1dbd9fc9.png)
