### PR TITLE
Switch to using `wp_print_inline_script_tag()` for inline scripts

### DIFF
--- a/classes/debug_bar.php
+++ b/classes/debug_bar.php
@@ -60,11 +60,12 @@ class Debug_Bar {
 		$dispatcher = QM_Dispatchers::get( 'html' );
 
 		if ( $this->panels && $dispatcher && $dispatcher::user_can_view() ) {
-			?>
-			<script type="text/javascript">
-			var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-			</script>
-			<?php
+			wp_print_inline_script_tag(
+				sprintf(
+					"var ajaxurl = '%s';",
+					esc_url_raw( admin_url( 'admin-ajax.php' ) )
+				)
+			);
 		}
 	}
 

--- a/classes/debug_bar.php
+++ b/classes/debug_bar.php
@@ -64,6 +64,9 @@ class Debug_Bar {
 				sprintf(
 					"var ajaxurl = '%s';",
 					esc_url_raw( admin_url( 'admin-ajax.php' ) )
+				),
+				array(
+					'id' => 'query-monitor-inline-debug-bar',
 				)
 			);
 		}

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -303,9 +303,12 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			);
 
 			echo '<!-- Begin Query Monitor output -->' . "\n\n";
-			echo '<script type="text/javascript">' . "\n\n";
-			echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
-			echo '</script>' . "\n\n";
+			wp_print_inline_script_tag(
+				sprintf(
+					'var qm = %s;',
+					wp_json_encode( $json )
+				)
+			);
 			echo '<div id="query-monitor-ceased"></div>';
 			echo '<!-- End Query Monitor output -->' . "\n\n";
 			return;
@@ -406,9 +409,12 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		);
 
 		echo '<!-- Begin Query Monitor output -->' . "\n\n";
-		echo '<script type="text/javascript">' . "\n\n";
-		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
-		echo '</script>' . "\n\n";
+		wp_print_inline_script_tag(
+			sprintf(
+				'var qm = %s;',
+				wp_json_encode( $json )
+			)
+		);
 
 		echo '<svg id="qm-icon-container">';
 		foreach ( (array) glob( $this->qm->plugin_path( 'assets/icons/*.svg' ) ) as $icon ) {
@@ -734,8 +740,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '</div>'; // #qm-wrapper
 		echo '</div>'; // #query-monitor-main
 
-		echo '<script type="text/javascript">' . "\n\n";
-		?>
+		wp_print_inline_script_tag( <<<JS
 		window.addEventListener('load', function() {
 			var main = document.getElementById( 'query-monitor-main' );
 			var broken = document.getElementById( 'qm-broken' );
@@ -772,8 +777,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 				main.className += ' qm-peek';
 			}
 		} );
-		<?php
-		echo '</script>' . "\n\n";
+		JS );
 		echo '<!-- End Query Monitor output -->' . "\n\n";
 
 	}

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -307,6 +307,9 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 				sprintf(
 					'var qm = %s;',
 					wp_json_encode( $json )
+				),
+				array(
+					'id' => 'query-monitor-inline-data',
 				)
 			);
 			echo '<div id="query-monitor-ceased"></div>';
@@ -413,6 +416,9 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			sprintf(
 				'var qm = %s;',
 				wp_json_encode( $json )
+			),
+			array(
+				'id' => 'query-monitor-inline-data',
 			)
 		);
 
@@ -739,6 +745,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '</div>'; // #qm-panels
 		echo '</div>'; // #qm-wrapper
 		echo '</div>'; // #query-monitor-main
+		echo "\n\n";
 
 		wp_print_inline_script_tag( <<<JS
 		window.addEventListener('load', function() {
@@ -777,7 +784,11 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 				main.className += ' qm-peek';
 			}
 		} );
-		JS );
+		JS,
+			array(
+				'id' => 'query-monitor-inline-worst-case',
+			)
+		);
 		echo '<!-- End Query Monitor output -->' . "\n\n";
 
 	}


### PR DESCRIPTION
This wasn't nearly as much work as I thought it might be.

Fixes #906.