### PR TITLE
Prevent an infinite loop when logging doing it wrong calls and deprecated calls

### DIFF
--- a/collectors/doing_it_wrong.php
+++ b/collectors/doing_it_wrong.php
@@ -16,6 +16,11 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 
 	public $id = 'doing_it_wrong';
 
+	/**
+	 * @var bool
+	 */
+	private $collecting = false;
+
 	public function get_storage(): QM_Data {
 		return new QM_Data_Doing_It_Wrong();
 	}
@@ -112,6 +117,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_doing_it_wrong_run( $function_name, $message, $version ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -135,6 +146,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 				$version
 			),
 		);
+
+		$this->collecting = false;
 	}
 
 	/**
@@ -144,6 +157,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_deprecated_function_run( $function_name, $replacement, $version ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -173,6 +192,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			'component'      => $trace->get_component(),
 			'message'        => $message,
 		);
+
+		$this->collecting = false;
 	}
 
 	/**
@@ -182,6 +203,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_deprecated_constructor_run( $class_name, $version, $parent_class ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -213,6 +240,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			'component'      => $trace->get_component(),
 			'message'        => $message,
 		);
+
+		$this->collecting = false;
 	}
 
 	/**
@@ -223,6 +252,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_deprecated_file_included( $file, $replacement, $version, $message ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -254,6 +289,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			'component'      => $trace->get_component(),
 			'message'        => $message,
 		);
+
+		$this->collecting = false;
 	}
 
 	/**
@@ -263,6 +300,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_deprecated_argument_run( $function_name, $message, $version ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -292,6 +335,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			'component'      => $trace->get_component(),
 			'message'        => $message,
 		);
+
+		$this->collecting = false;
 	}
 
 	/**
@@ -302,6 +347,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 	 * @return void
 	 */
 	public function action_deprecated_hook_run( $hook, $replacement, $version, $message ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
 		$trace = new QM_Backtrace( array(
 			'ignore_hook' => array(
 				current_action() => true,
@@ -333,6 +384,8 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			'component'      => $trace->get_component(),
 			'message'        => $message,
 		);
+
+		$this->collecting = false;
 	}
 
 }


### PR DESCRIPTION
Fixes #840 