### PR TITLE
Remove non-existent file from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@
 /tests export-ignore
 
 # Files
-/_config.yml export-ignore
 /.gitattributes export-ignore
 /.editorconfig export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
`_config.yml` was moved to a subdirectory.

