### PR TITLE
check if rows are countable

### DIFF
--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -228,7 +228,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 			'is_main_query' => true,
 		) );
 
-		$this->data->total_qs = count( $this->data->rows );
+		$this->data->total_qs = is_countable( $this->data->rows ) ? count( $this->data->rows ) : 0;
 		$this->data->total_time = $total_time;
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;


### PR DESCRIPTION
fatal errors catching this can be null sometimes, add is_countable check to prevent fatals.