### PR TITLE
Make docker-compose.yml a regular file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ You can clone this repo and activate it like a normal WordPress plugin, but you'
 * [Composer](https://getcomposer.org/)
 * [Node](https://nodejs.org/)
 
+To run the tests, you'll also need:
+
+* [Docker Desktop](https://www.docker.com/desktop) running Docker Compose version 2.20 or higher
+
 ### Setup
 
 1. Install the PHP dependencies:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,0 @@
-vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3.1'
 
 include:
-  - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
+   -
+     path: vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
+     project_directory: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,2 @@
+include:
+  - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,2 +1,4 @@
+version: '3.1'
+
 include:
   - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.1'
 
 include:
-   -
-     path: vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
-     project_directory: .
+  -
+    path: vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
+    project_directory: .


### PR DESCRIPTION
Symlinks have way more problems than regular files.

- Windows
- editing
- [_please find a third one_](https://docs.docker.com/compose/compose-file/14-include/)