### PR TITLE
Update Html.php

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -73,7 +73,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 	 * @return bool Should the authentication cookie be secure?
 	 */
 	public static function secure_cookie() {
-		return ( is_ssl() && ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) ) );
+		return ( is_ssl() && ( 'https' === wp_parse_url( home_url(), PHP_URL_SCHEME ) ) );
 	}
 
 	/**


### PR DESCRIPTION
parse_url() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead.