### PR TITLE
Update db_queries.php - Make sure data->rows is array/countable

### DIFF
--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -236,7 +236,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 			'is_main_query' => true,
 		) );
 
-		$this->data->total_qs = count( $this->data->rows );
+		$this->data->total_qs = count( (array) $this->data->rows );
 		$this->data->total_time = $total_time;
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;


### PR DESCRIPTION
I encountered a fatal error in one environment, but I am still investigating the root cause. It may be due to incorrect hooks like pre_get_posts or queries bleeding. 

This solution should prevent any future fatal errors related to this issue.