### PR TITLE
Improve check for Debug Bar existence

### DIFF
--- a/collectors/debug_bar.php
+++ b/collectors/debug_bar.php
@@ -66,7 +66,8 @@ function register_qm_collectors_debug_bar() {
 
 	global $debug_bar;
 
-	if ( class_exists( 'Debug_Bar', false ) || qm_debug_bar_being_activated() ) {
+	$debug_bar_exists = isset( $GLOBALS['debug_bar'] ) && $GLOBALS['debug_bar'] instanceof Debug_Bar;
+	if ( $debug_bar_exists || qm_debug_bar_being_activated() ) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #809 

Instead of simply checking if the class exists, this PR changes the code to actually check if the global variable was set and is an instance of the Debug_Bar class.