### PR TITLE
Avoid PHP Warning when there is no queried post object

### DIFF
--- a/collectors/block_editor.php
+++ b/collectors/block_editor.php
@@ -135,7 +135,7 @@ class QM_Collector_Block_Editor extends QM_DataCollector {
 		if ( ! empty( $_wp_current_template_content ) ) {
 			// Full site editor:
 			$content = $_wp_current_template_content;
-		} elseif ( is_singular() ) {
+		} elseif ( is_singular() && ! empty( get_queried_object_id() ) ) {
 			// Post editor:
 			$content = get_post( get_queried_object_id() )->post_content;
 		} else {


### PR DESCRIPTION
I'm encountering situations where I'm seeing the following PHP Warning in my logs:

```
PHP Warning:  Attempt to read property "post_content" on null in /path/to/httpdocs/wp-content/plugins/query-monitor/collectors/block_editor.php on line 150
```

This mostly happens when viewing CiviCRM admin pages... but also elsewhere, though I can't recall where 🙄

Anyway, this PR simply checks that there is a queried object before trying to access the corresponding Post's content.