### PR TITLE
Move the fatal error handling to the dispatchers

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -51,6 +51,10 @@ abstract class QM_Dispatcher {
 	 */
 	abstract public function is_active();
 
+	public function output_fatal( $message, array $e ): void {
+		print_r( $e );
+	}
+
 	/**
 	 * @return bool
 	 */

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -302,7 +302,16 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 	 * @return void
 	 */
 	protected function output_fatal( $error, array $e ) {
-		$dispatcher = QM_Dispatchers::get( 'html' );
+		$is_rest_request = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
+		$is_ajax_request = ( defined( 'DOING_AJAX' ) && DOING_AJAX );
+
+		if ( $is_rest_request ) {
+			$dispatcher = QM_Dispatchers::get( 'rest' );
+		} elseif ( $is_ajax_request ) {
+			$dispatcher = QM_Dispatchers::get( 'ajax' );
+		} else {
+			$dispatcher = QM_Dispatchers::get( 'html' );
+		}
 
 		if ( empty( $dispatcher ) ) {
 			return;
@@ -312,91 +321,19 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 			return;
 		}
 
-		// This hides the subsequent message from the fatal error handler in core. It cannot be
-		// disabled by a plugin so we'll just hide its output.
-		echo '<style type="text/css"> .wp-die-message { display: none; } </style>';
-
-		printf(
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-			'<link rel="stylesheet" href="%1$s?ver=%2$s" media="all" />',
-			esc_url( QueryMonitor::init()->plugin_url( 'assets/query-monitor.css' ) ),
-			esc_attr( QM_VERSION )
-		);
-
-		// This unused wrapper with an attribute serves to help the #qm-fatal div break out of an
-		// attribute if a fatal has occurred within one.
-		echo '<div data-qm="qm">';
-
-		printf(
-			'<div id="qm-fatal" data-qm-message="%1$s" data-qm-file="%2$s" data-qm-line="%3$d">',
-			esc_attr( $e['message'] ),
-			esc_attr( QM_Util::standard_dir( $e['file'], '' ) ),
-			intval( $e['line'] )
-		);
-
-		echo '<div class="qm-fatal-wrap">';
-
-		if ( QM_Output_Html::has_clickable_links() ) {
-			$file = QM_Output_Html::output_filename( $e['file'], $e['file'], $e['line'], true );
-		} else {
-			$file = esc_html( $e['file'] );
+		if ( ! headers_sent() ) {
+			status_header( 500 );
 		}
 
-		printf(
-			'<p><b>%1$s</b>: %2$s<br>in <b>%3$s</b> on line <b>%4$d</b></p>',
-			esc_html( $error ),
-			nl2br( esc_html( $e['message'] ), false ),
-			$file,
-			intval( $e['line'] )
-		); // WPCS: XSS ok.
+		$message = sprintf(
+			'%s in %s on line %d',
+			$e['message'],
+			$e['file'],
+			$e['line']
+		);
 
-		if ( ! empty( $e['trace'] ) ) {
-			echo '<p>Call stack:</p>';
-			echo '<ol>';
-			foreach ( $e['trace'] as $frame ) {
-				$callback = QM_Util::populate_callback( $frame );
-
-				if ( ! isset( $callback['name'] ) ) {
-					continue;
-				}
-
-				$args = array_map( function( $value ) {
-					$type = gettype( $value );
-
-					switch ( $type ) {
-						case 'object':
-							return get_class( $value );
-						case 'boolean':
-							return $value ? 'true' : 'false';
-						case 'integer':
-						case 'double':
-							return $value;
-						case 'string':
-							if ( strlen( $value ) > 50 ) {
-								return "'" . substr( $value, 0, 20 ) . '...' . substr( $value, -20 ) . "'";
-							}
-							return "'" . $value . "'";
-					}
-
-					return $type;
-				}, $frame['args'] ?? array() );
-
-				$name = str_replace( '()', '(' . implode( ', ', $args ) . ')', $callback['name'] );
-
-				printf(
-					'<li>%s</li>',
-					QM_Output_Html::output_filename( $name, $frame['file'], $frame['line'] )
-				); // WPCS: XSS ok.
-			}
-			echo '</ol>';
-		}
-
-		echo '</div>';
-
-		echo '<h2>Query Monitor</h2>';
-
-		echo '</div>';
-		echo '</div>';
+		$dispatcher->output_fatal( $message, $e );
+		exit;
 	}
 
 	/**

--- a/dispatchers/AJAX.php
+++ b/dispatchers/AJAX.php
@@ -112,6 +112,32 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 
 	}
 
+	/**
+	 * @param string $message
+	 * @param mixed[] $e
+	 * @phpstan-param array{
+	 *   message: string,
+	 *   file: string,
+	 *   line: int,
+	 *   type?: int,
+	 *   trace?: mixed|null,
+	 * } $e
+	 */
+	public function output_fatal( $message, array $e ): void {
+		if ( ! headers_sent() ) {
+			header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
+		}
+
+		// @TODO
+		echo wp_json_encode(
+			array(
+				'code' => 'qm_fatal',
+				'message' => $message,
+				'data' => $e,
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+	}
 }
 
 /**

--- a/dispatchers/REST.php
+++ b/dispatchers/REST.php
@@ -78,6 +78,31 @@ class QM_Dispatcher_REST extends QM_Dispatcher {
 
 	}
 
+	/**
+	 * @param string $message
+	 * @param mixed[] $e
+	 * @phpstan-param array{
+	 *   message: string,
+	 *   file: string,
+	 *   line: int,
+	 *   type?: int,
+	 *   trace?: mixed|null,
+	 * } $e
+	 */
+	public function output_fatal( $message, array $e ): void {
+		if ( ! headers_sent() ) {
+			header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
+		}
+
+		echo wp_json_encode(
+			array(
+				'code' => 'qm_fatal',
+				'message' => $message,
+				'data' => $e,
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
When a fatal error occurs during a REST API or Ajax request, the fatal error handler still outputs HTML. This fixes that by using the relevant dispatchers to output the fatal in an appropriate format.