### PR TITLE
Ignore wp_safe_redirect in redirects trace

### DIFF
--- a/collectors/redirects.php
+++ b/collectors/redirects.php
@@ -54,6 +54,7 @@ class QM_Collector_Redirects extends QM_DataCollector {
 			),
 			'ignore_func' => array(
 				'wp_redirect' => true,
+				'wp_safe_redirect' => true,
 			),
 		) );
 


### PR DESCRIPTION
Apologies if this was by design but I noticed the redirect trace was stripping the actual wp_redirect call but not wp_safe_redirect