### PR TITLE
Add HTTP API tests

### DIFF
--- a/collectors/http.php
+++ b/collectors/http.php
@@ -346,7 +346,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 				$code = intval( wp_remote_retrieve_response_code( $response['response'] ) );
 				$type = "HTTP {$code}";
 				if ( ( $code >= 400 ) && ( 'HEAD' !== $request['args']['method'] ) ) {
-					$this->data->errors['warning'][] = $key;
+					$this->data->errors['alert'][] = $key;
 				}
 			}
 
@@ -464,7 +464,7 @@ class QM_Collector_HTTP extends QM_DataCollector {
 		$this->data->ltime += $ltime;
 
 		if ( $exception || ( $response && $response->getStatusCode() >= 400 ) ) {
-			$this->data->errors['warning'][] = $key;
+			$this->data->errors['alert'][] = $key;
 		}
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,11 @@ include:
       - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
       - tests/_support/MUPlugin/acceptance.yml
     project_directory: .
+
+services:
+  httpbin:
+    image: mccutchen/go-httpbin:latest
+    container_name: ${COMPOSE_PROJECT_NAME}-httpbin
+    restart: always
+    environment:
+      PORT: 80

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -48,13 +48,15 @@ class AcceptanceTester extends \Codeception\Actor {
 		$this->seeElement( '#wp-admin-bar-query-monitor.qm-notice' );
 	}
 
-	public function seeQMMenu(): void {
+	protected function seeQMMenu(): void {
 		$this->seeElement( '#wp-admin-bar-query-monitor' );
+		$this->dontSeeElement( '#wp-admin-bar-query-monitor.qm-error' );
+		$this->dontSeeElement( '#wp-admin-bar-query-monitor.qm-alert' );
 		$this->dontSeeElement( '#wp-admin-bar-query-monitor.qm-warning' );
 		$this->dontSeeElement( '#wp-admin-bar-query-monitor.qm-notice' );
 	}
 
-	public function openQMPanel( string $panel ): void {
+	protected function openQMPanel( string $panel ): void {
 		$this->click( '#wp-admin-bar-query-monitor' );
 		$this->click( $panel, '#qm-panel-menu' );
 	}
@@ -62,5 +64,29 @@ class AcceptanceTester extends \Codeception\Actor {
 	public function seeInQMPanel( string $panel, string $text ): void {
 		$this->openQMPanel( $panel );
 		$this->see( $text, '.qm-panel-show' );
+		$this->seeQMMenu();
+	}
+
+	public function seeInQMPanelWithError( string $panel, string $text ): void {
+		$this->openQMPanel( $panel );
+		$this->see( $text, '.qm-panel-show' );
+		$this->seeElement( '#wp-admin-bar-query-monitor.qm-error' );
+	}
+
+	public function seeInQMPanelWithAlert( string $panel, string $text ): void {
+		$this->openQMPanel( $panel );
+		$this->see( $text, '.qm-panel-show' );
+		$this->seeElement( '#wp-admin-bar-query-monitor.qm-alert' );
+	}
+	public function seeInQMPanelWithWarning( string $panel, string $text ): void {
+		$this->openQMPanel( $panel );
+		$this->see( $text, '.qm-panel-show' );
+		$this->seeElement( '#wp-admin-bar-query-monitor.qm-warning' );
+	}
+
+	public function seeInQMPanelWithNotice( string $panel, string $text ): void {
+		$this->openQMPanel( $panel );
+		$this->see( $text, '.qm-panel-show' );
+		$this->seeElement( '#wp-admin-bar-query-monitor.qm-notice' );
 	}
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -36,6 +36,10 @@ class AcceptanceTester extends \Codeception\Actor {
 		$this->amOnPage( "/?_qm_acceptance_group=guzzle_requests&_qm_acceptance_test={$test}" );
 	}
 
+	public function amOnAPageThatMakesHttpRequest( string $test ): void {
+		$this->amOnPage( "/?_qm_acceptance_group=http_requests&_qm_acceptance_test={$test}" );
+	}
+
 	public function amOnAPageThatTriggersCallbackType( string $test ): void {
 		$this->amOnPage( "/?_qm_acceptance_group=callback_types&_qm_acceptance_test={$test}" );
 	}

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -62,50 +62,17 @@ add_action( 'init', function() {
 
 			switch ( $_GET['_qm_acceptance_test'] ) {
 				case 'successful_request':
-					// Create mock handler with a successful JSON response
-					$mock = new \GuzzleHttp\Handler\MockHandler(
-						[
-							new \GuzzleHttp\Psr7\Response(
-								200,
-								[
-									'Content-Type' => 'application/json',
-								],
-								json_encode(
-									[
-										'foo' => 'bar',
-									]
-								)
-							),
-						]
-					);
-
-					$stack = \GuzzleHttp\HandlerStack::create( $mock );
+					$stack = \GuzzleHttp\HandlerStack::create();
 					$stack->push( QM_Collector_HTTP::guzzle_middleware() );
 					$client = new \GuzzleHttp\Client( [ 'handler' => $stack ] );
-					$client->get( 'https://example.org/json' );
+					$client->get( 'http://httpbin/json' );
 					break;
 				case 'error_request':
-					// Create mock handler with a 404 response
-					$mock = new \GuzzleHttp\Handler\MockHandler(
-						[
-							new \GuzzleHttp\Psr7\Response(
-								404,
-								[
-									'Content-Type' => 'text/html',
-								],
-								'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-									<title>404 Not Found</title>
-									<h1>Not Found</h1>
-									<p>The requested URL was not found on the server.</p>'
-							),
-						]
-					);
-
-					$stack = \GuzzleHttp\HandlerStack::create( $mock );
+					$stack = \GuzzleHttp\HandlerStack::create();
 					$stack->push( QM_Collector_HTTP::guzzle_middleware() );
 					$client = new \GuzzleHttp\Client( [ 'handler' => $stack ] );
 					try {
-						$client->get( 'https://example.org/status/404' );
+						$client->get( 'http://httpbin/status/404' );
 					} catch ( \GuzzleHttp\Exception\ClientException $e ) {
 						// Expected 404 error
 					}

--- a/tests/_support/MUPlugin/acceptance.php
+++ b/tests/_support/MUPlugin/acceptance.php
@@ -82,6 +82,19 @@ add_action( 'init', function() {
 					break;
 			}
 			break;
+		case 'http_requests':
+			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'successful_request':
+					wp_remote_get( 'http://httpbin/status/200' );
+					break;
+				case '404_request':
+					wp_remote_get( 'http://httpbin/status/404' );
+					break;
+				default:
+					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
+					break;
+			}
+			break;
 		case 'callback_types':
 			switch ( $_GET['_qm_acceptance_test'] ) {
 				case 'function':

--- a/tests/acceptance/CallbacksCest.php
+++ b/tests/acceptance/CallbacksCest.php
@@ -10,28 +10,24 @@ class CallbacksCest {
 
 	public function FunctionCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersCallbackType( 'function' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'Hooks & Actions', '__return_true()' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
 	}
 
 	public function MethodCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersCallbackType( 'method' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'Hooks & Actions', 'test_method()' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
 	}
 
 	public function StaticMethodCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersCallbackType( 'static_method' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'Hooks & Actions', 'QM_Test_Static_Class::test_static_method()' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
 	}
 
 	public function ClosureCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersCallbackType( 'closure' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'Hooks & Actions', 'Closure on line' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'acceptance.php' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
@@ -39,7 +35,6 @@ class CallbacksCest {
 
 	public function InvokableCallbackShouldBeDisplayed( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersCallbackType( 'invokable' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'Hooks & Actions', '__invoke()' );
 		$I->seeInQMPanel( 'Hooks & Actions', 'qm_test_hook' );
 	}

--- a/tests/acceptance/DoingItWrongCest.php
+++ b/tests/acceptance/DoingItWrongCest.php
@@ -10,31 +10,31 @@ class DoingItWrongCest {
 
 	public function DeprecatedArgumentShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'argument' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'Function my_function was called with an argument that is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'Function my_function was called with an argument that is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedClassShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'class' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'My_Class is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'My_Class is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedConstructorShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'constructor' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'The called constructor method for My_Class class is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'The called constructor method for My_Class class is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedFileShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'file' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_file.php is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'my_file.php is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedFunctionShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'function' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_function is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'my_function is deprecated since version 2.0.0' );
 	}
 
 	public function DeprecatedHookShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatIsDoingItWrong( 'hook' );
-		$I->seeInQMPanel( 'Doing it Wrong (1)', 'my_hook is deprecated since version 2.0.0' );
+		$I->seeInQMPanelWithNotice( 'Doing it Wrong (1)', 'my_hook is deprecated since version 2.0.0' );
 	}
 }

--- a/tests/acceptance/GuzzleRequestsCest.php
+++ b/tests/acceptance/GuzzleRequestsCest.php
@@ -10,13 +10,13 @@ class GuzzleRequestsCest {
 
 	public function SuccessfulGuzzleRequestShouldBeLogged( AcceptanceTester $I ): void {
 		$I->amOnAPageThatMakesGuzzleRequest( 'successful_request' );
-		$I->seeQMMenu();
-		$I->seeInQMPanel( 'HTTP API Calls (1)', 'https://example.org/json' );
+		$I->seeInQMPanel( 'HTTP API Calls (1)', 'http://httpbin/json' );
+		$I->seeInQMPanel( 'HTTP API Calls (1)', '200 OK' );
 	}
 
 	public function ErrorGuzzleRequestShouldBeLogged( AcceptanceTester $I ): void {
 		$I->amOnAPageThatMakesGuzzleRequest( 'error_request' );
-		$I->seeQMMenuWithWarning();
-		$I->seeInQMPanel( 'HTTP API Calls (1)', 'https://example.org/status/404' );
+		$I->seeInQMPanelWithAlert( 'HTTP API Calls (1)', 'http://httpbin/status/404' );
+		$I->seeInQMPanelWithAlert( 'HTTP API Calls (1)', '404 Not Found' );
 	}
 }

--- a/tests/acceptance/HttpApiCest.php
+++ b/tests/acceptance/HttpApiCest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+/**
+ * Acceptance tests for WordPress HTTP API requests.
+ */
+
+class HttpApiCest {
+	public function _before( AcceptanceTester $I ): void {
+		$I->loginAsAdmin();
+	}
+
+	public function SuccessfulHttpRequestShouldBeLogged( AcceptanceTester $I ): void {
+		$I->amOnAPageThatMakesHttpRequest( 'successful_request' );
+		$I->seeInQMPanel( 'HTTP API Calls (1)', 'http://httpbin/status/200' );
+		$I->seeInQMPanel( 'HTTP API Calls (1)', '200 OK' );
+	}
+
+	public function ErrorHttpRequestShouldBeLogged( AcceptanceTester $I ): void {
+		$I->amOnAPageThatMakesHttpRequest( '404_request' );
+		$I->seeInQMPanelWithAlert( 'HTTP API Calls (1)', 'http://httpbin/status/404' );
+		$I->seeInQMPanelWithAlert( 'HTTP API Calls (1)', '404 Not Found' );
+	}
+}

--- a/tests/acceptance/PhpErrorsCest.php
+++ b/tests/acceptance/PhpErrorsCest.php
@@ -10,26 +10,22 @@ class PhpErrorsCest {
 
 	public function WarningShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersPhpError( 'warning' );
-		$I->seeQMMenuWithWarning();
-		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test warning' );
+		$I->seeInQMPanelWithWarning( 'PHP Errors (1)', 'This is a test warning' );
 	}
 
 	public function NoticeShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersPhpError( 'notice' );
-		$I->seeQMMenuWithNotice();
-		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test notice' );
+		$I->seeInQMPanelWithNotice( 'PHP Errors (1)', 'This is a test notice' );
 	}
 
 	public function SuppressedWarningShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersSuppressedPhpError( 'warning' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'PHP Errors (1)', 'Warning (Suppressed)' );
 		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test suppressed warning' );
 	}
 
 	public function SuppressedNoticeShouldBeHandled( AcceptanceTester $I ): void {
 		$I->amOnAPageThatTriggersSuppressedPhpError( 'notice' );
-		$I->seeQMMenu();
 		$I->seeInQMPanel( 'PHP Errors (1)', 'Notice (Suppressed)' );
 		$I->seeInQMPanel( 'PHP Errors (1)', 'This is a test suppressed notice' );
 	}


### PR DESCRIPTION
* Introduces an HTTP bin service container for better mocking requests during tests.
* Adds tests for HTTP API requests.
* Standardises on the `alert` type for HTTP API and Guzzle errors.

See #1043.