### PR TITLE
Add id attribute to qm-title-heading select

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -436,7 +436,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '<div id="qm-title" class="qm-resizer">';
 		echo '<h1 class="qm-title-heading">' . esc_html__( 'Query Monitor', 'query-monitor' ) . '</h1>';
 		echo '<div class="qm-title-heading">';
-		echo '<select>';
+		echo '<select id="qm-title-heading-select">';
 
 		printf(
 			'<option value="%1$s">%2$s</option>',


### PR DESCRIPTION
Fix for Chrome issue: A form field element has neither an id nor a name attribute.

Actually there has no form, but Chrome marks it as issue in Developer console:

![image](https://github.com/user-attachments/assets/5f07d35a-cc16-4f58-a090-035d0835eef4)
