### PR TITLE
Be more explicit about HTTP API requests that were short-circuited

### DIFF
--- a/collectors/http.php
+++ b/collectors/http.php
@@ -43,6 +43,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 	 *   args: array<string, mixed>,
 	 *   response: mixed[]|WP_Error,
 	 *   info: array<string, mixed>|null,
+	 *   intercepted: bool,
 	 * }>
 	 */
 	private $http_responses = array();
@@ -222,7 +223,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 		}
 
 		// Something's filtering the response, so we'll log it
-		$this->log_http_response( $response, $args, $url );
+		$this->log_http_response( $response, $args, $url, true );
 
 		return $response;
 	}
@@ -274,12 +275,13 @@ class QM_Collector_HTTP extends QM_DataCollector {
 	/**
 	 * Log an HTTP response.
 	 *
-	 * @param mixed[]|WP_Error     $response The HTTP response.
-	 * @param array<string, mixed> $args     HTTP request arguments.
-	 * @param string               $url      The request URL.
+	 * @param mixed[]|WP_Error     $response    The HTTP response.
+	 * @param array<string, mixed> $args        HTTP request arguments.
+	 * @param string               $url         The request URL.
+	 * @param bool                 $intercepted Whether the request was intercepted and short-circuited by a filter.
 	 * @return void
 	 */
-	public function log_http_response( $response, array $args, $url ) {
+	public function log_http_response( $response, array $args, $url, bool $intercepted = false ) {
 		/** @var string */
 		$key = $args['_qm_key'];
 
@@ -288,6 +290,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 			'response' => $response,
 			'args' => $args,
 			'info' => $this->info,
+			'intercepted' => $intercepted,
 		);
 
 		if ( isset( $args['_qm_original_key'] ) ) {
@@ -367,7 +370,9 @@ class QM_Collector_HTTP extends QM_DataCollector {
 				}
 			}
 
-			$this->data->ltime += $ltime;
+			if ( ! $response['intercepted'] ) {
+				$this->data->ltime += $ltime;
+			}
 
 			$host = (string) parse_url( $request['url'], PHP_URL_HOST );
 			$local = ( $host === $home_host );
@@ -386,6 +391,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 				'response' => $response['response'],
 				'type' => $type,
 				'url' => $request['url'],
+				'intercepted' => $response['intercepted'],
 			);
 		}
 

--- a/data/http.php
+++ b/data/http.php
@@ -20,6 +20,7 @@ class QM_Data_HTTP extends QM_Data {
 	 *   response: mixed[]|WP_Error,
 	 *   type: string,
 	 *   url: string,
+	 *   intercepted: bool,
 	 * }>
 	 */
 	public $http;

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -142,8 +142,11 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 
 				$row_attr['data-qm-component'] = $component->name;
 				$row_attr['data-qm-type'] = $row['type'];
-				$row_attr['data-qm-time'] = $row['ltime'];
 				$row_attr['data-qm-host'] = $row['host'];
+
+				if ( ! $row['intercepted'] ) {
+					$row_attr['data-qm-time'] = $row['ltime'];
+				}
 
 				if ( 'core' !== $component->context ) {
 					$row_attr['data-qm-component'] .= ' non-core';
@@ -164,6 +167,18 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 					esc_html( $row['args']['method'] )
 				);
 
