### PR TITLE
null on trim

### DIFF
--- a/collectors/raw_request.php
+++ b/collectors/raw_request.php
@@ -70,7 +70,9 @@ class QM_Collector_Raw_Request extends QM_DataCollector {
 		$raw_headers = headers_list();
 		foreach ( $raw_headers as $row ) {
 			list( $key, $value ) = explode( ':', $row, 2 );
-			$headers[ trim( $key ) ] = trim( $value );
+			if ( null !== $key && null !== $value ) {
+				$headers[ trim( $key ) ] = trim( $value );
+			}
 		}
 
 		ksort( $headers );


### PR DESCRIPTION
We have some cases where our pages in wp-admin don't work.

Fatal error: Uncaught Error: trim(): Argument #1 ($string) must be of type string, null given in /var/www/wp-content/mu-plugins/query-monitor/collectors/raw_request.php on line 73