### PR TITLE
Prune PHPStan ignores

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,20 +6,22 @@ parameters:
 	level: 7
 	paths:
 		- query-monitor.php
-		- classes
-		- collectors
-		- dispatchers
-		- output
-		- tests/acceptance
-		- tests/integration
-		- wp-content
+		- classes/
+		- collectors/
+		- dispatchers/
+		- output/
+		- tests/acceptance/
+		- tests/integration/
+		- wp-content/
 	scanDirectories:
-		- tests/_support
+		- tests/_support/
 	excludePaths:
 		analyse:
-			- tests/integration/Supports
+			- tests/integration/Supports/
 	bootstrapFiles:
 		- tests/phpstan/stubs.php
+	universalObjectCratesClasses:
+		- QM_Data_Fallback
 	ignoreErrors:
 		# Uses func_get_args()
 		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
@@ -34,6 +36,3 @@ parameters:
 		# Passing ints and floats to these functions is fine
 		- '#Parameter \#1 \$text of function esc_(html|attr) expects string, int\|string given#'
 		- '#Parameter \#1 \$text of function esc_(html|attr) expects string, float\|int\|string given#'
-	reportUnmatchedIgnoredErrors: false
-	universalObjectCratesClasses:
-		- QM_Data_Fallback

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,16 +23,14 @@ parameters:
 	universalObjectCratesClasses:
 		- QM_Data_Fallback
 	ignoreErrors:
-		# Uses func_get_args()
-		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
 		# The `wpdb` class exposes its properties via `__get()`
-		- '#Access to protected property wpdb::#'
+		- '#^Access to protected property wpdb::#'
 		# Properties in QM_Data* classes are nullable
-		- '#^Property QM_Data(.*)is not nullable\.$#'
-		# Data providers for acceptance tests:
+		- '#^Property QM_Data\S+ is not nullable\.$#'
+		# Data providers for acceptance tests
 		-
 			path: tests/acceptance/*
-			message: '#^Method [^:]+::data[a-zA-Z]+\(\) is unused\.$#'
+			message: '#^Method \S+::data[a-zA-Z]+\(\) is unused\.$#'
 		# Passing ints and floats to these functions is fine
-		- '#Parameter \#1 \$text of function esc_(html|attr) expects string, int\|string given#'
-		- '#Parameter \#1 \$text of function esc_(html|attr) expects string, float\|int\|string given#'
+		- '#^Parameter \#1 \$text of function (esc_html|esc_attr) expects string, int\|string given#'
+		- '#^Parameter \#1 \$text of function (esc_html|esc_attr) expects string, float\|int\|string given#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,7 +26,7 @@ parameters:
 		# The `wpdb` class exposes its properties via `__get()`
 		- '#^Access to protected property wpdb::#'
 		# Properties in QM_Data* classes are nullable
-		- '#^Property QM_Data\S+ is not nullable\.$#'
+		- '#^Property QM_Data_.+ is not nullable\.$#'
 		# Data providers for acceptance tests
 		-
 			path: tests/acceptance/*


### PR DESCRIPTION
Remove `reportUnmatchedIgnoredErrors: false` and 1 ignored error as the extension can handle `apply_filters`

Plus making regexps more readable.