+				if ( $row['intercepted'] ) {
+					$url = sprintf(
+						'<span class="qm-warn">%1$s%2$s</span><br>',
+						QueryMonitor::icon( 'warning' ),
+						sprintf(
+							/* translators: %s: The name of a filter that short-circuited an HTTP API request */
+							esc_html__( 'This HTTP request was not sent as it was short-circuited by the %s filter', 'query-monitor' ),
+							'<code>pre_http_request</code>'
+						)
+					) . $url;
+				}
+
 				if ( ! empty( $row['redirected_to'] ) ) {
 					$url .= sprintf(
 						'<br><span class="qm-warn">%1$s%2$s</span><br>%3$s',
@@ -180,58 +195,82 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 					$url
 				);
 
-				$show_toggle = ! empty( $row['info'] );
+				$size = '';
+				$timeout = $row['args']['timeout'];
 
-				echo '<td class="qm-has-toggle qm-col-status">';
-				if ( $is_error ) {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo QueryMonitor::icon( 'warning' );
-				}
-				echo esc_html( $response );
-
-				if ( $show_toggle ) {
-					echo self::build_toggler(); // WPCS: XSS ok;
-					echo '<ul class="qm-toggled">';
-				}
-
-				if ( ! empty( $row['info'] ) ) {
-					$time_fields = array(
-						'namelookup_time' => __( 'DNS Resolution Time', 'query-monitor' ),
-						'connect_time' => __( 'Connection Time', 'query-monitor' ),
-						'starttransfer_time' => __( 'Transfer Start Time (TTFB)', 'query-monitor' ),
+				if ( isset( $row['info']['size_download'] ) ) {
+					$size = sprintf(
+						/* translators: %s: Memory used in kilobytes */
+						__( '%s kB', 'query-monitor' ),
+						number_format_i18n( $row['info']['size_download'] / 1024, 1 )
 					);
-					foreach ( $time_fields as $key => $value ) {
-						if ( ! isset( $row['info'][ $key ] ) ) {
-							continue;
-						}
-						printf(
-							'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
-							esc_html( $value ),
-							esc_html( number_format_i18n( $row['info'][ $key ], 4 ) )
-						);
+				} elseif ( $row['intercepted'] ) {
+					$ltime = 0;
+					$timeout = '';
+				} elseif ( is_array( $row['response'] ) && isset( $row['response']['body'] ) ) {
+					$size = sprintf(
+						/* translators: %s: Memory used in kilobytes */
+						__( '%s kB', 'query-monitor' ),
+						number_format_i18n( strlen( $row['response']['body'] ) / 1024, 1 )
+					);
+				}
+
+				if ( $row['intercepted'] && ! $is_error ) {
+					echo '<td class="qm-col-status"></td>';
+				} else {
+					$show_toggle = ! empty( $row['info'] );
+
+					echo '<td class="qm-has-toggle qm-col-status">';
+					if ( $is_error ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo QueryMonitor::icon( 'warning' );
+					}
+					echo esc_html( $response );
+
+					if ( $show_toggle ) {
+						echo self::build_toggler(); // WPCS: XSS ok;
+						echo '<ul class="qm-toggled">';
 					}
 
-					$other_fields = array(
-						'content_type' => __( 'Response Content Type', 'query-monitor' ),
-						'primary_ip' => __( 'IP Address', 'query-monitor' ),
-					);
-					foreach ( $other_fields as $key => $value ) {
-						if ( ! isset( $row['info'][ $key ] ) ) {
-							continue;
-						}
-						printf(
-							'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
-							esc_html( $value ),
-							esc_html( $row['info'][ $key ] )
+					if ( ! empty( $row['info'] ) ) {
+						$time_fields = array(
+							'namelookup_time' => __( 'DNS Resolution Time', 'query-monitor' ),
+							'connect_time' => __( 'Connection Time', 'query-monitor' ),
+							'starttransfer_time' => __( 'Transfer Start Time (TTFB)', 'query-monitor' ),
 						);
+						foreach ( $time_fields as $key => $value ) {
+							if ( ! isset( $row['info'][ $key ] ) ) {
+								continue;
+							}
+							printf(
+								'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
+								esc_html( $value ),
+								esc_html( number_format_i18n( $row['info'][ $key ], 4 ) )
+							);
+						}
+
+						$other_fields = array(
+							'content_type' => __( 'Response Content Type', 'query-monitor' ),
+							'primary_ip' => __( 'IP Address', 'query-monitor' ),
+						);
+						foreach ( $other_fields as $key => $value ) {
+							if ( ! isset( $row['info'][ $key ] ) ) {
+								continue;
+							}
+							printf(
+								'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
+								esc_html( $value ),
+								esc_html( $row['info'][ $key ] )
+							);
+						}
 					}
-				}
 
-				if ( $show_toggle ) {
-					echo '</ul>';
-				}
+					if ( $show_toggle ) {
+						echo '</ul>';
+					}
 
-				echo '</td>';
+					echo '</td>';
+				}
 
 				$caller = array_shift( $stack );
 
@@ -256,16 +295,6 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 					esc_html( $component->name )
 				);
 
-				$size = '';
-
-				if ( isset( $row['info']['size_download'] ) ) {
-					$size = sprintf(
-						/* translators: %s: Memory used in kilobytes */
-						__( '%s kB', 'query-monitor' ),
-						number_format_i18n( $row['info']['size_download'] / 1024, 1 )
-					);
-				}
-
 				printf(
 					'<td class="qm-nowrap qm-num">%s</td>',
 					esc_html( $size )
@@ -273,7 +302,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 
 				printf(
 					'<td class="qm-num">%s</td>',
-					esc_html( $row['args']['timeout'] )
+					esc_html( $timeout )
 				);
 
 				if ( empty( $ltime ) ) {


### PR DESCRIPTION
When I first wrote the HTTP API request logging for QM the `http_api_debug` action didn't fire in every place where it needed to. [This hasn't been the case for years](https://core.trac.wordpress.org/changeset/45504) so it looks like QM can now accurately detect HTTP API requests which were short-circuited and show an explanatory message.

## Screenshot

![](https://github.com/user-attachments/assets/6ba01b1a-b3e3-4240-bc69-421b016411ad)
