### PR TITLE
Tell Chrome to use a temporary directory instead of `/dev/shm`

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -32,6 +32,7 @@ modules:
         chromeOptions:
           args: [
             "--headless",
+            "--disable-dev-shm-usage",
             "--disable-gpu",
             "--proxy-server='direct://'",
             "--proxy-bypass-list=*"


### PR DESCRIPTION
CoPilot suggests that this might help with the occasional failures experienced in the acceptance tests.

>[Facebook\WebDriver\Exception\UnrecognizedExceptionException] disconnected: not connected to DevTools
>  (failed to check if window was closed: disconnected: not connected to DevTools)
>  (Session info: chrome=124.0.6367.78)

https://github.com/johnbillion/query-monitor/actions/runs/16160853485/job/45612157846