### PR TITLE
Defer translation loading

### DIFF
--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -214,7 +214,7 @@ class QM_Backtrace {
 			$component = self::get_frame_component( $frame );
 
 			if ( $component ) {
-				if ( 'plugin' === $component->type ) {
+				if ( $component->is_plugin() ) {
 					// If the component is a plugin then it can't be anything else,
 					// so short-circuit and return early.
 					$this->component = $component;
@@ -226,7 +226,7 @@ class QM_Backtrace {
 		}
 
 		$file_dirs = QM_Util::get_file_dirs();
-		$file_dirs['dropin'] = WP_CONTENT_DIR;
+		$file_dirs[ QM_Component::TYPE_DROPIN ] = WP_CONTENT_DIR;
 
 		foreach ( $file_dirs as $type => $dir ) {
 			if ( isset( $components[ $type ] ) ) {
@@ -235,12 +235,7 @@ class QM_Backtrace {
 			}
 		}
 
-		$component = new QM_Component();
-		$component->type = 'unknown';
-		$component->name = __( 'Unknown', 'query-monitor' );
-		$component->context = 'unknown';
-
-		return $component;
+		return QM_Component::from( QM_Component::TYPE_UNKNOWN, 'unknown' );
 	}
 
 	/**

--- a/classes/Backtrace.php
+++ b/classes/Backtrace.php
@@ -303,9 +303,12 @@ class QM_Backtrace {
 	/**
 	 * @return array<int, array<string, mixed>>
 	 * @phpstan-return list<array{
+	 *   id: string,
+	 *   display: string,
+	 *   calling_file: string,
+	 *   calling_line: int,
 	 *   file: string,
 	 *   line: int,
-	 *   display: string,
 	 * }>
 	 */
 	public function get_filtered_trace() {

--- a/classes/Collector.php
+++ b/classes/Collector.php
@@ -83,20 +83,22 @@ abstract class QM_Collector {
 	 * @return void
 	 */
 	protected function log_component( $component, $ltime, $type ) {
-		if ( ! isset( $this->data->component_times[ $component->name ] ) ) {
-			$this->data->component_times[ $component->name ] = array(
-				'component' => $component->name,
+		$key = $component->get_id();
+
+		if ( ! isset( $this->data->component_times[ $key ] ) ) {
+			$this->data->component_times[ $key ] = array(
+				'component' => $component,
 				'ltime' => 0,
 				'types' => array(),
 			);
 		}
 
-		$this->data->component_times[ $component->name ]['ltime'] += $ltime;
+		$this->data->component_times[ $key ]['ltime'] += $ltime;
 
-		if ( isset( $this->data->component_times[ $component->name ]['types'][ $type ] ) ) {
-			$this->data->component_times[ $component->name ]['types'][ $type ]++;
+		if ( isset( $this->data->component_times[ $key ]['types'][ $type ] ) ) {
+			$this->data->component_times[ $key ]['types'][ $type ]++;
 		} else {
-			$this->data->component_times[ $component->name ]['types'][ $type ] = 1;
+			$this->data->component_times[ $key ]['types'][ $type ] = 1;
 		}
 
 	}

--- a/classes/Component.php
+++ b/classes/Component.php
@@ -40,8 +40,14 @@ class QM_Component implements JsonSerializable {
 	 */
 	public $context;
 
-	public function __construct( string $context, string $type = '' ) {
+	/**
+	 * @var string
+	 */
+	public $file;
+
+	public function __construct( string $context, string $file = '', string $type = '' ) {
 		$this->context = $context;
+		$this->file = $file;
 		$this->type = $type;
 	}
 
@@ -81,39 +87,37 @@ class QM_Component implements JsonSerializable {
 		return false;
 	}
 
-	final public static function from( string $type, string $context = '' ): QM_Component {
+	final public static function from( string $type, string $context = '', string $file = '' ): QM_Component {
 		switch ( $type ) {
 			case self::TYPE_ALTIS_VENDOR:
-				return new QM_Component_Altis_Vendor( $context, $type );
+				return new QM_Component_Altis_Vendor( $context, $file, $type );
 			case self::TYPE_PLUGIN:
-				return new QM_Component_Plugin( $context, $type );
+				return new QM_Component_Plugin( $context, $file, $type );
 			case self::TYPE_MU_PLUGIN:
-				return new QM_Component_MU_Plugin( $context, $type );
+				return new QM_Component_MU_Plugin( $context, $file, $type );
 			case self::TYPE_MU_VENDOR:
-				return new QM_Component_MU_Vendor( $context, $type );
+				return new QM_Component_MU_Vendor( $context, $file, $type );
 			case self::TYPE_GO_PLUGIN:
-				return new QM_Component_Go_Plugin( $context, $type );
+				return new QM_Component_Go_Plugin( $context, $file, $type );
 			case self::TYPE_VIP_PLUGIN:
-				return new QM_Component_VIP_Plugin( $context, $type );
+				return new QM_Component_VIP_Plugin( $context, $file, $type );
 			case self::TYPE_VIP_CLIENT_MU_PLUGIN:
-				return new QM_Component_VIP_Client_MU_Plugin( $context, $type );
+				return new QM_Component_VIP_Client_MU_Plugin( $context, $file, $type );
 			case self::TYPE_STYLESHEET:
-				return new QM_Component_Stylesheet( $context, $type );
+				return new QM_Component_Stylesheet( $context, $file, $type );
 			case self::TYPE_TEMPLATE:
-				return new QM_Component_Template( $context, $type );
+				return new QM_Component_Template( $context, $file, $type );
 			case self::TYPE_OTHER:
-				return new QM_Component_Other( $context, $type );
+				return new QM_Component_Other( $context, $file, $type );
 			case self::TYPE_CORE:
-				return new QM_Component_Core( $context, $type );
+				return new QM_Component_Core( $context, $file, $type );
 			case self::TYPE_DROPIN:
-				return new QM_Component_Dropin( $context, $type );
-			case self::TYPE_UNKNOWN:
-				return new QM_Component_Unknown( $context, $type );
+				return new QM_Component_Dropin( $context, $file, $type );
 			case self::TYPE_PHP:
-				return new QM_Component_PHP( $context, $type );
+				return new QM_Component_PHP( $context, $file, $type );
 		}
 
-		return new QM_Component( $context, $type );
+		return new QM_Component_Unknown( $context, $file, $type );
 	}
 
 	/**

--- a/classes/Component.php
+++ b/classes/Component.php
@@ -5,7 +5,31 @@
  * @package query-monitor
  */
 
-class QM_Component {
+/**
+ * @phpstan-type QM_Component_Array array{
+ *   type: string,
+ *   name: string,
+ *   context: string,
+ * }
+ * @property-read string $name
+ */
+class QM_Component implements JsonSerializable {
+	public const TYPE_ALTIS_VENDOR = 'altis-vendor';
+	public const TYPE_CORE = 'core';
+	public const TYPE_DROPIN = 'dropin';
+	public const TYPE_GO_PLUGIN = 'go-plugin';
+	public const TYPE_MU_PLUGIN = 'mu-plugin';
+	public const TYPE_MU_VENDOR = 'mu-vendor';
+	public const TYPE_OTHER = 'other';
+	public const TYPE_PHP = 'php';
+	public const TYPE_PLUGIN = 'plugin';
+	public const TYPE_STYLESHEET = 'stylesheet';
+	public const TYPE_TEMPLATE = 'template';
+	public const TYPE_THEME = 'theme';
+	public const TYPE_UNKNOWN = 'unknown';
+	public const TYPE_VIP_CLIENT_MU_PLUGIN = 'vip-client-mu-plugin';
+	public const TYPE_VIP_PLUGIN = 'vip-plugin';
+
 	/**
 	 * @var string
 	 */
@@ -14,10 +38,109 @@ class QM_Component {
 	/**
 	 * @var string
 	 */
-	public $name;
+	public $context;
+
+	public function __construct( string $context, string $type = '' ) {
+		$this->context = $context;
+		$this->type = $type;
+	}
+
+	public function get_name(): string {
+		if ( isset( $this->name ) ) {
+			return $this->name;
+		}
+
+		return sprintf(
+			$this->type,
+			$this->context
+		);
+	}
+
+	final public function get_id(): string {
+		return "{$this->type}-{$this->context}";
+	}
+
+	final public function is_plugin(): bool {
+		return ( $this->type === self::TYPE_PLUGIN );
+	}
+
+	final public function is_core(): bool {
+		return ( $this->type === self::TYPE_CORE );
+	}
 
 	/**
-	 * @var string
+	 * @param QM_Component[] $components
 	 */
-	public $context;
+	final public static function has_non_core( array $components ): bool {
+		foreach ( $components as $component ) {
+			if ( ! $component->is_core() ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	final public static function from( string $type, string $context = '' ): QM_Component {
+		switch ( $type ) {
+			case self::TYPE_ALTIS_VENDOR:
+				return new QM_Component_Altis_Vendor( $context, $type );
+			case self::TYPE_PLUGIN:
+				return new QM_Component_Plugin( $context, $type );
+			case self::TYPE_MU_PLUGIN:
+				return new QM_Component_MU_Plugin( $context, $type );
+			case self::TYPE_MU_VENDOR:
+				return new QM_Component_MU_Vendor( $context, $type );
+			case self::TYPE_GO_PLUGIN:
+				return new QM_Component_Go_Plugin( $context, $type );
+			case self::TYPE_VIP_PLUGIN:
+				return new QM_Component_VIP_Plugin( $context, $type );
+			case self::TYPE_VIP_CLIENT_MU_PLUGIN:
+				return new QM_Component_VIP_Client_MU_Plugin( $context, $type );
+			case self::TYPE_STYLESHEET:
+				return new QM_Component_Stylesheet( $context, $type );
+			case self::TYPE_TEMPLATE:
+				return new QM_Component_Template( $context, $type );
+			case self::TYPE_OTHER:
+				return new QM_Component_Other( $context, $type );
+			case self::TYPE_CORE:
+				return new QM_Component_Core( $context, $type );
+			case self::TYPE_DROPIN:
+				return new QM_Component_Dropin( $context, $type );
+			case self::TYPE_UNKNOWN:
+				return new QM_Component_Unknown( $context, $type );
+			case self::TYPE_PHP:
+				return new QM_Component_PHP( $context, $type );
+		}
+
+		return new QM_Component( $context, $type );
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function __get( string $key ) {
+		if ( 'name' === $key ) {
+			return $this->get_name();
+		}
+	}
+
+	/**
+	 * @phpstan-return QM_Component_Array
+	 * @return array<string, string>
+	 */
+	public function toArray(): array {
+		return array(
+			'type' => $this->type,
+			'name' => $this->name,
+			'context' => $this->context,
+		);
+	}
+	/**
+	 * @phpstan-return QM_Component_Array
+	 * @return array<string, string>
+	 */
+	public function jsonSerialize(): array {
+		return $this->toArray();
+	}
 }

--- a/classes/Component.php
+++ b/classes/Component.php
@@ -147,4 +147,8 @@ class QM_Component implements JsonSerializable {
 	public function jsonSerialize(): array {
 		return $this->toArray();
 	}
+
+	public static function sort( QM_Component $a, QM_Component $b ): int {
+		return strcasecmp( $a->get_name(), $b->get_name() );
+	}
 }

--- a/classes/Component_Altis_Vendor.php
+++ b/classes/Component_Altis_Vendor.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing an Altis vendor dependency component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Altis_Vendor extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Dependency name */
+			__( 'Dependency: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_Core.php
+++ b/classes/Component_Core.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing the WordPress core component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Core extends QM_Component {
+	public function get_name(): string {
+		return __( 'WordPress Core', 'query-monitor' );
+	}
+}

--- a/classes/Component_Dropin.php
+++ b/classes/Component_Dropin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a drop-in plugin component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Dropin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Drop-in plugin file name */
+			__( 'Drop-in: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_Go_Plugin.php
+++ b/classes/Component_Go_Plugin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a VIP Go mu-plugins/shared-plugins component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Go_Plugin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'VIP Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_MU_Plugin.php
+++ b/classes/Component_MU_Plugin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a mu-plugin component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_MU_Plugin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'MU Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_MU_Vendor.php
+++ b/classes/Component_MU_Vendor.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a mu-plugins/vendor dependency.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_MU_Vendor extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'MU Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_Other.php
+++ b/classes/Component_Other.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing any other known component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Other extends QM_Component {
+}

--- a/classes/Component_PHP.php
+++ b/classes/Component_PHP.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a PHP component.
+ *
+ * @package query-monitor
+ */
+
+final class QM_Component_PHP extends QM_Component {
+	public function get_name(): string {
+		return 'PHP';
+	}
+}

--- a/classes/Component_Plugin.php
+++ b/classes/Component_Plugin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a plugin component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Plugin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_Stylesheet.php
+++ b/classes/Component_Stylesheet.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a theme stylesheet component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Stylesheet extends QM_Component {
+	public function get_name(): string {
+		if ( is_child_theme() ) {
+			return __( 'Child Theme', 'query-monitor' );
+		}
+
+		return __( 'Theme', 'query-monitor' );
+	}
+}

--- a/classes/Component_Template.php
+++ b/classes/Component_Template.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a theme template (parent theme) component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_Template extends QM_Component {
+	public function get_name(): string {
+		return __( 'Parent Theme', 'query-monitor' );
+	}
+}

--- a/classes/Component_Unknown.php
+++ b/classes/Component_Unknown.php
@@ -7,7 +7,27 @@
 
 final class QM_Component_Unknown extends QM_Component {
 	public function get_name(): string {
-		// @TODO this needs the filter logic
-		return __( 'Unknown', 'query-monitor' );
+		$name = __( 'Unknown', 'query-monitor' );
+		$type = $this->type;
+
+		/**
+		 * Filters the user-facing name to display for a custom or unknown component.
+		 *
+		 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
+		 *
+		 * See also the corresponding filters:
+		 *
+		 *  - `qm/component_dirs`
+		 *  - `qm/component_type/{$type}`
+		 *  - `qm/component_context/{$type}`
+		 *
+		 * @since 3.6.0
+		 *
+		 * @param string $name The component name.
+		 * @param string $file The full file path for the file within the component.
+		 */
+		$name = apply_filters( "qm/component_name/{$type}", $name, $this->file );
+
+		return $name;
 	}
 }

--- a/classes/Component_Unknown.php
+++ b/classes/Component_Unknown.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing an unknown component.
+ *
+ * @package query-monitor
+ */
+
+final class QM_Component_Unknown extends QM_Component {
+	public function get_name(): string {
+		// @TODO this needs the filter logic
+		return __( 'Unknown', 'query-monitor' );
+	}
+}

--- a/classes/Component_VIP_Client_MU_Plugin.php
+++ b/classes/Component_VIP_Client_MU_Plugin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a VIP client mu-plugin component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_VIP_Client_MU_Plugin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'VIP Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Component_VIP_Plugin.php
+++ b/classes/Component_VIP_Plugin.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a VIP plugin component.
+ *
+ * @package query-monitor
+ */
+
+class QM_Component_VIP_Plugin extends QM_Component {
+	public function get_name(): string {
+		return sprintf(
+			/* translators: %s: Plugin name */
+			__( 'VIP Plugin: %s', 'query-monitor' ),
+			$this->context
+		);
+	}
+}

--- a/classes/Data.php
+++ b/classes/Data.php
@@ -16,7 +16,7 @@ abstract class QM_Data implements \ArrayAccess {
 	/**
 	 * @var array<string, array<string, mixed>>
 	 * @phpstan-var array<string, array{
-	 *   component: string,
+	 *   component: QM_Component,
 	 *   ltime: float,
 	 *   types: array<array-key, int>,
 	 * }>

--- a/classes/Deprecated_Argument_Run.php
+++ b/classes/Deprecated_Argument_Run.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated argument being used.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   function_name: string,
+ *   message: string,
+ *   version: string,
+ * }>
+ */
+final class QM_Deprecated_Argument_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'function_name' => $function_name,
+			'message' => $message,
+			'version' => $version,
+		] = $this->args;
+
+		if ( $message ) {
+			return sprintf(
+				/* translators: 1: PHP function name, 2: Version number, 3: Optional message regarding the change. */
+				__( 'Function %1$s was called with an argument that is deprecated since version %2$s! %3$s', 'query-monitor' ),
+				$function_name,
+				$version,
+				$message
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: PHP function name, 2: Version number. */
+			__( 'Function %1$s was called with an argument that is deprecated since version %2$s with no alternative available.', 'query-monitor' ),
+			$function_name,
+			$version
+		);
+	}
+}

--- a/classes/Deprecated_Class_Run.php
+++ b/classes/Deprecated_Class_Run.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated class being used.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   class_name: string,
+ *   replacement: string,
+ *   version: string,
+ * }>
+ */
+final class QM_Deprecated_Class_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'class_name' => $class_name,
+			'replacement' => $replacement,
+			'version' => $version,
+		] = $this->args;
+
+		if ( $replacement ) {
+			return sprintf(
+				/* translators: 1: PHP class name, 2: Version number, 3: Alternative class or function name. */
+				__( 'Class %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'query-monitor' ),
+				$class_name,
+				$version,
+				$replacement
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: PHP class name, 2: Version number. */
+			__( 'Class %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'query-monitor' ),
+			$class_name,
+			$version
+		);
+	}
+}

--- a/classes/Deprecated_Class_Run.php
+++ b/classes/Deprecated_Class_Run.php
@@ -23,7 +23,7 @@ final class QM_Deprecated_Class_Run extends QM_Wrong {
 		if ( $replacement ) {
 			return sprintf(
 				/* translators: 1: PHP class name, 2: Version number, 3: Alternative class or function name. */
-				__( 'Class %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'query-monitor' ),
+				__( 'Class %1$s is deprecated since version %2$s! Use %3$s instead.', 'query-monitor' ),
 				$class_name,
 				$version,
 				$replacement
@@ -32,7 +32,7 @@ final class QM_Deprecated_Class_Run extends QM_Wrong {
 
 		return sprintf(
 			/* translators: 1: PHP class name, 2: Version number. */
-			__( 'Class %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'query-monitor' ),
+			__( 'Class %1$s is deprecated since version %2$s with no alternative available.', 'query-monitor' ),
 			$class_name,
 			$version
 		);

--- a/classes/Deprecated_Constructor_Run.php
+++ b/classes/Deprecated_Constructor_Run.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated constructor run.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   class_name: string,
+ *   parent_class: string,
+ *   version: string,
+ * }>
+ */
+final class QM_Deprecated_Constructor_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'class_name' => $class_name,
+			'parent_class' => $parent_class,
+			'version' => $version,
+		] = $this->args;
+
+		if ( $parent_class ) {
+			return sprintf(
+				/* translators: 1: PHP class name, 2: PHP parent class name, 3: Version number, 4: __construct() method. */
+				__( 'The called constructor method for %1$s class in %2$s is deprecated since version %3$s! Use %4$s instead.', 'query-monitor' ),
+				$class_name,
+				$parent_class,
+				$version,
+				'<code>__construct()</code>'
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: PHP class name, 2: Version number, 3: __construct() method. */
+			__( 'The called constructor method for %1$s class is deprecated since version %2$s! Use %3$s instead.', 'query-monitor' ),
+			$class_name,
+			$version,
+			'<code>__construct()</code>'
+		);
+	}
+}

--- a/classes/Deprecated_File_Included.php
+++ b/classes/Deprecated_File_Included.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated file being included.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   file: string,
+ *   replacement: string,
+ *   version: string,
+ *   message: string,
+ * }>
+ */
+final class QM_Deprecated_File_Included extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'file' => $file,
+			'replacement' => $replacement,
+			'version' => $version,
+			'message' => $message,
+		] = $this->args;
+
+		if ( $replacement ) {
+			return sprintf(
+				/* translators: 1: PHP file name, 2: Version number, 3: Alternative file name, 4: Optional message regarding the change. */
+				__( 'File %1$s is deprecated since version %2$s! Use %3$s instead. %4$s', 'query-monitor' ),
+				$file,
+				$version,
+				$replacement,
+				$message
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: PHP file name, 2: Version number, 3: Optional message regarding the change. */
+			__( 'File %1$s is deprecated since version %2$s with no alternative available. %3$s', 'query-monitor' ),
+			$file,
+			$version,
+			$message
+		);
+	}
+}

--- a/classes/Deprecated_Function_Run.php
+++ b/classes/Deprecated_Function_Run.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated function run.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   function_name: string,
+ *   version: string,
+ *   replacement: string,
+ * }>
+ */
+final class QM_Deprecated_Function_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'function_name' => $function_name,
+			'version' => $version,
+			'replacement' => $replacement,
+		] = $this->args;
+
+		if ( $replacement ) {
+			return sprintf(
+				/* translators: 1: PHP function name, 2: Version number, 3: Alternative function name. */
+				__( 'Function %1$s is deprecated since version %2$s! Use %3$s instead.', 'query-monitor' ),
+				$function_name,
+				$version,
+				$replacement
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: PHP function name, 2: Version number. */
+			__( 'Function %1$s is deprecated since version %2$s with no alternative available.', 'query-monitor' ),
+			$function_name,
+			$version
+		);
+	}
+}

--- a/classes/Deprecated_Hook_Run.php
+++ b/classes/Deprecated_Hook_Run.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a deprecated hook being used.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   hook: string,
+ *   replacement: string,
+ *   version: string,
+ *   message: string,
+ * }>
+ */
+final class QM_Deprecated_Hook_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'hook' => $hook,
+			'replacement' => $replacement,
+			'version' => $version,
+			'message' => $message,
+		] = $this->args;
+
+		if ( $replacement ) {
+			return sprintf(
+				/* translators: 1: WordPress hook name, 2: Version number, 3: Alternative hook name, 4: Optional message regarding the change. */
+				__( 'Hook %1$s is deprecated since version %2$s! Use %3$s instead. %4$s', 'query-monitor' ),
+				$hook,
+				$version,
+				$replacement,
+				$message
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: WordPress hook name, 2: Version number, 3: Optional message regarding the change. */
+			__( 'Hook %1$s is deprecated since version %2$s with no alternative available. %3$s', 'query-monitor' ),
+			$hook,
+			$version,
+			$message
+		);
+	}
+}

--- a/classes/Doing_It_Wrong_Run.php
+++ b/classes/Doing_It_Wrong_Run.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing a doing it wrong run.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @extends QM_Wrong<array{
+ *   function_name: string,
+ *   message: string,
+ *   version: string,
+ * }>
+ */
+final class QM_Doing_It_Wrong_Run extends QM_Wrong {
+	public function get_message(): string {
+		[
+			'function_name' => $function_name,
+			'message' => $message,
+			'version' => $version,
+		] = $this->args;
+
+		if ( $version ) {
+			$version = sprintf(
+				/* translators: %s: Version number. */
+				__( '(This message was added in version %s.)', 'query-monitor' ),
+				$version
+			);
+		}
+
+		return sprintf(
+			/* translators: Developer debugging message. 1: PHP function name, 2: Explanatory message, 3: WordPress version number. */
+			__( 'Function %1$s was called incorrectly. %2$s %3$s', 'query-monitor' ),
+			$function_name,
+			$message,
+			$version
+		);
+	}
+}

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -23,7 +23,7 @@ class QM_Hook {
 	 *     callback: array<string, mixed>,
 	 *   }>,
 	 *   parts: list<string>,
-	 *   components: array<string, string>,
+	 *   components: array<string, QM_Component>,
 	 * }
 	 */
 	public static function process( $name, string $type, array $wp_filter, $hide_qm = false, $hide_core = false ) {
@@ -50,7 +50,7 @@ class QM_Hook {
 							continue;
 						}
 
-						$components[ $callback['component']->name ] = $callback['component']->name;
+						$components[ $callback['component']->get_id() ] = $callback['component'];
 					}
 
 					$actions[] = array(

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -218,6 +218,26 @@ class QM_Util {
 				$name = str_replace( dirname( self::$file_dirs[ QM_Component::TYPE_OTHER ] ), '', $name );
 				$parts = explode( '/', trim( $name, '/' ) );
 				$context = $parts[0] . '/' . $parts[1];
+
+				// Now detect specific drop-in plugins:
+				if ( ! function_exists( '_get_dropins' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				}
+
+				/** @var array<int, string> $dropins */
+				$dropins = array_keys( _get_dropins() );
+
+				foreach ( $dropins as $dropin ) {
+					$dropin_path = WP_CONTENT_DIR . $dropin;
+
+					if ( $file !== $dropin_path ) {
+						continue;
+					}
+
+					$type = QM_Component::TYPE_DROPIN;
+					$context = pathinfo( $dropin, PATHINFO_BASENAME );
+				}
+
 				break;
 			case QM_Component::TYPE_UNKNOWN:
 			default:
@@ -281,27 +301,6 @@ class QM_Util {
 				break;
 		}
 
-		if ( QM_Component::TYPE_OTHER === $type ) {
-			if ( ! function_exists( '_get_dropins' ) ) {
-				require_once trailingslashit( constant( 'ABSPATH' ) ) . 'wp-admin/includes/plugin.php';
-			}
-
-			/** @var array<int, string> $dropins */
-			$dropins = array_keys( _get_dropins() );
-
-			foreach ( $dropins as $dropin ) {
-				$dropin_path = trailingslashit( constant( 'WP_CONTENT_DIR' ) ) . $dropin;
-
-				if ( $file !== $dropin_path ) {
-					continue;
-				}
-
-				$type = QM_Component::TYPE_DROPIN; // !
-				$context = pathinfo( $dropin, PATHINFO_BASENAME );
-			}
-		}
-
-		self::$file_components[ $file ] = QM_Component::from( $type, $context );
 
 		return self::$file_components[ $file ];
 	}

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -259,29 +259,11 @@ class QM_Util {
 				 * @param string $name    The component name.
 				 * @param string $context The context for the component.
 				 */
-				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $name, $context );
-
-				/**
-				 * Filters the name of a custom or unknown component.
-				 *
-				 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
-				 *
-				 * See also the corresponding filters:
-				 *
-				 *  - `qm/component_dirs`
-				 *  - `qm/component_type/{$type}`
-				 *  - `qm/component_context/{$type}`
-				 *
-				 * @since 3.6.0
-				 *
-				 * @param string $name The component name.
-				 * @param string $file The full file path for the file within the component.
-				 */
-				$name = apply_filters( "qm/component_name/{$type}", $name, $file );
+				$type = apply_filters( "qm/component_type/{$type}", $type, $file, $file, $context );
 
 				/**
 				 * Filters the context for a custom or unknown component. The context is usually a
-				 * representation of its type more specific to the individual component.
+				 * representation specific to the individual component, for example the file base name.
 				 *
 				 * The dynamic portion of the hook name, `$type`, refers to the component identifier.
 				 *
@@ -297,10 +279,11 @@ class QM_Util {
 				 * @param string $file    The full file path for the file within the component.
 				 * @param string $name    The component name.
 				 */
-				$context = apply_filters( "qm/component_context/{$type}", $context, $file, $name );
+				$context = apply_filters( "qm/component_context/{$type}", $context, $file, $file );
 				break;
 		}
 
+		self::$file_components[ $file ] = QM_Component::from( $type, $context, $file );
 
 		return self::$file_components[ $file ];
 	}

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -117,26 +117,26 @@ class QM_Util {
 			 */
 			self::$file_dirs = apply_filters( 'qm/component_dirs', self::$file_dirs );
 
-			self::$file_dirs['plugin'] = WP_PLUGIN_DIR;
-			self::$file_dirs['mu-vendor'] = WPMU_PLUGIN_DIR . '/vendor';
-			self::$file_dirs['go-plugin'] = WPMU_PLUGIN_DIR . '/shared-plugins';
-			self::$file_dirs['mu-plugin'] = WPMU_PLUGIN_DIR;
-			self::$file_dirs['vip-plugin'] = get_theme_root() . '/vip/plugins';
+			self::$file_dirs[ QM_Component::TYPE_PLUGIN ] = WP_PLUGIN_DIR;
+			self::$file_dirs[ QM_Component::TYPE_MU_VENDOR ] = WPMU_PLUGIN_DIR . '/vendor';
+			self::$file_dirs[ QM_Component::TYPE_GO_PLUGIN ] = WPMU_PLUGIN_DIR . '/shared-plugins';
+			self::$file_dirs[ QM_Component::TYPE_MU_PLUGIN ] = WPMU_PLUGIN_DIR;
+			self::$file_dirs[ QM_Component::TYPE_VIP_PLUGIN ] = get_theme_root() . '/vip/plugins';
 
 			if ( defined( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR' ) ) {
-				self::$file_dirs['vip-client-mu-plugin'] = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR;
+				self::$file_dirs[ QM_Component::TYPE_VIP_CLIENT_MU_PLUGIN ] = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR;
 			}
 
 			if ( defined( '\Altis\ROOT_DIR' ) ) {
-				self::$file_dirs['altis-vendor'] = \Altis\ROOT_DIR . '/vendor';
+				self::$file_dirs[ QM_Component::TYPE_ALTIS_VENDOR ] = \Altis\ROOT_DIR . '/vendor';
 			}
 
-			self::$file_dirs['theme'] = null;
-			self::$file_dirs['stylesheet'] = get_stylesheet_directory();
-			self::$file_dirs['template'] = get_template_directory();
-			self::$file_dirs['other'] = WP_CONTENT_DIR;
-			self::$file_dirs['core'] = ABSPATH;
-			self::$file_dirs['unknown'] = null;
+			self::$file_dirs[ QM_Component::TYPE_THEME ] = null;
+			self::$file_dirs[ QM_Component::TYPE_STYLESHEET ] = get_stylesheet_directory();
+			self::$file_dirs[ QM_Component::TYPE_TEMPLATE ] = get_template_directory();
+			self::$file_dirs[ QM_Component::TYPE_OTHER ] = WP_CONTENT_DIR;
+			self::$file_dirs[ QM_Component::TYPE_CORE ] = ABSPATH;
+			self::$file_dirs[ QM_Component::TYPE_UNKNOWN ] = null;
 
 			foreach ( self::$file_dirs as $type => $dir ) {
 				if ( null === $dir ) {
@@ -174,16 +174,15 @@ class QM_Util {
 		$context = $type;
 
 		switch ( $type ) {
-			case 'altis-vendor':
+			case QM_Component::TYPE_ALTIS_VENDOR:
 				$plug = str_replace( \Altis\ROOT_DIR . '/vendor/', '', $file );
 				$plug = explode( '/', $plug, 3 );
 				$plug = $plug[0] . '/' . $plug[1];
-				/* translators: %s: Dependency name */
-				$name = sprintf( __( 'Dependency: %s', 'query-monitor' ), $plug );
+				$context = $plug;
 				break;
-			case 'plugin':
-			case 'mu-plugin':
-			case 'mu-vendor':
+			case QM_Component::TYPE_PLUGIN:
+			case QM_Component::TYPE_MU_PLUGIN:
+			case QM_Component::TYPE_MU_VENDOR:
 				$plug = str_replace( '/vendor/', '/', $file );
 				$plug = plugin_basename( $plug );
 				if ( strpos( $plug, '/' ) ) {
@@ -192,18 +191,11 @@ class QM_Util {
 				} else {
 					$plug = basename( $plug );
 				}
-				if ( 'plugin' !== $type ) {
-					/* translators: %s: Plugin name */
-					$name = sprintf( __( 'MU Plugin: %s', 'query-monitor' ), $plug );
-				} else {
-					/* translators: %s: Plugin name */
-					$name = sprintf( __( 'Plugin: %s', 'query-monitor' ), $plug );
-				}
 				$context = $plug;
 				break;
-			case 'go-plugin':
-			case 'vip-plugin':
-			case 'vip-client-mu-plugin':
+			case QM_Component::TYPE_GO_PLUGIN:
+			case QM_Component::TYPE_VIP_PLUGIN:
+			case QM_Component::TYPE_VIP_CLIENT_MU_PLUGIN:
 				$plug = str_replace( self::$file_dirs[ $type ], '', $file );
 				$plug = trim( $plug, '/' );
 				if ( strpos( $plug, '/' ) ) {
@@ -212,28 +204,15 @@ class QM_Util {
 				} else {
 					$plug = basename( $plug );
 				}
-				if ( 'vip-client-mu-plugin' === $type ) {
-					/* translators: %s: Plugin name */
-					$name = sprintf( __( 'VIP Client MU Plugin: %s', 'query-monitor' ), $plug );
-				} else {
-					/* translators: %s: Plugin name */
-					$name = sprintf( __( 'VIP Plugin: %s', 'query-monitor' ), $plug );
-				}
 				$context = $plug;
 				break;
-			case 'stylesheet':
-				if ( is_child_theme() ) {
-					$name = __( 'Child Theme', 'query-monitor' );
-				} else {
-					$name = __( 'Theme', 'query-monitor' );
-				}
-				$type = 'theme';
+			case QM_Component::TYPE_STYLESHEET:
+				// Nothing
 				break;
-			case 'template':
-				$name = __( 'Parent Theme', 'query-monitor' );
-				$type = 'theme';
+			case QM_Component::TYPE_TEMPLATE:
+				// Nothing.
 				break;
-			case 'other':
+			case QM_Component::TYPE_OTHER:
 				// Anything else that's within the content directory should appear as
 				// `wp-content/{dir}` or `wp-content/{file}`
 				$name = self::standard_dir( $file );
@@ -242,13 +221,11 @@ class QM_Util {
 				$name = $parts[0] . '/' . $parts[1];
 				$context = $file;
 				break;
-			case 'core':
-				$name = __( 'WordPress Core', 'query-monitor' );
+			case QM_Component::TYPE_CORE:
+				// Nothing.
 				break;
-			case 'unknown':
+			case QM_Component::TYPE_UNKNOWN:
 			default:
-				$name = __( 'Unknown', 'query-monitor' );
-
 				/**
 				 * Filters the type of a custom or unknown component.
 				 *
@@ -309,7 +286,7 @@ class QM_Util {
 				break;
 		}
 
-		if ( 'other' === $type ) {
+		if ( QM_Component::TYPE_OTHER === $type ) {
 			if ( ! function_exists( '_get_dropins' ) ) {
 				require_once trailingslashit( constant( 'ABSPATH' ) ) . 'wp-admin/includes/plugin.php';
 			}
@@ -324,18 +301,12 @@ class QM_Util {
 					continue;
 				}
 
-				$type = 'dropin';
-				/* translators: %s: Drop-in plugin file name */
-				$name = sprintf( __( 'Drop-in: %s', 'query-monitor' ), pathinfo( $dropin, PATHINFO_BASENAME ) );
+				$type = QM_Component::TYPE_DROPIN; // !
+				$context = pathinfo( $dropin, PATHINFO_BASENAME );
 			}
 		}
 
-		$component = new QM_Component();
-		$component->type = $type;
-		$component->name = $name;
-		$component->context = $context;
-
-		self::$file_components[ $file ] = $component;
+		self::$file_components[ $file ] = QM_Component::from( $type, $context );
 
 		return self::$file_components[ $file ];
 	}
@@ -432,10 +403,7 @@ class QM_Util {
 			if ( ! empty( $callback['file'] ) ) {
 				$callback['component'] = self::get_file_component( $callback['file'] );
 			} else {
-				$callback['component'] = new QM_Component();
-				$callback['component']->type = 'php';
-				$callback['component']->name = 'PHP';
-				$callback['component']->context = '';
+				$callback['component'] = QM_Component::from( QM_Component::TYPE_PHP, 'php' );
 			}
 		} catch ( ReflectionException $e ) {
 

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -207,9 +207,8 @@ class QM_Util {
 				$context = $plug;
 				break;
 			case QM_Component::TYPE_STYLESHEET:
-				// Nothing
-				break;
 			case QM_Component::TYPE_TEMPLATE:
+			case QM_Component::TYPE_CORE:
 				// Nothing.
 				break;
 			case QM_Component::TYPE_OTHER:
@@ -219,9 +218,6 @@ class QM_Util {
 				$name = str_replace( dirname( self::$file_dirs[ QM_Component::TYPE_OTHER ] ), '', $name );
 				$parts = explode( '/', trim( $name, '/' ) );
 				$context = $parts[0] . '/' . $parts[1];
-				break;
-			case QM_Component::TYPE_CORE:
-				// Nothing.
 				break;
 			case QM_Component::TYPE_UNKNOWN:
 			default:

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -216,10 +216,9 @@ class QM_Util {
 				// Anything else that's within the content directory should appear as
 				// `wp-content/{dir}` or `wp-content/{file}`
 				$name = self::standard_dir( $file );
-				$name = str_replace( dirname( self::$file_dirs['other'] ), '', $name );
+				$name = str_replace( dirname( self::$file_dirs[ QM_Component::TYPE_OTHER ] ), '', $name );
 				$parts = explode( '/', trim( $name, '/' ) );
-				$name = $parts[0] . '/' . $parts[1];
-				$context = $file;
+				$context = $parts[0] . '/' . $parts[1];
 				break;
 			case QM_Component::TYPE_CORE:
 				// Nothing.

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -300,6 +300,9 @@ class QM_Util {
 	 *   line?: string|false,
 	 *   error?: WP_Error,
 	 *   component?: QM_Component,
+	 *   callback_type: string,
+	 *   start_line?: int,
+	 *   display_file?: string,
 	 * }
 	 */
 	public static function populate_callback( array $callback ) {
@@ -321,9 +324,11 @@ class QM_Util {
 				if ( is_object( $callback['function'][0] ) ) {
 					$class = get_class( $callback['function'][0] );
 					$access = '->';
+					$callback['callback_type'] = 'method';
 				} else {
 					$class = $callback['function'][0];
 					$access = '::';
+					$callback['callback_type'] = 'static_method';
 				}
 
 				$callback['name'] = self::shorten_fqn( $class . $access . $callback['function'][1] ) . '()';
@@ -338,46 +343,35 @@ class QM_Util {
 						if ( 0 === strpos( $file, '/' ) ) {
 							$file = basename( $filename );
 						}
-						$callback['name'] = sprintf(
-							/* translators: A closure is an anonymous PHP function. 1: Line number, 2: File name */
-							__( 'Closure on line %1$d of %2$s', 'query-monitor' ),
-							$ref->getStartLine(),
-							$file
-						);
+						$callback['callback_type'] = 'closure';
+						$callback['start_line'] = $ref->getStartLine();
+						$callback['display_file'] = $file;
 					} else {
-						/* translators: A closure is an anonymous PHP function */
-						$callback['name'] = __( 'Unknown closure', 'query-monitor' );
+						$callback['callback_type'] = 'unknown_closure';
 					}
 				} else {
 					// the object should have a __invoke() method
 					$class = get_class( $callback['function'] );
 					$callback['name'] = self::shorten_fqn( $class ) . '->__invoke()';
+					$callback['callback_type'] = 'invokable';
 					$ref = new ReflectionMethod( $class, '__invoke' );
 				}
 			} else {
 				$callback['name'] = self::shorten_fqn( $callback['function'] ) . '()';
+				$callback['callback_type'] = 'function';
 				$ref = new ReflectionFunction( $callback['function'] );
 			}
 
 			$callback['file'] = $ref->getFileName();
 			$callback['line'] = $ref->getStartLine();
 
-			// https://github.com/facebook/hhvm/issues/5856
+			// Handle legacy create_function() lambdas (PHP 7.4 only, removed in PHP 8.0)
 			$name = trim( $ref->getName() );
-
-			if ( '__lambda_func' === $name || 0 === strpos( $name, 'lambda_' ) ) {
-				if ( $callback['file'] && preg_match( '|(?P<file>.*)\((?P<line>[0-9]+)\)|', $callback['file'], $matches ) ) {
-					$callback['file'] = $matches['file'];
-					$callback['line'] = $matches['line'];
-					$file = trim( self::standard_dir( $callback['file'], '' ), '/' );
-					/* translators: 1: Line number, 2: File name */
-					$callback['name'] = sprintf( __( 'Anonymous function on line %1$d of %2$s', 'query-monitor' ), $callback['line'], $file );
-				} else {
-					// https://github.com/facebook/hhvm/issues/5807
-					unset( $callback['line'], $callback['file'] );
-					$callback['name'] = $name . '()';
-					$callback['error'] = new WP_Error( 'unknown_lambda', __( 'Unable to determine source of lambda function', 'query-monitor' ) );
-				}
+			if ( 0 === strpos( $name, 'lambda_' ) ) {
+				// Just use the lambda name as-is, these are from deprecated create_function()
+				$callback['name'] = $name . '()';
+				$callback['callback_type'] = 'lambda';
+				unset( $callback['file'], $callback['line'] );
 			}
 
 			if ( ! empty( $callback['file'] ) ) {
@@ -388,6 +382,7 @@ class QM_Util {
 		} catch ( ReflectionException $e ) {
 
 			$callback['error'] = new WP_Error( 'reflection_exception', $e->getMessage() );
+			$callback['callback_type'] = 'unknown';
 
 		}
 
@@ -395,6 +390,45 @@ class QM_Util {
 
 		return $callback;
 
+	}
+
+	/**
+	 * Generate the translated callback name from callback properties.
+	 *
+	 * @param array<string, mixed> $callback Callback data array.
+	 * @return string Translated callback name.
+	 */
+	public static function get_callback_name( array $callback ) {
+		if ( isset( $callback['name'] ) ) {
+			return $callback['name'];
+		}
+
+		if ( ! isset( $callback['callback_type'] ) ) {
+			return '';
+		}
+
+		switch ( $callback['callback_type'] ) {
+			case 'closure':
+				return sprintf(
+					/* translators: A closure is an anonymous PHP function. 1: Line number, 2: File name */
+					__( 'Closure on line %1$d of %2$s', 'query-monitor' ),
+					$callback['start_line'],
+					$callback['display_file']
+				);
+
+			case 'unknown_closure':
+				/* translators: A closure is an anonymous PHP function */
+				return __( 'Unknown closure', 'query-monitor' );
+
+			case 'function':
+			case 'method':
+			case 'static_method':
+			case 'invokable':
+			case 'lambda':
+			case 'unknown':
+			default:
+				return $callback['name'] ?? '';
+		}
 	}
 
 	/**

--- a/classes/Wrong.php
+++ b/classes/Wrong.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+/**
+ * Class representing something that's kind of wrong.
+ *
+ * @package query-monitor
+ */
+
+/**
+ * @template TArgs of array
+ */
+abstract class QM_Wrong implements JsonSerializable {
+	private QM_Backtrace $backtrace;
+
+	/**
+	 * @phpstan-var TArgs $args
+	 */
+	protected array $args;
+
+	/**
+	 * @phpstan-param TArgs $args
+	 */
+	public function __construct( QM_Backtrace $backtrace, array $args = [] ) {
+		$this->backtrace = $backtrace;
+		$this->args = $args;
+	}
+
+	abstract public function get_message(): string;
+
+	final public function get_trace(): QM_Backtrace {
+		return $this->backtrace;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return [];
+	}
+}

--- a/collectors/caps.php
+++ b/collectors/caps.php
@@ -259,7 +259,7 @@ class QM_Collector_Caps extends QM_DataCollector {
 
 			$all_parts = array_merge( $all_parts, $parts );
 			$all_users[] = (int) $user_id;
-			$components[ $component->name ] = $component->name;
+			$components[ $component->get_id() ] = $component;
 		}
 
 		$this->data->parts = array_values( array_unique( array_filter( $all_parts ) ) );

--- a/collectors/doing_it_wrong.php
+++ b/collectors/doing_it_wrong.php
@@ -37,6 +37,7 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		add_action( 'deprecated_file_included', array( $this, 'action_deprecated_file_included' ), 10, 4 );
 		add_action( 'deprecated_argument_run', array( $this, 'action_deprecated_argument_run' ), 10, 3 );
 		add_action( 'deprecated_hook_run', array( $this, 'action_deprecated_hook_run' ), 10, 4 );
+		add_action( 'deprecated_class_run', array( $this, 'action_deprecated_class_run' ), 10, 3 );
 
 		add_filter( 'deprecated_function_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		add_filter( 'deprecated_constructor_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
@@ -44,6 +45,7 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		add_filter( 'deprecated_argument_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		add_filter( 'deprecated_hook_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		add_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		add_filter( 'deprecated_class_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 	}
 
 	/**
@@ -56,6 +58,7 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		remove_action( 'deprecated_file_included', array( $this, 'action_deprecated_file_included' ) );
 		remove_action( 'deprecated_argument_run', array( $this, 'action_deprecated_argument_run' ) );
 		remove_action( 'deprecated_hook_run', array( $this, 'action_deprecated_hook_run' ) );
+		remove_action( 'deprecated_class_run', array( $this, 'action_deprecated_class_run' ) );
 
 		remove_filter( 'deprecated_function_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		remove_filter( 'deprecated_constructor_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
@@ -63,6 +66,7 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		remove_filter( 'deprecated_argument_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		remove_filter( 'deprecated_hook_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		remove_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'deprecated_class_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 
 		parent::tear_down();
 	}
@@ -299,6 +303,36 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		$this->collecting = false;
 	}
 
+	/**
+	 * @param string $class_name
+	 * @param string $replacement
+	 * @param string $version
+	 * @return void
+	 */
+	public function action_deprecated_class_run( $class_name, $replacement, $version ) {
+		if ( $this->collecting ) {
+			return;
+		}
+
+		$this->collecting = true;
+
+		$trace = new QM_Backtrace( array(
+			'ignore_hook' => array(
+				current_action() => true,
+			),
+		) );
+
+		$this->data->actions[] = new QM_Deprecated_Class_Run(
+			$trace,
+			[
+				'class_name'  => $class_name,
+				'replacement' => $replacement,
+				'version'     => $version,
+			]
+		);
+
+		$this->collecting = false;
+	}
 }
 
 # Load early to catch early actions

--- a/collectors/doing_it_wrong.php
+++ b/collectors/doing_it_wrong.php
@@ -43,7 +43,7 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		add_filter( 'deprecated_file_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		add_filter( 'deprecated_argument_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 		add_filter( 'deprecated_hook_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
-		add_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_doing_it_wrong_error' ), 999, 4 );
+		add_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 	}
 
 	/**
@@ -59,12 +59,12 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		remove_action( 'deprecated_argument_run', array( $this, 'action_deprecated_argument_run' ) );
 		remove_action( 'deprecated_hook_run', array( $this, 'action_deprecated_hook_run' ) );
 
-		remove_filter( 'deprecated_function_trigger_error', array( $this, 'maybe_prevent_error' ) );
-		remove_filter( 'deprecated_constructor_trigger_error', array( $this, 'maybe_prevent_error' ) );
-		remove_filter( 'deprecated_file_trigger_error', array( $this, 'maybe_prevent_error' ) );
-		remove_filter( 'deprecated_argument_trigger_error', array( $this, 'maybe_prevent_error' ) );
-		remove_filter( 'deprecated_hook_trigger_error', array( $this, 'maybe_prevent_error' ) );
-		remove_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_doing_it_wrong_error' ), 999 );
+		remove_filter( 'deprecated_function_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'deprecated_constructor_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'deprecated_file_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'deprecated_argument_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'deprecated_hook_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
+		remove_filter( 'doing_it_wrong_trigger_error', array( $this, 'maybe_prevent_error' ), 999 );
 	}
 
 	/**
@@ -80,25 +80,6 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 		}
 
 		return $trigger;
-	}
-
-	/**
-	 * Prevents the doing_it_wrong error from being triggered for doing it wrong calls when the
-	 * current user can view Query Monitor output.
-	 *
-	 * @param bool|mixed $trigger Whether to trigger the error for _doing_it_wrong() calls. Default true.
-	 * @param string $function_name The function that was called.
-	 * @param string $message A message explaining what has been done incorrectly.
-	 * @param string $version The version of WordPress where the message was added.
-	 *
-	 * @return bool
-	 */
-	public function maybe_prevent_doing_it_wrong_error( $trigger, $function_name, $message, $version ) {
-		if ( function_exists( 'wp_get_current_user' ) && current_user_can( 'view_query_monitor' ) ) {
-			return false;
-		}
-
-		return $this->is_just_in_time_for_qm_domain( $function_name, $message ) ? false : $trigger;
 	}
 
 	/**
@@ -140,10 +121,6 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			return;
 		}
 
-		if ( $this->is_just_in_time_for_qm_domain( $function_name, $message ) ) {
-			return;
-		}
-
 		$this->collecting = true;
 
 		$trace = new QM_Backtrace( array(
@@ -152,22 +129,13 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		if ( $version ) {
-			/* translators: %s: Version number. */
-			$version = sprintf( __( '(This message was added in version %s.)', 'query-monitor' ), $version );
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'doing_it_wrong_run',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => sprintf(
-				/* translators: Developer debugging message. 1: PHP function name, 2: Explanatory message, 3: WordPress version number. */
-				__( 'Function %1$s was called incorrectly. %2$s %3$s', 'query-monitor' ),
-				$function_name,
-				$message,
-				$version
-			),
+		$this->data->actions[] = new QM_Doing_It_Wrong_Run(
+			$trace,
+			[
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			]
 		);
 
 		$this->collecting = false;
@@ -192,28 +160,13 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		$message = sprintf(
-			/* translators: 1: PHP function name, 2: Version number. */
-			__( 'Function %1$s is deprecated since version %2$s with no alternative available.', 'query-monitor' ),
-			$function_name,
-			$version
-		);
-
-		if ( $replacement ) {
-			$message = sprintf(
-				/* translators: 1: PHP function name, 2: Version number, 3: Alternative function name. */
-				__( 'Function %1$s is deprecated since version %2$s! Use %3$s instead.', 'query-monitor' ),
-				$function_name,
-				$version,
-				$replacement
-			);
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'deprecated_function_run',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => $message,
+		$this->data->actions[] = new QM_Deprecated_Function_Run(
+			$trace,
+			[
+				'function_name' => $function_name,
+				'replacement'   => $replacement,
+				'version'       => $version,
+			]
 		);
 
 		$this->collecting = false;
@@ -238,30 +191,13 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		$message = sprintf(
-			/* translators: 1: PHP class name, 2: Version number, 3: __construct() method. */
-			__( 'The called constructor method for %1$s class is deprecated since version %2$s! Use %3$s instead.', 'query-monitor' ),
-			$class_name,
-			$version,
-			'<code>__construct()</code>'
-		);
-
-		if ( $parent_class ) {
-			$message = sprintf(
-				/* translators: 1: PHP class name, 2: PHP parent class name, 3: Version number, 4: __construct() method. */
-				__( 'The called constructor method for %1$s class in %2$s is deprecated since version %3$s! Use %4$s instead.', 'query-monitor' ),
-				$class_name,
-				$parent_class,
-				$version,
-				'<code>__construct()</code>'
-			);
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'deprecated_constructor_run',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => $message,
+		$this->data->actions[] = new QM_Deprecated_Constructor_Run(
+			$trace,
+			[
+				'class_name'   => $class_name,
+				'parent_class' => $parent_class,
+				'version'      => $version,
+			]
 		);
 
 		$this->collecting = false;
@@ -287,30 +223,14 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		if ( $replacement ) {
-			$message = sprintf(
-				/* translators: 1: PHP file name, 2: Version number, 3: Alternative file name, 4: Optional message regarding the change. */
-				__( 'File %1$s is deprecated since version %2$s! Use %3$s instead. %4$s', 'query-monitor' ),
-				$file,
-				$version,
-				$replacement,
-				$message
-			);
-		} else {
-			$message = sprintf(
-				/* translators: 1: PHP file name, 2: Version number, 3: Optional message regarding the change. */
-				__( 'File %1$s is deprecated since version %2$s with no alternative available. %3$s', 'query-monitor' ),
-				$file,
-				$version,
-				$message
-			);
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'deprecated_file_included',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => $message,
+		$this->data->actions[] = new QM_Deprecated_File_Included(
+			$trace,
+			[
+				'file'        => $file,
+				'replacement' => $replacement,
+				'version'     => $version,
+				'message'     => $message,
+			]
 		);
 
 		$this->collecting = false;
@@ -335,30 +255,14 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		if ( $message ) {
-			$message = sprintf(
-				/* translators: 1: PHP function name, 2: Version number, 3: Optional message regarding the change. */
-				__( 'Function %1$s was called with an argument that is deprecated since version %2$s! %3$s', 'query-monitor' ),
-				$function_name,
-				$version,
-				$message
-			);
-		} else {
-			$message = sprintf(
-				/* translators: 1: PHP function name, 2: Version number. */
-				__( 'Function %1$s was called with an argument that is deprecated since version %2$s with no alternative available.', 'query-monitor' ),
-				$function_name,
-				$version
-			);
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'deprecated_argument_run',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => $message,
+		$this->data->actions[] = new QM_Deprecated_Argument_Run(
+			$trace,
+			[
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			]
 		);
-
 		$this->collecting = false;
 	}
 
@@ -382,45 +286,17 @@ class QM_Collector_Doing_It_Wrong extends QM_DataCollector {
 			),
 		) );
 
-		if ( $replacement ) {
-			$message = sprintf(
-				/* translators: 1: WordPress hook name, 2: Version number, 3: Alternative hook name, 4: Optional message regarding the change. */
-				__( 'Hook %1$s is deprecated since version %2$s! Use %3$s instead. %4$s', 'query-monitor' ),
-				$hook,
-				$version,
-				$replacement,
-				$message
-			);
-		} else {
-			$message = sprintf(
-				/* translators: 1: WordPress hook name, 2: Version number, 3: Optional message regarding the change. */
-				__( 'Hook %1$s is deprecated since version %2$s with no alternative available. %3$s', 'query-monitor' ),
-				$hook,
-				$version,
-				$message
-			);
-		}
-
-		$this->data->actions[] = array(
-			'hook'           => 'deprecated_hook_run',
-			'filtered_trace' => $trace->get_filtered_trace(),
-			'component'      => $trace->get_component(),
-			'message'        => $message,
+		$this->data->actions[] = new QM_Deprecated_Hook_Run(
+			$trace,
+			[
+				'hook'        => $hook,
+				'replacement' => $replacement,
+				'version'     => $version,
+				'message'     => $message,
+			]
 		);
 
 		$this->collecting = false;
-	}
-
-	/**
-	 * Whether it is the just_in_time_error for the QM domains.
-	 *
-	 * @param string $function_name Function name.
-	 * @param string $message       Message.
-	 *
-	 * @return bool
-	 */
-	protected function is_just_in_time_for_qm_domain( string $function_name, string $message ): bool {
-		return $function_name === '_load_textdomain_just_in_time' && strpos( $message, '<code>query-monitor' ) !== false;
 	}
 
 }

--- a/collectors/environment.php
+++ b/collectors/environment.php
@@ -267,21 +267,7 @@ class QM_Collector_Environment extends QM_DataCollector {
 	 * @return string
 	 */
 	protected static function get_server_version( wpdb $db ) {
-		$version = null;
-
-		if ( method_exists( $db, 'db_server_info' ) ) {
-			$version = $db->db_server_info();
-		}
-
-		if ( ! $version ) {
-			$version = $db->get_var( 'SELECT VERSION()' );
-		}
-
-		if ( ! $version ) {
-			$version = __( 'Unknown', 'query-monitor' );
-		}
-
-		return $version;
+		return $db->db_server_info();
 	}
 
 	/**

--- a/collectors/hooks.php
+++ b/collectors/hooks.php
@@ -79,7 +79,7 @@ class QM_Collector_Hooks extends QM_DataCollector {
 		$this->data->components = $components;
 
 		usort( $this->data->parts, 'strcasecmp' );
-		// usort( $this->data->components, 'strcasecmp' );
+		usort( $this->data->components, '\QM_Component::sort' );
 	}
 
 }

--- a/collectors/hooks.php
+++ b/collectors/hooks.php
@@ -76,10 +76,10 @@ class QM_Collector_Hooks extends QM_DataCollector {
 
 		$this->data->hooks = $hooks;
 		$this->data->parts = array_unique( array_filter( $all_parts ) );
-		$this->data->components = array_unique( array_filter( $components ) );
+		$this->data->components = $components;
 
 		usort( $this->data->parts, 'strcasecmp' );
-		usort( $this->data->components, 'strcasecmp' );
+		// usort( $this->data->components, 'strcasecmp' );
 	}
 
 }

--- a/collectors/http.php
+++ b/collectors/http.php
@@ -287,11 +287,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 			/** @var string */
 			$original_key = $args['_qm_original_key'];
 			$this->http_responses[ $original_key ]['end'] = $this->http_requests[ $original_key ]['start'];
-			$this->http_responses[ $original_key ]['response'] = new WP_Error( 'http_request_not_executed', sprintf(
-				/* translators: %s: Hook name */
-				__( 'Request not executed due to a filter on %s', 'query-monitor' ),
-				'pre_http_request'
-			) );
+			$this->http_responses[ $original_key ]['response'] = new WP_Error( 'http_request_not_executed' );
 		}
 
 		$this->http_responses[ $key ] = $http_response;
@@ -328,7 +324,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 
 			if ( empty( $response['response'] ) ) {
 				// Timed out
-				$response['response'] = new WP_Error( 'http_request_timed_out', __( 'Request timed out', 'query-monitor' ) );
+				$response['response'] = new WP_Error( 'http_request_timed_out' );
 				$response['end'] = floatval( $request['start'] + $response['args']['timeout'] );
 			}
 

--- a/collectors/logger.php
+++ b/collectors/logger.php
@@ -298,7 +298,7 @@ class QM_Collector_Logger extends QM_DataCollector {
 
 		foreach ( $this->data->logs as $row ) {
 			$component = $row['component'];
-			$components[ $component->name ] = $component->name;
+			$components[ $component->get_id() ] = $component;
 		}
 
 		$this->data->components = $components;

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -15,12 +15,6 @@ if ( ! defined( 'QM_ERROR_FATALS' ) ) {
 
 /**
  * @extends QM_DataCollector<QM_Data_PHP_Errors>
- * @phpstan-type errorLabels array{
- *   warning: string,
- *   notice: string,
- *   strict: string,
- *   deprecated: string,
- * }
  * @phpstan-import-type errorObject from QM_Data_PHP_Errors
  */
 class QM_Collector_PHP_Errors extends QM_DataCollector {
@@ -29,16 +23,6 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 	 * @var string
 	 */
 	public $id = 'php_errors';
-
-	/**
-	 * @var array<string, array<string, string>>
-	 * @phpstan-var array{
-	 *   errors: errorLabels,
-	 *   suppressed: errorLabels,
-	 *   silenced: errorLabels,
-	 * }
-	 */
-	public $types;
 
 	/**
 	 * @var int|null
@@ -361,26 +345,6 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 	 * @return void
 	 */
 	public function process() {
-		$this->types = array(
-			'errors' => array(
-				'warning' => _x( 'Warning', 'PHP error level', 'query-monitor' ),
-				'notice' => _x( 'Notice', 'PHP error level', 'query-monitor' ),
-				'strict' => _x( 'Strict', 'PHP error level', 'query-monitor' ),
-				'deprecated' => _x( 'Deprecated', 'PHP error level', 'query-monitor' ),
-			),
-			'suppressed' => array(
-				'warning' => _x( 'Warning (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
-				'notice' => _x( 'Notice (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
-				'strict' => _x( 'Strict (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
-				'deprecated' => _x( 'Deprecated (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
-			),
-			'silenced' => array(
-				'warning' => _x( 'Warning (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
-				'notice' => _x( 'Notice (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
-				'strict' => _x( 'Strict (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
-				'deprecated' => _x( 'Deprecated (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
-			),
-		);
 		$components = array();
 
 		if ( ! empty( $this->data->errors ) ) {
@@ -426,17 +390,19 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 
 			array_map( array( $this, 'filter_reportable_errors' ), $levels, array_keys( $levels ) );
 
-			foreach ( $this->types as $error_group => $error_types ) {
-				foreach ( $error_types as $type => $title ) {
-					if ( isset( $this->data->{$error_group}[ $type ] ) ) {
-						/**
-						 * @var array<string, mixed> $error
-						 * @phpstan-var errorObject $error
-						 */
-						foreach ( $this->data->{$error_group}[ $type ] as $error ) {
-							$components[ $error['component']->get_id() ] = $error['component'];
-						}
-					}
+			foreach ( $this->data->errors as $errors ) {
+				foreach ( $errors as $error ) {
+					$components[ $error['component']->get_id() ] = $error['component'];
+				}
+			}
+			foreach ( $this->data->suppressed as $errors ) {
+				foreach ( $errors as $error ) {
+					$components[ $error['component']->get_id() ] = $error['component'];
+				}
+			}
+			foreach ( $this->data->silenced as $errors ) {
+				foreach ( $errors as $error ) {
+					$components[ $error['component']->get_id() ] = $error['component'];
 				}
 			}
 		}

--- a/collectors/php_errors.php
+++ b/collectors/php_errors.php
@@ -419,7 +419,7 @@ class QM_Collector_PHP_Errors extends QM_DataCollector {
 						 * @phpstan-var errorObject $error
 						 */
 						foreach ( $this->data->{$error_group}[ $type ] as $error ) {
-							$components[ $error['component']->name ] = $error['component']->name;
+							$components[ $error['component']->get_id() ] = $error['component'];
 						}
 					}
 				}

--- a/data/caps.php
+++ b/data/caps.php
@@ -31,7 +31,7 @@ class QM_Data_Caps extends QM_Data {
 	public $users;
 
 	/**
-	 * @var array<string, string>
+	 * @var array<string, QM_Component>
 	 */
 	public $components;
 }

--- a/data/db_components.php
+++ b/data/db_components.php
@@ -11,7 +11,7 @@ class QM_Data_DB_Components extends QM_Data {
 	 * @phpstan-var array<string, array{
 	 *   ltime: float,
 	 *   types: array<string, int>,
-	 *   component: string,
+	 *   component: QM_Component,
 	 * }>
 	 */
 	public $times;

--- a/data/doing_it_wrong.php
+++ b/data/doing_it_wrong.php
@@ -7,13 +7,7 @@
 
 class QM_Data_Doing_It_Wrong extends QM_Data {
 	/**
-	 * @var array<int, array<string, mixed>>
-	 * @phpstan-var array<int, array{
-	 *   hook: string,
-	 *   filtered_trace: list<array<string, mixed>>,
-	 *   message: string,
-	 *   component: QM_Component,
-	 * }>
+	 * @var array<int, QM_Wrong>
 	 */
 	public $actions;
 }

--- a/data/hooks.php
+++ b/data/hooks.php
@@ -15,7 +15,7 @@ class QM_Data_Hooks extends QM_Data {
 	 *     callback: array<string, mixed>,
 	 *   }>,
 	 *   parts: list<string>,
-	 *   components: array<string, string>,
+	 *   components: array<string, QM_Component>,
 	 * }>
 	 */
 	public $hooks;
@@ -26,7 +26,7 @@ class QM_Data_Hooks extends QM_Data {
 	public $parts;
 
 	/**
-	 * @var array<string, string>
+	 * @var array<string, QM_Component>
 	 */
 	public $components;
 

--- a/data/logger.php
+++ b/data/logger.php
@@ -24,7 +24,7 @@ class QM_Data_Logger extends QM_Data {
 	public $logs;
 
 	/**
-	 * @var array<string, string>
+	 * @var array<string, QM_Component>
 	 */
 	public $components;
 }

--- a/data/php_errors.php
+++ b/data/php_errors.php
@@ -21,7 +21,7 @@
  */
 class QM_Data_PHP_Errors extends QM_Data {
 	/**
-	 * @var array<string, string>
+	 * @var array<string, QM_Component>
 	 */
 	public $components;
 

--- a/data/php_errors.php
+++ b/data/php_errors.php
@@ -29,17 +29,17 @@ class QM_Data_PHP_Errors extends QM_Data {
 	 * @var array<string, array<string, array<string, mixed>>>
 	 * @phpstan-var errorObjects
 	 */
-	public $errors;
+	public $errors = [];
 
 	/**
 	 * @var array<string, array<string, array<string, mixed>>>
 	 * @phpstan-var errorObjects
 	 */
-	public $suppressed;
+	public $suppressed = [];
 
 	/**
 	 * @var array<string, array<string, array<string, mixed>>>
 	 * @phpstan-var errorObjects
 	 */
-	public $silenced;
+	public $silenced = [];
 }

--- a/output/Html.php
+++ b/output/Html.php
@@ -646,4 +646,5 @@ abstract class QM_Output_Html extends QM_Output {
 		return ( false !== self::get_file_link_format() );
 	}
 
+
 }

--- a/output/html/block_editor.php
+++ b/output/html/block_editor.php
@@ -252,20 +252,20 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 			if ( isset( $block['callback']['file'] ) ) {
 				if ( self::has_clickable_links() ) {
 					echo '<td class="qm-nowrap qm-ltr' . esc_attr( $class ) . '">';
-					echo self::output_filename( $block['callback']['name'], $block['callback']['file'], $block['callback']['line'] ); // WPCS: XSS ok.
+					echo self::output_filename( QM_Util::get_callback_name( $block['callback'] ), $block['callback']['file'], $block['callback']['line'] ); // WPCS: XSS ok.
 					echo '</td>';
 				} else {
 					echo '<td class="qm-nowrap qm-ltr qm-has-toggle' . esc_attr( $class ) . '">';
 					echo self::build_toggler(); // WPCS: XSS ok;
 					echo '<ol>';
 					echo '<li>';
-					echo self::output_filename( $block['callback']['name'], $block['callback']['file'], $block['callback']['line'] ); // WPCS: XSS ok.
+					echo self::output_filename( QM_Util::get_callback_name( $block['callback'] ), $block['callback']['file'], $block['callback']['line'] ); // WPCS: XSS ok.
 					echo '</li>';
 					echo '</ol></td>';
 				}
 			} else {
 				echo '<td class="qm-ltr qm-nowrap' . esc_attr( $class ) . '">';
-				echo '<code>' . esc_html( $block['callback']['name'] ) . '</code>';
+				echo '<code>' . esc_html( QM_Util::get_callback_name( $block['callback'] ) ) . '</code>';
 
 				if ( isset( $block['callback']['error'] ) ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -71,7 +71,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			$components = $data->components;
 
 			usort( $parts, 'strcasecmp' );
-			// usort( $components, 'strcasecmp' );
+			usort( $components, '\QM_Component::sort' );
 
 			echo '<thead>';
 			echo '<tr>';

--- a/output/html/caps.php
+++ b/output/html/caps.php
@@ -71,7 +71,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			$components = $data->components;
 
 			usort( $parts, 'strcasecmp' );
-			usort( $components, 'strcasecmp' );
+			// usort( $components, 'strcasecmp' );
 
 			echo '<thead>';
 			echo '<tr>';
@@ -92,7 +92,8 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 			echo '</th>';
 			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+			$values = wp_list_pluck( $components, 'name' );
+			echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
 			echo '</th>';
 			echo '</tr>';
 			echo '</thead>';
@@ -108,7 +109,7 @@ class QM_Output_Html_Caps extends QM_Output_Html {
 				$row_attr['data-qm-component'] = $component->name;
 				$row_attr['data-qm-result'] = ( $row['result'] ) ? 'true' : 'false';
 
-				if ( 'core' !== $component->context ) {
+				if ( ! $component->is_core() ) {
 					$row_attr['data-qm-component'] .= ' non-core';
 				}
 

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -70,7 +70,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 
 			echo '<tr>';
 			echo '<td class="qm-row-component">';
-			echo self::build_filter_trigger( 'db_queries', 'component', $row['component'], esc_html( $row['component'] ) ); // WPCS: XSS ok;
+			echo self::build_filter_trigger( 'db_queries', 'component', $row['component']->name, esc_html( $row['component']->name ) ); // WPCS: XSS ok;
 
 			foreach ( $data->types as $type_name => $type_count ) {
 				if ( isset( $row['types'][ $type_name ] ) ) {

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -246,10 +246,12 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		if ( $data->has_trace ) {
 			$components = array_column( $data->component_times, 'component' );
 
-			usort( $components, 'strcasecmp' );
+			// usort( $components, 'strcasecmp' );
+
+			$values = wp_list_pluck( $components, 'name' );
 
 			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+			echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
 			echo '</th>';
 		}
 
@@ -366,7 +368,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		if ( isset( $cols['component'] ) && $row['component'] ) {
 			$row_attr['data-qm-component'] = $row['component']->name;
 
-			if ( 'core' !== $row['component']->context ) {
+			if ( ! $row['component']->is_core() ) {
 				$row_attr['data-qm-component'] .= ' non-core';
 			}
 		}
@@ -435,7 +437,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 		if ( isset( $cols['component'] ) ) {
 			if ( $row['component'] ) {
-			echo "<td class='qm-row-component qm-nowrap'>" . esc_html( $row['component']->name ) . "</td>\n";
+				echo "<td class='qm-row-component qm-nowrap'>" . esc_html( $row['component']->name ) . "</td>\n";
 			} else {
 				echo "<td class='qm-row-component qm-nowrap'>" . esc_html__( 'Unknown', 'query-monitor' ) . "</td>\n";
 			}

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -246,7 +246,7 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		if ( $data->has_trace ) {
 			$components = array_column( $data->component_times, 'component' );
 
-			// usort( $components, 'strcasecmp' );
+			usort( $components, '\QM_Component::sort' );
 
 			$values = wp_list_pluck( $components, 'name' );
 

--- a/output/html/doing_it_wrong.php
+++ b/output/html/doing_it_wrong.php
@@ -77,7 +77,7 @@ class QM_Output_Html_Doing_It_Wrong extends QM_Output_Html {
 		foreach ( $data->actions as $row ) {
 			$stack = array();
 
-			foreach ( $row['filtered_trace'] as $frame ) {
+			foreach ( $row->get_trace()->get_filtered_trace() as $frame ) {
 				$stack[] = self::output_filename( $frame['display'], $frame['calling_file'], $frame['calling_line'] );
 			}
 
@@ -85,7 +85,7 @@ class QM_Output_Html_Doing_It_Wrong extends QM_Output_Html {
 
 			echo '<tr>';
 
-			printf( '<td>%s</td>', esc_html( wp_strip_all_tags( $row['message'] ) ) );
+			printf( '<td>%s</td>', esc_html( wp_strip_all_tags( $row->get_message() ) ) );
 
 			echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
 
@@ -103,7 +103,7 @@ class QM_Output_Html_Doing_It_Wrong extends QM_Output_Html {
 
 			echo '</ol></td>';
 
-			echo '<td class="qm-nowrap">' . esc_html( $row['component']->name ) . '</td>';
+			echo '<td class="qm-nowrap">' . esc_html( $row->get_trace()->get_component()->get_name() ) . '</td>';
 
 			echo '</tr>';
 		}

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -72,7 +72,8 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html( $callback_label ) . '</th>';
 		echo '<th scope="col" class="qm-filterable-column">';
-		echo $this->build_filter( 'component', $data->components, __( 'Component', 'query-monitor' ), array(
+		$values = wp_list_pluck( $data->components, 'name' );
+		echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ), array(
 			'highlight' => 'subject',
 		) ); // WPCS: XSS ok.
 		echo '</th>';
@@ -97,10 +98,10 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 		foreach ( $hooks as $hook ) {
 			$row_attr = array();
 			$row_attr['data-qm-name'] = implode( ' ', $hook['parts'] );
-			$row_attr['data-qm-component'] = implode( ' ', $hook['components'] );
+			$row_attr['data-qm-component'] = implode( ' ', wp_list_pluck( $hook['components'], 'name' ) );
 			$row_attr['data-qm-type'] = $hook['type'];
 
-			if ( ! empty( $row_attr['data-qm-component'] ) && $core !== $row_attr['data-qm-component'] ) {
+			if ( QM_Component::has_non_core( $hook['components'] ) ) {
 				$row_attr['data-qm-component'] .= ' non-core';
 			}
 

--- a/output/html/hooks.php
+++ b/output/html/hooks.php
@@ -185,20 +185,20 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 					if ( isset( $action['callback']['file'] ) ) {
 						if ( self::has_clickable_links() ) {
 							echo '<td class="qm-nowrap qm-ltr' . esc_attr( $class ) . '">';
-							echo self::output_filename( $action['callback']['name'], $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
+							echo self::output_filename( QM_Util::get_callback_name( $action['callback'] ), $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
 							echo '</td>';
 						} else {
 							echo '<td class="qm-nowrap qm-ltr qm-has-toggle' . esc_attr( $class ) . '">';
 							echo self::build_toggler(); // WPCS: XSS ok;
 							echo '<ol>';
 							echo '<li>';
-							echo self::output_filename( $action['callback']['name'], $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
+							echo self::output_filename( QM_Util::get_callback_name( $action['callback'] ), $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
 							echo '</li>';
 							echo '</ol></td>';
 						}
 					} else {
 						echo '<td class="qm-ltr qm-nowrap' . esc_attr( $class ) . '">';
-						echo '<code>' . esc_html( $action['callback']['name'] ) . '</code>';
+						echo '<code>' . esc_html( QM_Util::get_callback_name( $action['callback'] ) ) . '</code>';
 
 						if ( isset( $action['callback']['error'] ) ) {
 							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -95,7 +95,24 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				$css = '';
 
 				if ( $row['response'] instanceof WP_Error ) {
-					$response = $row['response']->get_error_message();
+					// These are both fallback errors that handle particularly broken scenarios.
+					switch ( $row['response']->get_error_code() ) {
+						case 'http_request_not_executed':
+							$response = sprintf(
+								/* translators: An HTTP API request was not executed. %s: Hook name */
+								__( 'Request not executed due to a filter on %s', 'query-monitor' ),
+								'pre_http_request'
+							);
+							break;
+						case 'http_request_timed_out':
+							/* translators: An HTTP API request timed out */
+							$response = __( 'Request timed out', 'query-monitor' );
+							break;
+						default:
+							$response = $row['response']->get_error_message();
+							break;
+					}
+
 					$is_error = true;
 				} elseif ( ! $row['args']['blocking'] ) {
 					/* translators: A non-blocking HTTP API request */

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -43,7 +43,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			$components = array_column( $data->component_times, 'component' );
 
 			usort( $statuses, 'strcasecmp' );
-			// usort( $components, 'strcasecmp' );
+			usort( $components, '\QM_Component::sort' );
 
 			$status_output = array();
 			$hosts = array_unique( array_column( $data->http, 'host' ) );

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -43,7 +43,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			$components = array_column( $data->component_times, 'component' );
 
 			usort( $statuses, 'strcasecmp' );
-			usort( $components, 'strcasecmp' );
+			// usort( $components, 'strcasecmp' );
 
 			$status_output = array();
 			$hosts = array_unique( array_column( $data->http, 'host' ) );
@@ -73,7 +73,10 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			echo '</th>';
 			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+
+			$values = wp_list_pluck( $components, 'name' );
+
+			echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
 			echo '</th>';
 			echo '<th scope="col" class="qm-num">' . esc_html__( 'Size', 'query-monitor' ) . '</th>';
 			echo '<th scope="col" class="qm-num">' . esc_html__( 'Timeout', 'query-monitor' ) . '</th>';

--- a/output/html/logger.php
+++ b/output/html/logger.php
@@ -85,7 +85,8 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 		echo '<th scope="col" class="qm-col-message">' . esc_html__( 'Message', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
 		echo '<th scope="col" class="qm-filterable-column">';
-		echo $this->build_filter( 'component', $data->components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		$values = wp_list_pluck( $data->components, 'name' );
+		echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
 		echo '</th>';
 		echo '</tr>';
 		echo '</thead>';

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -52,7 +52,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 		$components = $data->components;
 		$count = 0;
 
-		// usort( $components, 'strcasecmp' );
+		usort( $components, '\QM_Component::sort' );
 
 		$this->before_tabular_output();
 

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -43,12 +43,27 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 			return;
 		}
 
-		$levels = array(
-			'Warning',
-			'Notice',
-			'Strict',
-			'Deprecated',
-		);
+		$labels = [
+			'errors' => array(
+				'warning' => _x( 'Warning', 'PHP error level', 'query-monitor' ),
+				'notice' => _x( 'Notice', 'PHP error level', 'query-monitor' ),
+				'strict' => _x( 'Strict', 'PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated', 'PHP error level', 'query-monitor' ),
+			),
+			'suppressed' => array(
+				'warning' => _x( 'Warning (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'notice' => _x( 'Notice (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'strict' => _x( 'Strict (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+			),
+			'silenced' => array(
+				'warning' => _x( 'Warning (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'notice' => _x( 'Notice (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'strict' => _x( 'Strict (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+			),
+		];
+
 		$components = $data->components;
 		$count = 0;
 
@@ -59,7 +74,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 		echo '<thead>';
 		echo '<tr>';
 		echo '<th scope="col" class="qm-filterable-column">';
-		echo $this->build_filter( 'type', $levels, __( 'Level', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo $this->build_filter( 'type', $labels['errors'], __( 'Level', 'query-monitor' ) ); // WPCS: XSS ok.
 		echo '</th>';
 		echo '<th scope="col" class="qm-col-message">' . esc_html__( 'Message', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Location', 'query-monitor' ) . '</th>';
@@ -73,7 +88,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 
 		echo '<tbody>';
 
-		foreach ( $this->collector->types as $error_group => $error_types ) {
+		foreach ( $labels as $error_group => $error_types ) {
 			foreach ( $error_types as $type => $title ) {
 
 				if ( ! isset( $data->{$error_group}[ $type ] ) ) {
@@ -84,7 +99,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 					$count += $error['calls'];
 
 					$row_attr = array();
-					$row_attr['data-qm-type'] = ucfirst( $type );
+					$row_attr['data-qm-type'] = $type;
 					$row_attr['data-qm-key'] = $error_key;
 					$row_attr['data-qm-count'] = $error['calls'];
 

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -52,7 +52,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 		$components = $data->components;
 		$count = 0;
 
-		usort( $components, 'strcasecmp' );
+		// usort( $components, 'strcasecmp' );
 
 		$this->before_tabular_output();
 
@@ -65,7 +65,8 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 		echo '<th scope="col">' . esc_html__( 'Location', 'query-monitor' ) . '</th>';
 		echo '<th scope="col" class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
 		echo '<th scope="col" class="qm-filterable-column">';
-		echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		$values = wp_list_pluck( $components, 'name' );
+		echo $this->build_filter( 'component', $values, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
 		echo '</th>';
 		echo '</tr>';
 		echo '</thead>';
@@ -91,7 +92,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 						$component = $error['component'];
 						$row_attr['data-qm-component'] = $component->name;
 
-						if ( 'core' !== $component->context ) {
+						if ( ! $component->is_core() ) {
 							$row_attr['data-qm-component'] .= ' non-core';
 						}
 					}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,7 @@
 		<!-- We have the means -->
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 
 		<!-- QM looks at several superglobals -->
 		<exclude name="WordPress.Security.NonceVerification.Missing" />

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -36,6 +36,10 @@ class AcceptanceTester extends \Codeception\Actor {
 		$this->amOnPage( "/?_qm_acceptance_group=guzzle_requests&_qm_acceptance_test={$test}" );
 	}
 
+	public function amOnAPageThatTriggersCallbackType( string $test ): void {
+		$this->amOnPage( "/?_qm_acceptance_group=callback_types&_qm_acceptance_test={$test}" );
+	}
+
 	public function seeQMMenuWithWarning(): void {
 		$this->seeElement( '#wp-admin-bar-query-monitor.qm-warning' );
 	}

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -77,6 +77,57 @@ add_action( 'init', function() {
 					break;
 			}
 			break;
+		case 'callback_types':
+			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'function':
+					// Regular function callback
+					add_action( 'qm_test_hook', '__return_true' );
+					do_action( 'qm_test_hook' );
+					break;
+				case 'method':
+					// Object method callback
+					$obj = new class {
+						public function test_method() {
+							return true;
+						}
+					};
+					add_action( 'qm_test_hook', [ $obj, 'test_method' ] );
+					do_action( 'qm_test_hook' );
+					break;
+				case 'static_method':
+					// Static method callback - create our own test class
+					if ( ! class_exists( 'QM_Test_Static_Class' ) ) {
+						class QM_Test_Static_Class {
+							public static function test_static_method() {
+								return 'static test result';
+							}
+						}
+					}
+					add_action( 'qm_test_hook', [ 'QM_Test_Static_Class', 'test_static_method' ] );
+					do_action( 'qm_test_hook' );
+					break;
+				case 'closure':
+					// Closure callback
+					add_action( 'qm_test_hook', function() {
+						// Test closure for acceptance testing
+						return 'test closure result';
+					} );
+					do_action( 'qm_test_hook' );
+					break;
+				case 'invokable':
+					// Invokable object callback
+					add_action( 'qm_test_hook', new class {
+						public function __invoke() {
+							return 'invokable result';
+						}
+					} );
+					do_action( 'qm_test_hook' );
+					break;
+				default:
+					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
+					break;
+			}
+			break;
 		default:
 			throw new \InvalidArgumentException( 'Unknown group: ' . $_GET['_qm_acceptance_group'] );
 			break;

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -16,7 +16,7 @@ add_action( 'init', function() {
 						_deprecated_class( 'My_Class', '2.0.0' );
 					} else {
 						// Fallback for WordPress < 6.4.0
-						_doing_it_wrong( 'My_Class', 'Class is deprecated since version 2.0.0', '2.0.0' );
+						_doing_it_wrong( 'My_Class', 'My_Class is deprecated since version 2.0.0', '2.0.0' );
 					}
 					break;
 				case 'constructor':

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -12,7 +12,12 @@ add_action( 'init', function() {
 					_deprecated_argument( 'my_function', '2.0.0' );
 					break;
 				case 'class':
-					_deprecated_class( 'My_Class', '2.0.0' );
+					if ( function_exists( '_deprecated_class' ) ) {
+						_deprecated_class( 'My_Class', '2.0.0' );
+					} else {
+						// Fallback for WordPress < 6.4.0
+						_doing_it_wrong( 'My_Class', 'Class is deprecated since version 2.0.0', '2.0.0' );
+					}
 					break;
 				case 'constructor':
 					_deprecated_constructor( 'My_Class', '2.0.0' );

--- a/tests/acceptance/CallbacksCest.php
+++ b/tests/acceptance/CallbacksCest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+/**
+ * Acceptance tests for callback types in Hooks and Actions panel.
+ */
+
+class CallbacksCest {
+	public function _before( AcceptanceTester $I ): void {
+		$I->loginAsAdmin();
+	}
+
+	public function FunctionCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersCallbackType( 'function' );
+		$I->seeQMMenu();
+		$I->seeInQMPanel( 'Hooks & Actions', '__return_true()' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
+	}
+
+	public function MethodCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersCallbackType( 'method' );
+		$I->seeQMMenu();
+		$I->seeInQMPanel( 'Hooks & Actions', 'test_method()' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
+	}
+
+	public function StaticMethodCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersCallbackType( 'static_method' );
+		$I->seeQMMenu();
+		$I->seeInQMPanel( 'Hooks & Actions', 'QM_Test_Static_Class::test_static_method()' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
+	}
+
+	public function ClosureCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersCallbackType( 'closure' );
+		$I->seeQMMenu();
+		$I->seeInQMPanel( 'Hooks & Actions', 'Closure on line' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'acceptance.php' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
+	}
+
+	public function InvokableCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersCallbackType( 'invokable' );
+		$I->seeQMMenu();
+		$I->seeInQMPanel( 'Hooks & Actions', '__invoke()' );
+		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
+	}
+}

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -13,6 +13,11 @@ class DoingItWrongCest {
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'Function my_function was called with an argument that is deprecated since version 2.0.0' );
 	}
 
+	public function DeprecatedClassShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amOnAPageThatIsDoingItWrong( 'class' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'My_Class is deprecated since version 2.0.0' );
+	}
+
 	public function DeprecatedConstructorShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'constructor' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'The called constructor method for My_Class class is deprecated since version 2.0.0' );

--- a/tests/integration/CallbacksTest.php
+++ b/tests/integration/CallbacksTest.php
@@ -114,17 +114,17 @@ class CallbacksTest extends Test {
 
 		$ref = new \ReflectionFunction( $function );
 		$actual = \QM_Util::populate_callback( $callback );
-		$name = sprintf(
-			'Closure on line %1$d of %2$s',
-			$ref->getStartLine(),
-			'wp-content/plugins/query-monitor/tests/integration/includes/dummy-closures.php'
-		);
 
-		self::assertArrayHasKey( 'name', $actual );
+		// Test deferred translation properties instead of translated name
+		self::assertArrayHasKey( 'callback_type', $actual );
+		self::assertArrayHasKey( 'start_line', $actual );
+		self::assertArrayHasKey( 'display_file', $actual );
 		self::assertArrayHasKey( 'file', $actual );
 		self::assertArrayHasKey( 'line', $actual );
-		self::assertSame( $name,                $actual['name'] );
-		self::assertSame( $ref->getFileName(),  $actual['file'] );
+		self::assertSame( 'closure', $actual['callback_type'] );
+		self::assertSame( $ref->getStartLine(), $actual['start_line'] );
+		self::assertSame( 'wp-content/plugins/query-monitor/tests/integration/includes/dummy-closures.php', $actual['display_file'] );
+		self::assertSame( $ref->getFileName(), $actual['file'] );
 		self::assertSame( $ref->getStartLine(), $actual['line'] );
 
 	}
@@ -212,6 +212,58 @@ class CallbacksTest extends Test {
 		self::assertArrayHasKey( 'error', $actual );
 		$this->assertWPError( $actual['error'] );
 
+	}
+
+	public function testGetCallbackNameWithName(): void {
+		$callback = array(
+			'name' => 'test_function()',
+			'callback_type' => 'function'
+		);
+
+		$result = \QM_Util::get_callback_name( $callback );
+
+		self::assertSame( 'test_function()', $result );
+	}
+
+	public function testGetCallbackNameWithClosure(): void {
+		$callback = array(
+			'callback_type' => 'closure',
+			'start_line' => 42,
+			'display_file' => 'test.php'
+		);
+
+		$result = \QM_Util::get_callback_name( $callback );
+
+		self::assertStringContainsString( 'Closure on line 42 of test.php', $result );
+	}
+
+	public function testGetCallbackNameWithUnknownClosure(): void {
+		$callback = array(
+			'callback_type' => 'unknown_closure'
+		);
+
+		$result = \QM_Util::get_callback_name( $callback );
+
+		self::assertStringContainsString( 'Unknown closure', $result );
+	}
+
+	public function testGetCallbackNameWithoutCallbackType(): void {
+		$callback = array();
+
+		$result = \QM_Util::get_callback_name( $callback );
+
+		self::assertSame( '', $result );
+	}
+
+	public function testGetCallbackNameWithUnknownType(): void {
+		$callback = array(
+			'callback_type' => 'unknown',
+			'name' => 'unknown_callback()'
+		);
+
+		$result = \QM_Util::get_callback_name( $callback );
+
+		self::assertSame( 'unknown_callback()', $result );
 	}
 
 }

--- a/tests/integration/CollectorPhpErrorsTest.php
+++ b/tests/integration/CollectorPhpErrorsTest.php
@@ -56,7 +56,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsCoreFileIsNotInPlugin(): void {
 		$component = \QM_Util::get_file_component( ABSPATH . 'wp-includes/plugin.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'core', $component->context );
@@ -66,7 +66,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsThemeFileIsNotInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_CONTENT_DIR . '/themes/foo/taxonomy.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		// self::assertSame( 'other', $component->context );
@@ -76,7 +76,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsAnotherPluginFileIsNotInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_PLUGIN_DIR . '/bar/taxonomy.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'bar', $component->context );
@@ -86,7 +86,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsEmptyFilePathIsNotInPlugin(): void {
 		$component = \QM_Util::get_file_component( ABSPATH );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'core', $component->context );
@@ -106,7 +106,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsPluginFileIsInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_PLUGIN_DIR . '/foo/taxonomy.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'foo', $component->context );
@@ -116,7 +116,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsThemeFileIsInTheme(): void {
 		$component = \QM_Util::get_file_component( get_stylesheet_directory() . '/taxonomy.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'theme', 'stylesheet'
+			$component, \QM_Component::TYPE_STYLESHEET, 'stylesheet'
 		);
 
 		self::assertSame( 'stylesheet', $component->context );
@@ -126,7 +126,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsCoreFileIsInCore(): void {
 		$component = \QM_Util::get_file_component( ABSPATH . 'wp-includes/plugin.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'core', 'core'
+			$component, \QM_Component::TYPE_CORE, 'core'
 		);
 
 		self::assertSame( 'core', $component->context );
@@ -136,7 +136,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsFolderlessPluginFileIsInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_PLUGIN_DIR . '/foo.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo.php'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo.php'
 		);
 
 		self::assertSame( 'foo.php', $component->context );
@@ -146,7 +146,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsInternalPluginFileIsInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_PLUGIN_DIR . '/foo/includes/A/B/foo.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'foo', $component->context );
@@ -156,7 +156,7 @@ class CollectorPhpErrorsTest extends Test {
 	function testItKnowsPluginExtensionFileIsNotInPlugin(): void {
 		$component = \QM_Util::get_file_component( WP_PLUGIN_DIR . '/foo-extension/foo-extension.php.php' );
 		$actual = $this->collector->is_affected_component(
-			$component, 'plugin', 'foo'
+			$component, \QM_Component::TYPE_PLUGIN, 'foo'
 		);
 
 		self::assertSame( 'foo-extension', $component->context );
@@ -204,7 +204,7 @@ class CollectorPhpErrorsTest extends Test {
 
 	function testItWillFilterNoticesFromPlugin(): void {
 		add_filter( 'qm/collect/php_error_levels', function( $table ) {
-			$table['plugin']['foo'] = E_ALL & ~E_NOTICE;
+			$table[ \QM_Component::TYPE_PLUGIN ]['foo'] = E_ALL & ~E_NOTICE;
 			return $table;
 		} );
 

--- a/tests/integration/CollectorPhpErrorsTest.php
+++ b/tests/integration/CollectorPhpErrorsTest.php
@@ -192,14 +192,11 @@ class CollectorPhpErrorsTest extends Test {
 		$actual = $this->collector->get_data();
 
 		// errors:
-		self::assertTrue( property_exists( $actual, 'errors' ) );
 		self::assertArrayHasKey( 'notice', $actual->errors );
 		self::assertSame( 2, count( $actual->errors['notice'] ) );
 
 		// silenced errors:
-		self::assertTrue( property_exists( $actual, 'silenced' ) );
-		// @phpstan-ignore-next-line
-		self::assertFalse( isset( $actual->silenced ) );
+		self::assertSame( [], $actual->silenced );
 	}
 
 	function testItWillFilterNoticesFromPlugin(): void {
@@ -237,13 +234,11 @@ class CollectorPhpErrorsTest extends Test {
 		$actual = $this->collector->get_data();
 
 		// errors:
-		self::assertTrue( property_exists( $actual, 'errors' ) );
 		self::assertArrayHasKey( 'warning', $actual->errors );
 		self::assertArrayNotHasKey( 'notice', $actual->errors );
 		self::assertSame( 1, count( $actual->errors['warning'] ) );
 
 		// silenced errors:
-		self::assertTrue( property_exists( $actual, 'silenced' ) );
 		self::assertArrayHasKey( 'notice', $actual->silenced );
 		self::assertArrayNotHasKey( 'warning', $actual->silenced );
 		self::assertSame( 1, count( $actual->silenced['notice'] ) );


### PR DESCRIPTION
Fairly substantial re-architecting so that internationalised strings aren't loaded until they're needed. It affects all collectors plus any classes that are called by them. Essentially no function or method should use an internationalised string until it's called from a dispatcher or outputter.

* [x] All (almost) collectors
* [x] Backtrace collection
* [x] Component detection
* [x] Callback population
* [x] Timer