### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -54,6 +54,9 @@ jobs:
           - '8.3'
           - '7.4'
         include:
+          # Latest WordPress on PHP 8.5
+          - wp: '6.8'
+            php: '8.5'
           # Latest WordPress on PHP 8.4
           - wp: '6.8'
             php: '8.4'

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -44,6 +44,7 @@ jobs:
         label:
           - 'PHP'
         php:
+          - '8.5'
           - '8.4'
       fail-fast: false
     with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,6 +55,9 @@ jobs:
           - '8.3'
           - '7.4'
         include:
+          # Latest WordPress on PHP 8.5
+          - wp: '6.8'
+            php: '8.5'
           # Latest WordPress on PHP 8.4
           - wp: '6.8'
             php: '8.4'

--- a/classes/Collector_Assets.php
+++ b/classes/Collector_Assets.php
@@ -283,13 +283,13 @@ abstract class QM_Collector_Assets extends QM_DataCollector {
 		$reflector = new ReflectionClass( $modules );
 
 		$get_marked_for_enqueue = $reflector->getMethod( 'get_marked_for_enqueue' );
-		(\PHP_VERSION_ID < 80100) and $get_marked_for_enqueue->setAccessible( true );
+		( \PHP_VERSION_ID < 80100 ) && $get_marked_for_enqueue->setAccessible( true );
 
 		$get_dependencies = $reflector->getMethod( 'get_dependencies' );
-		(\PHP_VERSION_ID < 80100) and $get_dependencies->setAccessible( true );
+		( \PHP_VERSION_ID < 80100 ) && $get_dependencies->setAccessible( true );
 
 		$get_src = $reflector->getMethod( 'get_src' );
-		(\PHP_VERSION_ID < 80100) and $get_src->setAccessible( true );
+		( \PHP_VERSION_ID < 80100 ) && $get_src->setAccessible( true );
 
 		/**
 		 * @var array<string, array<string, mixed>> $enqueued
@@ -365,9 +365,9 @@ abstract class QM_Collector_Assets extends QM_DataCollector {
 		}
 
 		// @todo check isPrivate before changing visibility back
-		(\PHP_VERSION_ID < 80100) and $get_marked_for_enqueue->setAccessible( false );
-		(\PHP_VERSION_ID < 80100) and $get_dependencies->setAccessible( false );
-		(\PHP_VERSION_ID < 80100) and $get_src->setAccessible( false );
+		( \PHP_VERSION_ID < 80100 ) && $get_marked_for_enqueue->setAccessible( false );
+		( \PHP_VERSION_ID < 80100 ) && $get_dependencies->setAccessible( false );
+		( \PHP_VERSION_ID < 80100 ) && $get_src->setAccessible( false );
 
 		return $sources;
 	}

--- a/classes/Collector_Assets.php
+++ b/classes/Collector_Assets.php
@@ -283,13 +283,13 @@ abstract class QM_Collector_Assets extends QM_DataCollector {
 		$reflector = new ReflectionClass( $modules );
 
 		$get_marked_for_enqueue = $reflector->getMethod( 'get_marked_for_enqueue' );
-		$get_marked_for_enqueue->setAccessible( true );
+		(\PHP_VERSION_ID < 80100) and $get_marked_for_enqueue->setAccessible( true );
 
 		$get_dependencies = $reflector->getMethod( 'get_dependencies' );
-		$get_dependencies->setAccessible( true );
+		(\PHP_VERSION_ID < 80100) and $get_dependencies->setAccessible( true );
 
 		$get_src = $reflector->getMethod( 'get_src' );
-		$get_src->setAccessible( true );
+		(\PHP_VERSION_ID < 80100) and $get_src->setAccessible( true );
 
 		/**
 		 * @var array<string, array<string, mixed>> $enqueued
@@ -365,9 +365,9 @@ abstract class QM_Collector_Assets extends QM_DataCollector {
 		}
 
 		// @todo check isPrivate before changing visibility back
-		$get_marked_for_enqueue->setAccessible( false );
-		$get_dependencies->setAccessible( false );
-		$get_src->setAccessible( false );
+		(\PHP_VERSION_ID < 80100) and $get_marked_for_enqueue->setAccessible( false );
+		(\PHP_VERSION_ID < 80100) and $get_dependencies->setAccessible( false );
+		(\PHP_VERSION_ID < 80100) and $get_src->setAccessible( false );
 
 		return $sources;
 	}


### PR DESCRIPTION
Since PHP 8.1, calling the Reflection*::setAccessible() methods is no longer necessary as reflected properties/methods/etc will always be accessible. However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the Reflection*::setAccessible() methods is now formally deprecated and will yield a deprecation notice, which will fail test runs. As of PHP 9.0, the setAccessible() method(s) will be removed.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

Fixes #1025