### PR TITLE
Add more to the acceptance testing framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,10 @@ To run tests individually, run one of:
 	composer test:integration
 	composer test:acceptance
 
+To run individual tests:
+
+	composer test:acceptance -- --codecept-args="tests/acceptance/DoingItWrongCest.php"
+
 The individual integration and acceptance tests require the Docker containers to be running. To start and stop them, use:
 
 	composer exec tests-start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 include:
   -
-    path: vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
+    path:
+      - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
+      - tests/_support/MUPlugin/acceptance.yml
     project_directory: .

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -24,6 +24,10 @@ class AcceptanceTester extends \Codeception\Actor {
 		$this->amOnPage( "/?_qm_acceptance_group=doing_it_wrong&_qm_acceptance_test={$test}" );
 	}
 
+	public function amOnAPageThatTriggersPhpError( string $test ): void {
+		$this->amOnPage( "/?_qm_acceptance_group=php_errors&_qm_acceptance_test={$test}" );
+	}
+
 	public function openQMPanel( string $panel ): void {
 		$this->click( '#wp-admin-bar-query-monitor' );
 		$this->click( $panel, '#qm-panel-menu' );

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -20,7 +20,7 @@
 class AcceptanceTester extends \Codeception\Actor {
 	use _generated\AcceptanceTesterActions;
 
-	public function amDoingItWrong( string $test ): void {
+	public function amOnAPageThatIsDoingItWrong( string $test ): void {
 		$this->amOnPage( "/?_qm_acceptance_group=doing_it_wrong&_qm_acceptance_test={$test}" );
 	}
 

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -20,4 +20,17 @@
 class AcceptanceTester extends \Codeception\Actor {
 	use _generated\AcceptanceTesterActions;
 
+	public function amDoingItWrong( string $test ): void {
+		$this->amOnPage( "/?_qm_acceptance_group=doing_it_wrong&_qm_acceptance_test={$test}" );
+	}
+
+	public function openQMPanel( string $panel ): void {
+		$this->click( '#wp-admin-bar-query-monitor' );
+		$this->click( $panel, '#qm-panel-menu' );
+	}
+
+	public function seeInQMPanel( string $panel, string $text ): void {
+		$this->openQMPanel( $panel );
+		$this->see( $text, '#query-monitor-main' );
+	}
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -28,6 +28,10 @@ class AcceptanceTester extends \Codeception\Actor {
 		$this->amOnPage( "/?_qm_acceptance_group=php_errors&_qm_acceptance_test={$test}" );
 	}
 
+	public function amOnAPageThatTriggersSuppressedPhpError( string $test ): void {
+		$this->amOnPage( "/?_qm_acceptance_group=php_errors&_qm_acceptance_test=suppressed-{$test}" );
+	}
+
 	public function openQMPanel( string $panel ): void {
 		$this->click( '#wp-admin-bar-query-monitor' );
 		$this->click( $panel, '#qm-panel-menu' );

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -31,6 +31,6 @@ class AcceptanceTester extends \Codeception\Actor {
 
 	public function seeInQMPanel( string $panel, string $text ): void {
 		$this->openQMPanel( $panel );
-		$this->see( $text, '#query-monitor-main' );
+		$this->see( $text, '.qm-panel-show' );
 	}
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Acceptance testing helper.
- */
-
-namespace Helper;
-
-class Acceptance extends \Codeception\Module {
-}

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -26,7 +26,13 @@ add_action( 'init', function() {
 				case 'hook':
 					_deprecated_hook( 'my_hook', '2.0.0' );
 					break;
+				default:
+					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
+					break;
 			}
+			break;
+		default:
+			throw new \InvalidArgumentException( 'Unknown group: ' . $_GET['_qm_acceptance_group'] );
 			break;
 	}
 } );

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -31,6 +31,19 @@ add_action( 'init', function() {
 					break;
 			}
 			break;
+		case 'php_errors':
+			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'warning':
+					trigger_error( 'This is a test warning', E_USER_WARNING );
+					break;
+				case 'notice':
+					trigger_error( 'This is a test notice', E_USER_NOTICE );
+					break;
+				default:
+					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
+					break;
+			}
+			break;
 		default:
 			throw new \InvalidArgumentException( 'Unknown group: ' . $_GET['_qm_acceptance_group'] );
 			break;

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -1,0 +1,23 @@
+<?php
+
+add_action( 'init', function() {
+	if ( ! isset( $_GET['_qm_acceptance_group'], $_GET['_qm_acceptance_test'] ) ) {
+		return;
+	}
+
+	switch ( $_GET['_qm_acceptance_group'] ) {
+		case 'doing_it_wrong':
+			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'function':
+					_deprecated_function( 'my_function', '2.0.0' );
+					break;
+				case 'hook':
+					_deprecated_hook( 'my_hook', '2.0.0' );
+					break;
+				case 'class':
+					_deprecated_class( 'My_Class', '2.0.0' );
+					break;
+			}
+			break;
+	}
+} );

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -8,14 +8,23 @@ add_action( 'init', function() {
 	switch ( $_GET['_qm_acceptance_group'] ) {
 		case 'doing_it_wrong':
 			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'argument':
+					_deprecated_argument( 'my_function', '2.0.0' );
+					break;
+				case 'class':
+					_deprecated_class( 'My_Class', '2.0.0' );
+					break;
+				case 'constructor':
+					_deprecated_constructor( 'My_Class', '2.0.0' );
+					break;
+				case 'file':
+					_deprecated_file( 'my_file.php', '2.0.0' );
+					break;
 				case 'function':
 					_deprecated_function( 'my_function', '2.0.0' );
 					break;
 				case 'hook':
 					_deprecated_hook( 'my_hook', '2.0.0' );
-					break;
-				case 'class':
-					_deprecated_class( 'My_Class', '2.0.0' );
 					break;
 			}
 			break;

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -39,6 +39,12 @@ add_action( 'init', function() {
 				case 'notice':
 					trigger_error( 'This is a test notice', E_USER_NOTICE );
 					break;
+				case 'suppressed-warning':
+					@trigger_error( 'This is a test suppressed warning', E_USER_WARNING );
+					break;
+				case 'suppressed-notice':
+					@trigger_error( 'This is a test suppressed notice', E_USER_NOTICE );
+					break;
 				default:
 					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
 					break;

--- a/tests/_support/MUPlugin/acceptance.yml
+++ b/tests/_support/MUPlugin/acceptance.yml
@@ -1,0 +1,4 @@
+services:
+  php:
+    volumes:
+      - ./tests/_support/MUPlugin/acceptance.php:/var/www/html/wp-content/mu-plugins/acceptance.php

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -8,7 +8,6 @@ modules:
   enabled:
     - WPWebDriver
     - WPDb
-    - \Helper\Acceptance
   config:
     WPDb:
       dsn: 'mysql:host=localhost:%TEST_SITE_DATABASE_PORT%;dbname=plugindb'

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -5,8 +5,7 @@
 
 class DoingItWrongCest {
 	public function _before( AcceptanceTester $I ): void {
-		$I->haveUserInDatabase( 'administrator', 'administrator' );
-		$I->loginAs( 'administrator', 'administrator' );
+		$I->loginAsAdmin();
 	}
 
 	public function DeprecatedArgumentShouldBeHandled( AcceptanceTester $I ): void {

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -10,27 +10,27 @@ class DoingItWrongCest {
 	}
 
 	public function DeprecatedArgumentShouldBeHandled( AcceptanceTester $I ): void {
-		$I->amDoingItWrong( 'argument' );
+		$I->amOnAPageThatIsDoingItWrong( 'argument' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'Function my_function was called with an argument that is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedConstructorShouldBeHandled( AcceptanceTester $I ): void {
-		$I->amDoingItWrong( 'constructor' );
+		$I->amOnAPageThatIsDoingItWrong( 'constructor' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'The called constructor method for My_Class class is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedFileShouldBeHandled( AcceptanceTester $I ): void {
-		$I->amDoingItWrong( 'file' );
+		$I->amOnAPageThatIsDoingItWrong( 'file' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_file.php is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedFunctionShouldBeHandled( AcceptanceTester $I ): void {
-		$I->amDoingItWrong( 'function' );
+		$I->amOnAPageThatIsDoingItWrong( 'function' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_function is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedHookShouldBeHandled( AcceptanceTester $I ): void {
-		$I->amDoingItWrong( 'hook' );
+		$I->amOnAPageThatIsDoingItWrong( 'hook' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_hook is deprecated since version 2.0.0' );
 	}
 }

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -9,6 +9,21 @@ class DoingItWrongCest {
 		$I->loginAs( 'administrator', 'administrator' );
 	}
 
+	public function DeprecatedArgumentShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amDoingItWrong( 'argument' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'Function my_function was called with an argument that is deprecated since version 2.0.0' );
+	}
+
+	public function DeprecatedConstructorShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amDoingItWrong( 'constructor' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'The called constructor method for My_Class class is deprecated since version 2.0.0' );
+	}
+
+	public function DeprecatedFileShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amDoingItWrong( 'file' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_file.php is deprecated since version 2.0.0' );
+	}
+
 	public function DeprecatedFunctionShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amDoingItWrong( 'function' );
 		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_function is deprecated since version 2.0.0' );

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+/**
+ * Acceptance tests for doing it wrong.
+ */
+
+class DoingItWrongCest {
+	public function _before( AcceptanceTester $I ): void {
+		$I->haveUserInDatabase( 'administrator', 'administrator' );
+		$I->loginAs( 'administrator', 'administrator' );
+	}
+
+	public function DeprecatedFunctionShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amDoingItWrong( 'function' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_function is deprecated since version 2.0.0' );
+	}
+
+	public function DeprecatedHookShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amDoingItWrong( 'hook' );
+		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_hook is deprecated since version 2.0.0' );
+	}
+}

--- a/tests/acceptance/PhpErrorsCest.php
+++ b/tests/acceptance/PhpErrorsCest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+/**
+ * Acceptance tests for PHP errors.
+ */
+
+class PhpErrorsCest {
+	public function _before( AcceptanceTester $I ): void {
+		$I->loginAsAdmin();
+	}
+
+	public function WarningShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersPhpError( 'warning' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test warning' );
+	}
+
+	public function NoticeShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersPhpError( 'notice' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test notice' );
+	}
+}

--- a/tests/acceptance/PhpErrorsCest.php
+++ b/tests/acceptance/PhpErrorsCest.php
@@ -17,4 +17,16 @@ class PhpErrorsCest {
 		$I->amOnAPageThatTriggersPhpError( 'notice' );
 		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test notice' );
 	}
+
+	public function SuppressedWarningShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersSuppressedPhpError( 'warning' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'Warning (Suppressed)' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test suppressed warning' );
+	}
+
+	public function SuppressedNoticeShouldBeHandled( AcceptanceTester $I ): void {
+		$I->amOnAPageThatTriggersSuppressedPhpError( 'notice' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'Notice (Suppressed)' );
+		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test suppressed notice' );
+	}
 }


### PR DESCRIPTION
The acceptance testing framework is only used for basic tests but I need to make a whole lot more use of it. This adds helper methods and some more tests.