### PR TITLE
Remove a global from query-monitor.php

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -38,22 +38,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'QM_VERSION', '3.16.0' );
 
-$qm_dir = dirname( __FILE__ );
-
 // This must be required before vendor/autoload.php so QM can serve its own message about PHP compatibility.
-require_once "{$qm_dir}/classes/PHP.php";
+require_once __DIR__ . '/classes/PHP.php';
 
 if ( ! QM_PHP::version_met() ) {
 	add_action( 'all_admin_notices', 'QM_PHP::php_version_nope' );
 	return;
 }
 
-if ( ! file_exists( "{$qm_dir}/vendor/autoload.php" ) ) {
+if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	add_action( 'all_admin_notices', 'QM_PHP::vendor_nope' );
 	return;
 }
 
-require_once "{$qm_dir}/vendor/autoload.php";
+require_once __DIR__ . '/vendor/autoload.php';
 
 // Safety check to ensure the autoloader is operational.
 if ( ! class_exists( 'QM_Activation' ) ) {
@@ -95,7 +93,5 @@ if ( is_admin() ) {
 		return;
 	}
 }
-
-unset( $qm_dir );
 
 QueryMonitor::init( __FILE__ )->set_up();


### PR DESCRIPTION
`__DIR__` is available in PHP 7.4.
