### PR TITLE
Call previous error handler at end of `QM_Collector_PHP_Errors::error_handler()`

### DIFF
--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -280,11 +280,14 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		 * Filters the PHP error handler return value. This can be used to control whether or not the default error
 		 * handler is called after Query Monitor's.
 		 *
+		 * Return true to stop further error handling, false to run the normal error handler.
+		 *
 		 * @since 2.7.0
 		 *
 		 * @param bool $return_value Error handler return value. Default false.
 		 */
-		return apply_filters( 'qm/collect/php_errors_return_value', false );
+		return apply_filters( 'qm/collect/php_errors_return_value', false )
+			|| ( is_callable( $this->previous_error_handler ) && call_user_func($this->previous_error_handler, func_get_args() ) );
 
 	}
 

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -287,7 +287,7 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		 * @param bool $return_value Error handler return value. Default false.
 		 */
 		return apply_filters( 'qm/collect/php_errors_return_value', false )
-			|| ( is_callable( $this->previous_error_handler ) && call_user_func( $this->previous_error_handler, func_get_args() ) );
+			|| ( is_callable( $this->previous_error_handler ) && call_user_func_array( $this->previous_error_handler, func_get_args() ) );
 
 	}
 

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -287,7 +287,7 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		 * @param bool $return_value Error handler return value. Default false.
 		 */
 		return apply_filters( 'qm/collect/php_errors_return_value', false )
-			|| ( is_callable( $this->previous_error_handler ) && call_user_func($this->previous_error_handler, func_get_args() ) );
+			|| ( is_callable( $this->previous_error_handler ) && call_user_func( $this->previous_error_handler, func_get_args() ) );
 
 	}
 

--- a/tests/integration/CollectorPhpErrorsTest.php
+++ b/tests/integration/CollectorPhpErrorsTest.php
@@ -248,4 +248,36 @@ class CollectorPHPErrors extends Test {
 		self::assertArrayNotHasKey( 'warning', $actual->silenced );
 		self::assertEquals( 1, count( $actual->silenced['notice'] ) );
 	}
+
+	function testItReturnsFalseWhenNoPreviousErrorHandler(): void {
+		$result = $this->collector->error_handler( E_WARNING, 'test' );
+
+		self::assertFalse( $result );
+	}
+
+	function testItCallsFilterForErrorHandlerResult(): void {
+		add_filter( 'qm/collect/php_errors_return_value', '__return_true' );
+
+		$result = $this->collector->error_handler( E_WARNING, 'test' );
+
+		self::assertTrue( $result );
+	}
+
+	function testItCallsPreviousErrorHandler(): void {
+		// Test needs the previous error handler set before the sut is set up.
+		ini_set( 'display_errors', '0' );
+		$this->collector->set_up();
+		$this->collector->tear_down();
+
+		set_error_handler(function( $errno, $message, $file = null, $line = null, $context = null, $do_trace = true ) {
+			return true;
+		});
+
+		$this->collector = new \QM_Collector_PHP_Errors();
+		$this->collector->set_up();
+
+		$result = $this->collector->error_handler( E_WARNING, 'test' );
+
+		self::assertTrue( $result );
+	}
 }


### PR DESCRIPTION
We have an MU plugin to mute deprecation warnings. With Query Monitor active, its error handler is never run.

The common pattern is to save the return value of `set_error_handler()` to an instance variable, as you have done with `$previous_error_handler`, and then to call it at the end of the new error handler, if it exists. I have added the latter part.

https://www.php.net/manual/en/function.set-error-handler.php#123459