### PR TITLE
Support and test on the last nine versions of WordPress

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,7 +24,7 @@
 /package-lock.json export-ignore
 /package.json export-ignore
 /phpcs.xml.dist export-ignore
-/phpcs53.xml export-ignore
+/phpcs56.xml export-ignore
 /phpstan.neon.dist export-ignore
 /README.md export-ignore
 /SECURITY.md export-ignore

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -28,23 +28,33 @@ jobs:
   test:
     name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
     strategy:
+      # See the following for PHP Compatibility of WordPress versions:
+      # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
       matrix:
         wp:
+          # Nightly:
           - 'nightly'
+          # Latest three stable:
+          - '6.3'
           - '6.2'
-          - '5.6'
+          - '6.1'
         php:
           - '8.0'
           - '7.4'
         include:
-          - wp: '6.2'
+          # Latest stable on PHP 8.1 and 8.2:
+          - wp: '6.3'
             php: '8.1'
-          - wp: '6.2'
+          - wp: '6.3'
             php: '8.2'
+          # Nightly on PHP 8.1 and 8.2:
           - wp: 'nightly'
             php: '8.1'
           - wp: 'nightly'
             php: '8.2'
+          # Oldest supported on PHP 7.4:
+          - wp: '5.5'
+            php: '7.4'
         dev:
           - ${{ github.ref_name == 'develop' }}
         exclude:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -55,12 +55,6 @@ jobs:
           # Oldest supported on PHP 7.4:
           - wp: '5.5'
             php: '7.4'
-        dev:
-          - ${{ github.ref_name == 'develop' }}
-        exclude:
-          # Only run the nightly tests on the develop branch.
-          - wp: 'nightly'
-            dev: false
       fail-fast: false
     uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@trunk
     with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,15 +29,33 @@ jobs:
     name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
     uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@trunk
     strategy:
+      # See the following for PHP Compatibility of WordPress versions:
+      # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
       matrix:
         wp:
-          - 'latest'
+          # Nightly:
           - 'nightly'
+          # Latest three stable:
+          - '6.3'
+          - '6.2'
+          - '6.1'
         php:
-          - '8.2'
-          - '8.1'
           - '8.0'
           - '7.4'
+        include:
+          # Latest stable on PHP 8.1 and 8.2:
+          - wp: '6.3'
+            php: '8.1'
+          - wp: '6.3'
+            php: '8.2'
+          # Nightly on PHP 8.1 and 8.2:
+          - wp: 'nightly'
+            php: '8.1'
+          - wp: 'nightly'
+            php: '8.2'
+          # Oldest supported on PHP 7.4:
+          - wp: '5.5'
+            php: '7.4'
         dev:
           - ${{ github.ref_name == 'develop' }}
         exclude:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,12 +56,6 @@ jobs:
           # Oldest supported on PHP 7.4:
           - wp: '5.5'
             php: '7.4'
-        dev:
-          - ${{ github.ref_name == 'develop' }}
-        exclude:
-          # Only run the nightly tests on the develop branch.
-          - wp: 'nightly'
-            dev: false
       fail-fast: false
     with:
       wp: ${{ matrix.wp }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ These are the steps to take to release a new version of Query Monitor (for contr
 1. If this is a non-patch release, check issues and PRs assigned to the patch or minor milestones that will get skipped. Reassign as necessary.
 1. Ensure you're on the `develop` branch and all the changes for this release have been merged in.
 1. Ensure both `README.md` and `readme.txt` contain up to date descriptions, "Tested up to" versions, FAQs, screenshots, etc.
+   - Query Monitor supports the last nine versions of WordPress (support for versions up to approximately three years old)
 1. Ensure `.gitattributes` is up to date with all files that shouldn't be part of the build.
    - To do this, run `git archive --output=qm.zip HEAD` then check the contents for files that shouldn't be part of the package.
 1. Run `composer test` and ensure everything passes.

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
 			"integration-tests"
 		],
 		"test:phpcs": [
-			"phpcs -nps --colors --report-code --report-summary --report-width=80 --cache=tests/cache/phpcs53.json --basepath='./' --standard=phpcs53.xml",
+			"phpcs -nps --colors --report-code --report-summary --report-width=80 --cache=tests/cache/phpcs56.json --basepath='./' --standard=phpcs56.xml",
 			"phpcs -nps --colors --report-code --report-summary --report-width=80 --cache=tests/cache/phpcs.json --basepath='./' ."
 		],
 		"test:phpstan": [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -64,7 +64,7 @@
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_supported_version" value="5.3" />
+			<property name="minimum_supported_version" value="5.5" />
 		</properties>
 	</rule>
 

--- a/phpcs56.xml
+++ b/phpcs56.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<ruleset name="Query Monitor PHP 5.3 compatibility">
+<ruleset name="Query Monitor PHP 5.6 compatibility">
 
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<!--
 	Prevent deprecated errors caused by WordPress Coding Standards not supporting PHP 8.0+.
@@ -9,7 +9,7 @@
 	-->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 
-	<!-- These files must remain compatible with PHP 5.3 to prevent an unwanted fatal error -->
+	<!-- These files must remain compatible with PHP 5.6 to prevent an unwanted fatal error -->
 	<file>./classes/PHP.php</file>
 	<file>./query-monitor.php</file>
 	<file>./wp-content/db.php</file>

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 # Query Monitor
 Contributors: johnbillion
 Tags: debug, debug-bar, development, performance, query monitor, rest-api
-Requires at least: 5.3
+Requires at least: 5.5
 Tested up to: 6.3
 Stable tag: 3.13.1
 License: GPLv2 or later
@@ -17,6 +17,8 @@ Query Monitor is the developer tools panel for WordPress. It enables debugging o
 It includes some advanced features such as debugging of Ajax calls, REST API calls, user capability checks, and full support for block themes and full site editing. It includes the ability to narrow down much of its output by plugin or theme, allowing you to quickly determine poorly performing plugins, themes, or functions.
 
 Query Monitor focuses heavily on presenting its information in a useful manner, for example by showing aggregate database queries grouped by the plugins, themes, or functions that are responsible for them. It adds an admin toolbar menu showing an overview of the current page, with complete debugging information shown in panels once you select a menu item.
+
+Query Monitor supports versions of WordPress up to three years old, and PHP version 7.4 or higher.
 
 For complete information, please see [the Query Monitor website](https://querymonitor.com/).
 

--- a/tests/integration/CollectorThemeTest.php
+++ b/tests/integration/CollectorThemeTest.php
@@ -14,15 +14,8 @@ class CollectorThemeTest extends Test {
 
 		self::assertNotFalse( $contents );
 
-		// Pre-5.3 regex:
-		$regex = '#^\s*(?:else)?if\s+\(\s*(is_[a-z0-9_]+)\(\)(?:.*?)get_([a-z0-9_]+)_template\(\)#m';
+		$regex = '#^\s*\'(is_[a-z0-9_]+)\' +=> \'get_([a-z0-9_]+)_template\'#m';
 		$count = preg_match_all( $regex, $contents, $matches );
-
-		if ( ! $count ) {
-			// 5.3+ regex:
-			$regex = '#^\s*\'(is_[a-z0-9_]+)\' +=> \'get_([a-z0-9_]+)_template\'#m';
-			$count = preg_match_all( $regex, $contents, $matches );
-		}
 
 		self::assertGreaterThan( 0, $count );
 


### PR DESCRIPTION
This makes explicit that Query Monitor supports the last nine versions of WordPress which covers versions up to approximately three years old.