### PR TITLE
Fix Fatal error: Object of class WP_Term could not be converted to string

### DIFF
--- a/collectors/theme.php
+++ b/collectors/theme.php
@@ -102,6 +102,10 @@ class QM_Collector_Theme extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_get_position( $name ) {
+	    	if ( !is_string( $name ) && !is_null( $name ) )  {
+      			return;
+    		}
+		
 		$filter = current_filter();
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(


### PR DESCRIPTION
## Error
`Fatal error: Uncaught Error: Object of class WP_Term could not be converted to string in /query-monitor/collectors/theme.php on line 119`

## Reproduce

1. Define a taxonomy called `sidebar`
2.  `wp/wp-includes/taxonomy.php:1015` executes `$_term = apply_filters( "get_{$taxonomy}", $_term, $taxonomy );`
3.  `web/app/plugins/query-monitor/collectors/theme.php` catches the action `( 'get_sidebar', array( $this, 'action_get_position' ));`
4. and the function `action_get_position` will explode