### PR TITLE
fix PHP Warning: Undefined array key "line"

### DIFF
--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -236,7 +236,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 			'is_main_query' => true,
 		) );
 
-		$this->data->total_qs = count( $this->data->rows );
+		$this->data->total_qs = count( $this->data->rows ?? [] );
 		$this->data->total_time = $total_time;
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;


### PR DESCRIPTION
php log

```
2025/11/12 23:57:25 [error] 306#306: *1069280 FastCGI sent in stderr: "PHP message: PHP Warning: Undefined array key "file" in /www/sites/www.krjojo.com/index/wp-content/plugins/query-monitor/dispatchers/Html.php on line 1021; PHP message: PHP Warning: Undefined array key "line" in /www/sites/www.krjojo.com/index/wp-content/plugins/query-monitor/dispatchers/Html.php on line 1021" while reading upstream, client: 2409:*****, server: www.krjojo.com, request: "GET /wp-admin/options-general.php?page=krj_optimiz_slug HTTP/2.0", upstream: "fastcgi://127.0.0.1:9003", host: "www.krjojo.com", referrer: "https://www.krjojo.com/wp-admin/options-general.php"
```

query-monitor log

```
Uncaught Error: count(): Argument #1 ($value) must be of type Countable|array, null given

in /www/sites/www.krjojo.com/index/wp-content/plugins/query-monitor/collectors/db_queries.php on line 239

Call stack:

QM_Collector_DB_Queries::process_db_object()

wp-content/plugins/query-monitor/collectors/db_queries.php:77

QM_Collector_DB_Queries::process()

wp-content/plugins/query-monitor/classes/Collectors.php:84

QM_Collectors::process()

wp-content/plugins/query-monitor/classes/Dispatcher.php:123

QM_Dispatcher::get_outputters()

wp-content/plugins/query-monitor/dispatchers/Html.php:357

QM_Dispatcher_Html::before_output()

wp-content/plugins/query-monitor/dispatchers/Html.php:321

QM_Dispatcher_Html::dispatch()

wp-includes/class-wp-hook.php:324

WP_Hook::apply_filters()

wp-includes/class-wp-hook.php:348

WP_Hook::do_action()

wp-includes/plugin.php:517

do_action()

wp-includes/load.php:1304

shutdown_action_hook()
```