### PR TITLE
Error handler chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /assets/*.css
 /assets/*.map
 /composer.lock

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -216,11 +216,13 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		}
 
 		if ( null === $type ) {
-			return false;
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+			return $this->fallback_error_handler( func_get_args() );
 		}
 
 		if ( ! class_exists( 'QM_Backtrace' ) ) {
-			return false;
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+			return $this->fallback_error_handler( func_get_args() );
 		}
 
 		$error_group = 'errors';
@@ -245,7 +247,14 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		// Intentionally skip reporting these core warnings. They're a distraction when developing offline.
 		// The failed HTTP request will still appear in QM's output so it's not a big problem hiding these warnings.
 		if ( false !== strpos( $message, self::$unexpected_error ) ) {
-			return false;
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+			return $this->fallback_error_handler( func_get_args() );
+		}
+
+		// If the fallback error handler returns true, the error was suppressed.
+		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+		if ( $this->fallback_error_handler( func_get_args() ) ) {
+			return true;
 		}
 
 		$trace = new QM_Backtrace();
@@ -287,6 +296,21 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 		 */
 		return apply_filters( 'qm/collect/php_errors_return_value', false );
 
+	}
+
+	/**
+	 * Fallback error handler.
+	 *
+	 * @param array $args Arguments.
+	 *
+	 * @return bool
+	 * @noinspection PhpTernaryExpressionCanBeReplacedWithConditionInspection
+	 */
+	private function fallback_error_handler( array $args ): bool {
+		return null === $this->previous_error_handler ?
+			// Use standard error handler.
+			false :
+			(bool) call_user_func_array( $this->previous_error_handler, $args );
 	}
 
 	/**

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -301,7 +301,7 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 	/**
 	 * Fallback error handler.
 	 *
-	 * @param array $args Arguments.
+	 * @param array<int, string, string, int> $args Arguments.
 	 *
 	 * @return bool
 	 * @noinspection PhpTernaryExpressionCanBeReplacedWithConditionInspection

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -301,7 +301,7 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 	/**
 	 * Fallback error handler.
 	 *
-	 * @param array<int, string, string, int> $args Arguments.
+	 * @param mixed[] $args Arguments.
 	 *
 	 * @return bool
 	 * @noinspection PhpTernaryExpressionCanBeReplacedWithConditionInspection


### PR DESCRIPTION
## Description

This PR correctly supports the PHP error handler chain.

When the previous error handler is not null, the QM error handler should call it accordingly to make the chain work. In my plugin [KAGG Compatibility](https://github.com/kagg-design/kagg-compatibility), the PHP error handler is set in the mu-plugin created at the plugin activation. Even though QM is loaded as the first plugin, the previous handler already exists.

I implemented a similar error handler in the WPForms Development plugin and, partially, in the [WPForms](https://wordpress.org/plugins/wpforms-lite/) plugin. In the presence of QM, I am setting my error handler again on the `plugin_loaded` hook and making the QM error handler work as a fallback.

An error handler in the mu-plugin aimed to suppress annoying deprecated errors by PHP 8.0+ in different plugins or libraries. Letting the previous handler do its work and showing only meaningful errors in the QM would be good.

## Testing steps

1. Use PHP 8.4.
2. Activate QM from develop.
3. Install and activate Elementor.
4. See a bunch of deprecated errors in the QM console.
5. Install and activate the KAGG Compatibility plugin (can be found on [wp.org](https://wordpress.org/plugins/kagg-compatibility/)).
6. Check that `kagg-compatibility-error-handler.php` is added to the `mu-plugins` folder.
7. See that Elementor errors are gone from the QM console. This is due to the second error handler added after QM loading.
8. In the `kagg-compatibility-error-handler.php` comment out the line `add_action( 'plugin_loaded', [ $this, 'plugin_loaded' ], 500 )`.
9. See that Elementor deprecated errors create significant noise in the QM console again.
10. Switch to the current branch.
11. See that Elementor deprecated errors are gone.

