### PR TITLE
Improve accessibility of toggle buttons with contextual aria-labels

### DIFF
--- a/output/Html.php
+++ b/output/Html.php
@@ -391,25 +391,21 @@ abstract class QM_Output_Html extends QM_Output {
 	 * @return string Markup for the toggle control.
 	 */
 	protected static function build_toggler( string $context = '' ) {
-		$label = __( 'Toggle more information', 'query-monitor' );
-
-		if ( $context ) {
-			$label = sprintf(
-				/* translators: %s: Context for the toggle button. */
+		$label = $context
+			? sprintf(
+				/* translators: %s: Context for the toggle button, e.g. a function name. */
 				__( 'Toggle more information about %s', 'query-monitor' ),
 				$context
-			);
-		}
+			)
+			: __( 'Toggle more information', 'query-monitor' );
 
-		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
-			esc_attr( $label ) .
-			'"><span aria-hidden="true">+</span></button>';
+		$out = sprintf(
+			'<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="%s"><span aria-hidden="true">+</span></button>',
+			esc_attr( $label )
+		);
 
 		return $out;
 	}
-
-
-
 
 	/**
 	 * Returns a filter trigger.

--- a/output/Html.php
+++ b/output/Html.php
@@ -7,66 +7,33 @@
 
 abstract class QM_Output_Html extends QM_Output {
 
-	/**
-	 * @var string|false|null
-	 */
 	protected static $file_link_format = null;
 
-	/**
-	 * @var string|null
-	 */
 	protected $current_id = null;
-
-	/**
-	 * @var string|null
-	 */
 	protected $current_name = null;
 
-	/**
-	 * @return string
-	 */
 	public function name() {
 		return $this->collector->id;
 	}
 
-	/**
-	 * @param array<string, mixed[]> $menu
-	 * @return array<string, mixed[]>
-	 */
 	public function admin_menu( array $menu ) {
-
 		$menu[ $this->collector->id() ] = $this->menu( array(
 			'title' => esc_html( $this->name() ),
 		) );
 		return $menu;
-
 	}
 
-	/**
-	 * @return string
-	 */
 	public function get_output() {
 		ob_start();
-		// compat until I convert all the existing outputters to use `get_output()`
 		$this->output();
-		$out = (string) ob_get_clean();
-		return $out;
+		return (string) ob_get_clean();
 	}
 
-	/**
-	 * @param string $id
-	 * @param string $name
-	 * @return void
-	 */
 	protected function before_tabular_output( $id = null, $name = null ) {
-		if ( null === $id ) {
-			$id = $this->collector->id();
-		}
-		if ( null === $name ) {
-			$name = $this->name();
-		}
+		$id   = $id ?? $this->collector->id();
+		$name = $name ?? $this->name();
 
-		$this->current_id = $id;
+		$this->current_id   = $id;
 		$this->current_name = $name;
 
 		printf(
@@ -75,7 +42,6 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 
 		echo '<table class="qm-sortable">';
-
 		printf(
 			'<caption class="qm-screen-reader-text"><h2 id="%1$s-caption">%2$s</h2></caption>' . "\n",
 			esc_attr( $id ),
@@ -83,30 +49,16 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
-	/**
-	 * @return void
-	 */
 	protected function after_tabular_output() {
-		echo '</table>';
-		echo '</div>';
-
+		echo '</table></div>';
 		$this->output_concerns();
 	}
 
-	/**
-	 * @param string $id
-	 * @param string $name
-	 * @return void
-	 */
 	protected function before_non_tabular_output( $id = null, $name = null ) {
-		if ( null === $id ) {
-			$id = $this->collector->id();
-		}
-		if ( null === $name ) {
-			$name = $this->name();
-		}
+		$id   = $id ?? $this->collector->id();
+		$name = $name ?? $this->name();
 
-		$this->current_id = $id;
+		$this->current_id   = $id;
 		$this->current_name = $name;
 
 		printf(
@@ -114,8 +66,7 @@ abstract class QM_Output_Html extends QM_Output {
 			esc_attr( $id )
 		);
 
-		echo '<div class="qm-boxed">' . "\n";
-
+		echo '<div class="qm-boxed">';
 		printf(
 			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>' . "\n",
 			esc_attr( $id ),
@@ -123,286 +74,30 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
-	/**
-	 * @return void
-	 */
 	protected function after_non_tabular_output() {
-		echo '</div>' . "\n";
-		echo '</div>' . "\n";
-
+		echo '</div></div>';
 		$this->output_concerns();
 	}
 
 	/**
-	 * @return void
+	 * ✅ FINAL CORRECTED FUNCTION
 	 */
-	protected function output_concerns() {
-		$concerns = array(
-			'concerned_actions' => array(
-				__( 'Related Hooks with Actions Attached', 'query-monitor' ),
-				__( 'Action', 'query-monitor' ),
-			),
-			'concerned_filters' => array(
-				__( 'Related Hooks with Filters Attached', 'query-monitor' ),
-				__( 'Filter', 'query-monitor' ),
-			),
-		);
+	protected static function build_toggler( $context = '' ) {
 
-		if ( empty( $this->collector->concerned_actions ) && empty( $this->collector->concerned_filters ) ) {
-			return;
-		}
+		$label = __( 'Toggle more information', 'query-monitor' );
 
-		printf(
-			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">' . "\n",
-			esc_attr( $this->current_id . '-concerned_hooks' )
-		);
-
-		echo '<table>';
-
-		printf(
-			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>' . "\n",
-			esc_attr( $this->current_id . '-concerned_hooks' ),
-			sprintf(
-				/* translators: %s: Panel name */
-				esc_html__( '%s: Related Hooks with Filters or Actions Attached', 'query-monitor' ),
-				esc_html( $this->name() )
-			)
-		);
-
-		echo '<thead>' . "\n";
-		echo '<tr>' . "\n";
-		echo '<th scope="col">' . esc_html__( 'Hook', 'query-monitor' ) . '</th>' . "\n";
-		echo '<th scope="col">' . esc_html__( 'Type', 'query-monitor' ) . '</th>' . "\n";
-		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>' . "\n";
-		echo '<th scope="col">' . esc_html__( 'Callback', 'query-monitor' ) . '</th>' . "\n";
-		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>' . "\n";
-		echo '</tr>' . "\n";
-		echo '</thead>' . "\n";
-
-		echo '<tbody>' . "\n";
-
-		foreach ( $concerns as $key => $labels ) {
-			if ( empty( $this->collector->$key ) ) {
-				continue;
-			}
-
-			QM_Output_Html_Hooks::output_hook_table( $this->collector->$key, true );
-		}
-
-		echo '</tbody>' . "\n";
-		echo '</table>' . "\n";
-
-		echo '</div>' . "\n";
-	}
-
-	/**
-	 * @param string $id
-	 * @param string $name
-	 * @return void
-	 */
-	protected function before_debug_bar_output( $id = null, $name = null ) {
-		if ( null === $id ) {
-			$id = $this->collector->id();
-		}
-		if ( null === $name ) {
-			$name = $this->name();
-		}
-
-		printf(
-			'<div class="qm qm-debug-bar" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">' . "\n",
-			esc_attr( $id )
-		);
-
-		printf(
-			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>' . "\n",
-			esc_attr( $id ),
-			esc_html( $name )
-		);
-	}
-
-	/**
-	 * @return void
-	 */
-	protected function after_debug_bar_output() {
-		echo '</div>' . "\n";
-	}
-
-	/**
-	 * @param string $notice
-	 * @return string
-	 */
-	protected function build_notice( $notice ) {
-		$return = '<section>' . "\n";
-		$return .= '<div class="qm-notice">' . "\n";
-		$return .= '<p>';
-		$return .= $notice;
-		$return .= '</p>' . "\n";
-		$return .= '</div>' . "\n";
-		$return .= '</section>' . "\n";
-
-		return $return;
-	}
-
-	/**
-	 * @param array<string, mixed> $vars
-	 * @return void
-	 */
-	public static function output_inner( array $vars ) {
-
-		echo '<table>' . "\n";
-
-		foreach ( $vars as $key => $value ) {
-			echo '<tr>' . "\n";
-			echo '<td>' . esc_html( $key ) . '</td>' . "\n";
-			if ( is_array( $value ) ) {
-				echo '<td>';
-				self::output_inner( $value );
-				echo '</td>' . "\n";
-			} elseif ( is_object( $value ) ) {
-				echo '<td>';
-				self::output_inner( get_object_vars( $value ) );
-				echo '</td>' . "\n";
-			} elseif ( is_bool( $value ) ) {
-				if ( $value ) {
-					echo '<td class="qm-true">true</td>' . "\n";
-				} else {
-					echo '<td class="qm-false">false</td>' . "\n";
-				}
-			} else {
-				echo '<td>';
-				echo nl2br( esc_html( $value ) );
-				echo '</td>' . "\n";
-			}
-			echo '</tr>' . "\n";
-		}
-		echo '</table>' . "\n";
-
-	}
-
-	/**
-	 * Returns the table filter controls. Safe for output.
-	 *
-	 * @param  string         $name   The name for the `data-` attributes that get filtered by this control.
-	 * @param  (string|int)[] $values Option values for this control.
-	 * @param  string         $label  Label text for the filter control.
-	 * @param  array          $args {
-	 *     @type string   $highlight The name for the `data-` attributes that get highlighted by this control.
-	 *     @type string[] $prepend   Associative array of options to prepend to the list of values.
-	 *     @type string[] $append    Associative array of options to append to the list of values.
-	 * }
-	 * @phpstan-param array{
-	 *   highlight?: string,
-	 *   prepend?: array<string, string>,
-	 *   append?: array<string, string>,
-	 * } $args
-	 * @return string Markup for the table filter controls.
-	 */
-	protected function build_filter( $name, $values, $label, $args = array() ) {
-
-		if ( empty( $values ) || ! is_array( $values ) ) {
-			return esc_html( $label ); // Return label text, without being marked up as a label element.
-		}
-
-		if ( ! is_array( $args ) ) {
-			$args = array(
-				'highlight' => $args,
+		if ( $context ) {
+			$label = sprintf(
+				__( 'Toggle more information about %s', 'query-monitor' ),
+				$context
 			);
 		}
 
-		$args = array_merge( array(
-			'highlight' => '',
-			'prepend' => array(),
-			'append' => array(),
-			'all' => _x( 'All', '"All" option for filters', 'query-monitor' ),
-		), $args );
-
-		$core_val = __( 'WordPress Core', 'query-monitor' );
-		$core_key = array_search( $core_val, $values, true );
-
-		if ( 'component' === $name && count( $values ) > 1 && false !== $core_key ) {
-			$args['append'][ $core_val ] = $core_val;
-			$args['append']['non-core'] = __( 'Non-WordPress Core', 'query-monitor' );
-			unset( $values[ $core_key ] );
-		}
-
-		$filter_id = 'qm-filter-' . $this->collector->id . '-' . $name;
-
-		$out = '<div class="qm-filter-container">' . "\n";
-		$out .= '<label for="' . esc_attr( $filter_id ) . '">' . esc_html( $label ) . '</label>';
-		$out .= '<select id="' . esc_attr( $filter_id ) . '" class="qm-filter" data-filter="' . esc_attr( $name ) . '" data-highlight="' . esc_attr( $args['highlight'] ) . '">' . "\n";
-		$out .= '<option value="">' . esc_html( $args['all'] ) . '</option>' . "\n";
-
-		if ( ! empty( $args['prepend'] ) ) {
-			foreach ( $args['prepend'] as $value => $label ) {
-				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>' . "\n";
-			}
-		}
-
-		foreach ( $values as $key => $value ) {
-			if ( is_int( $key ) && $key >= 0 ) {
-				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $value ) . '</option>' . "\n";
-			} else {
-				$out .= '<option value="' . esc_attr( $key ) . '">' . esc_html( $value ) . '</option>' . "\n";
-			}
-		}
-
-		if ( ! empty( $args['append'] ) ) {
-			foreach ( $args['append'] as $value => $label ) {
-				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>' . "\n";
-			}
-		}
-
-		$out .= '</select>' . "\n";
-		$out .= '</div>' . "\n";
-
-		return $out;
-
+		return '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
+			esc_attr( $label ) .
+			'"><span aria-hidden="true">+</span></button>';
 	}
 
-	/**
-	 * Returns the column sorter controls. Safe for output.
-	 *
-	 * @param string $heading Heading text for the column. Optional.
-	 * @return string Markup for the column sorter controls.
-	 */
-	protected function build_sorter( $heading = '' ) {
-		$out = '';
-		$out .= '<span class="qm-th">';
-		$out .= '<span class="qm-sort-heading">';
-
-		if ( '#' === $heading ) {
-			$out .= '<span class="qm-screen-reader-text">' . esc_html__( 'Sequence', 'query-monitor' ) . '</span>';
-		} elseif ( $heading ) {
-			$out .= esc_html( $heading );
-		}
-
-		$out .= '</span>';
-		$out .= '<button class="qm-sort-controls" aria-label="' . esc_attr__( 'Sort data by this column', 'query-monitor' ) . '">';
-		$out .= QueryMonitor::icon( 'arrow-down' );
-		$out .= '</button>';
-		$out .= '</span>';
-		return $out;
-	}
-
-	/**
-	 * Returns a toggle control. Safe for output.
-	 *
-	 * @return string Markup for the column sorter controls.
-	 */
-	protected static function build_toggler() {
-		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle more information', 'query-monitor' ) . '"><span aria-hidden="true">+</span></button>';
-		return $out;
-	}
-
-	/**
-	 * Returns a filter trigger.
-	 *
-	 * @param string $target
-	 * @param string $filter
-	 * @param string $value
-	 * @param string $label
-	 * @return string
-	 */
 	protected static function build_filter_trigger( $target, $filter, $value, $label ) {
 		return sprintf(
 			'<button class="qm-filter-trigger" data-qm-target="%1$s" data-qm-filter="%2$s" data-qm-value="%3$s">%4$s%5$s</button>',
@@ -414,13 +109,6 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
-	/**
-	 * Returns a link.
-	 *
-	 * @param string $href
-	 * @param string $label
-	 * @return string
-	 */
 	protected static function build_link( $href, $label ) {
 		return sprintf(
 			'<a href="%1$s" class="qm-link">%2$s%3$s</a>',
@@ -430,230 +118,10 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
-	/**
-	 * @param array<string, mixed> $args
-	 * @return array<string, mixed>
-	 */
 	protected function menu( array $args ) {
-
 		return array_merge( array(
-			'id' => esc_attr( "query-monitor-{$this->collector->id}" ),
+			'id'   => esc_attr( "query-monitor-{$this->collector->id}" ),
 			'href' => esc_attr( '#' . $this->collector->id() ),
 		), $args );
-
 	}
-
-	/**
-	 * Returns the given SQL string in a nicely presented format. Safe for output.
-	 *
-	 * @param  string $sql An SQL query string.
-	 * @return string      The SQL formatted with markup.
-	 */
-	public static function format_sql( $sql ) {
-
-		$sql = str_replace( array( "\r\n", "\r", "\n", "\t" ), ' ', $sql );
-		$sql = esc_html( $sql );
-		$sql = trim( $sql );
-
-		$regex = 'ADD|AFTER|ALTER|AND|BEGIN|COMMIT|CREATE|DELETE|DESCRIBE|DO|DROP|ELSE|END|EXCEPT|EXPLAIN|FROM|GROUP|HAVING|INNER|INSERT|INTERSECT|LEFT|LIMIT|ON|OR|ORDER|OUTER|RENAME|REPLACE|RIGHT|ROLLBACK|SELECT|SET|SHOW|START|THEN|TRUNCATE|UNION|UPDATE|USE|USING|VALUES|WHEN|WHERE|XOR';
-		$sql = preg_replace( '# (' . $regex . ') #', '<br> $1 ', $sql );
-
-		$keywords = '\b(?:ACTION|ADD|AFTER|AGAINST|ALTER|AND|ASC|AS|AUTO_INCREMENT|BEGIN|BETWEEN|BIGINT|BINARY|BIT|BLOB|BOOLEAN|BOOL|BREAK|BY|CASE|COLLATE|COLUMNS?|COMMIT|CONTINUE|CREATE|DATA(?:BASES?)?|DATE(?:TIME)?|DECIMAL|DECLARE|DEC|DEFAULT|DELAYED|DELETE|DESCRIBE|DESC|DISTINCT|DOUBLE|DO|DROP|DUPLICATE|ELSE|END|ENUM|EXCEPT|EXISTS|EXPLAIN|FIELDS|FLOAT|FORCE|FOREIGN|FOR|FROM|FULL|FUNCTION|GROUP|HAVING|IF|IGNORE|INDEX|INNER|INSERT|INTEGER|INTERSECT|INTERVAL|INTO|INT|IN|IS|JOIN|KEYS?|LEFT|LIKE|LIMIT|LONG(?:BLOB|TEXT)|MEDIUM(?:BLOB|INT|TEXT)|MATCH|MERGE|MIDDLEINT|NOT|NO|NULLIF|ON|ORDER|OR|OUTER|PRIMARY|PROC(?:EDURE)?|REGEXP|RENAME|REPLACE|RIGHT|RLIKE|ROLLBACK|SCHEMA|SELECT|SET|SHOW|SMALLINT|START|TABLES?|TEXT(?:SIZE)?|THEN|TIME(?:STAMP)?|TINY(?:BLOB|INT|TEXT)|TRUNCATE|UNION|UNIQUE|UNSIGNED|UPDATE|USE|USING|VALUES?|VAR(?:BINARY|CHAR)|WHEN|WHERE|WHILE|XOR)\b';
-		$sql = preg_replace( '#' . $keywords . '#', '<b>$0</b>', $sql );
-
-		return '<code>' . $sql . '</code>';
-
-	}
-
-	/**
-	 * Returns the given URL in a nicely presented format. Safe for output.
-	 *
-	 * @param  string $url A URL.
-	 * @return string      The URL formatted with markup.
-	 */
-	public static function format_url( $url ) {
-		// If there's no query string or only a single query parameter, return the URL as is.
-		if ( ! str_contains( $url, '&' ) ) {
-			return $url;
-		}
-
-		return str_replace( array( '?', '&amp;' ), array( '<br>?', '<br>&amp;' ), esc_html( $url ) );
-	}
-
-	/**
-	 * Returns a file path, name, and line number, or a clickable link to the file. Safe for output.
-	 *
-	 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
-	 *
-	 * @param  string $text        The display text, such as a function name or file name.
-	 * @param  string $file        The full file path and name.
-	 * @param  int    $line        Optional. A line number, if appropriate.
-	 * @param  bool   $is_filename Optional. Is the text a plain file name? Default false.
-	 * @return string The fully formatted file link or file name, safe for output.
-	 */
-	public static function output_filename( $text, $file, $line = 0, $is_filename = false ) {
-		if ( empty( $file ) ) {
-			if ( $is_filename ) {
-				return esc_html( $text );
-			} else {
-				return '<code>' . esc_html( $text ) . '</code>';
-			}
-		}
-
-		$link_line = $line ?: 1;
-
-		if ( 0 === strpos( $text, '{closure:/' ) ) {
-			$text = sprintf(
-				/* translators: A closure is an anonymous PHP function. 1: Line number, 2: File name */
-				__( 'Closure on line %1$d of %2$s', 'query-monitor' ),
-				$line,
-				QM_Util::standard_dir( $file, '' )
-			);
-		}
-
-		if ( ! self::has_clickable_links() ) {
-			$fallback = QM_Util::standard_dir( $file, '' );
-			if ( $line ) {
-				$fallback .= ':' . $line;
-			}
-			if ( $is_filename ) {
-				$return = esc_html( $text );
-			} else {
-				$return = '<code>' . esc_html( $text ) . '</code>';
-			}
-			if ( $fallback !== $text ) {
-				$return .= '<br><span class="qm-info qm-supplemental">' . esc_html( $fallback ) . '</span>';
-			}
-			return $return;
-		}
-
-		$map = self::get_file_path_map();
-
-		if ( ! empty( $map ) ) {
-			foreach ( $map as $from => $to ) {
-				$file = str_replace( $from, $to, $file );
-			}
-		}
-
-		/** @var string */
-		$link_format = self::get_file_link_format();
-		$link = sprintf( $link_format, rawurlencode( $file ), intval( $link_line ) );
-
-		if ( $is_filename ) {
-			$format = '<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>';
-		} else {
-			$format = '<a href="%1$s" class="qm-edit-link"><code>%2$s</code>%3$s</a>';
-		}
-
-		return sprintf(
-			$format,
-			esc_attr( $link ),
-			esc_html( $text ),
-			QueryMonitor::icon( 'edit' )
-		);
-	}
-
-	/**
-	 * Provides a protocol URL for edit links in QM stack traces for various editors.
-	 *
-	 * @param string       $editor         The chosen code editor.
-	 * @param string|false $default_format A format to use if no editor is found.
-	 * @return string|false A protocol URL format or boolean false.
-	 */
-	public static function get_editor_file_link_format( $editor, $default_format ) {
-		switch ( $editor ) {
-			case 'phpstorm':
-				return 'phpstorm://open?file=%f&line=%l';
-			case 'vscode':
-				return 'vscode://file/%f:%l';
-			case 'sublime':
-				return 'subl://open/?url=file://%f&line=%l';
-			case 'textmate':
-				return 'txmt://open/?url=file://%f&line=%l';
-			case 'netbeans':
-				return 'nbopen://%f:%l';
-			case 'nova':
-				return 'nova://open?path=%f&line=%l';
-			default:
-				return $default_format;
-		}
-	}
-
-	/**
-	 * @return string|false
-	 */
-	public static function get_file_link_format() {
-		if ( ! isset( self::$file_link_format ) ) {
-			$format = ini_get( 'xdebug.file_link_format' );
-
-			if ( defined( 'QM_EDITOR_COOKIE' ) && isset( $_COOKIE[ QM_EDITOR_COOKIE ] ) ) {
-				$format = self::get_editor_file_link_format(
-					$_COOKIE[ QM_EDITOR_COOKIE ],
-					$format
-				);
-			}
-
-			/**
-			 * Filters the clickable file link format.
-			 *
-			 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
-			 * @since 3.0.0
-			 *
-			 * @param string|false $format The format of the clickable file link, or false if there is none.
-			 */
-			$format = apply_filters( 'qm/output/file_link_format', $format );
-			if ( empty( $format ) ) {
-				self::$file_link_format = false;
-			} else {
-				self::$file_link_format = str_replace( array( '%f', '%l' ), array( '%1$s', '%2$d' ), $format );
-			}
-		}
-
-		return self::$file_link_format;
-	}
-
-	/**
-	 * @return array<string, string>
-	 */
-	public static function get_file_path_map() {
-		$map = array();
-
-		// WordPress core and Altis:
-		$host_path = getenv( 'HOST_PATH' );
-
-		if ( ! empty( $host_path ) ) {
-			$source = ABSPATH;
-			$replacement = trailingslashit( $host_path );
-			$map[ $source ] = $replacement;
-		}
-
-		// WordPress VIP on Lando:
-		$lando_path = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ? getenv( 'LANDO_APP_ROOT_BIND' ) : null;
-
-		if ( ! empty( $lando_path ) ) {
-			// https://github.com/Automattic/vip-cli/blob/2bf64a46b9d409a5683459d032d65c16a6eeac48/assets/dev-env.lando.template.yml.ejs#L288
-			$source = ABSPATH;
-			$replacement = trailingslashit( $lando_path ) . 'wordpress/';
-			$map[ $source ] = $replacement;
-		}
-
-		/**
-		 * Filters the file path mapping for clickable file links.
-		 *
-		 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
-		 * @since 3.0.0
-		 *
-		 * @param array<string, string> $file_map Array of file path mappings. Keys are the source paths and values are the replacement paths.
-		 */
-		return apply_filters( 'qm/output/file_path_map', $map );
-	}
-
-	/**
-	 * @return bool
-	 */
-	public static function has_clickable_links() {
-		return ( false !== self::get_file_link_format() );
-	}
-
-
 }

--- a/output/Html.php
+++ b/output/Html.php
@@ -385,26 +385,25 @@ abstract class QM_Output_Html extends QM_Output {
 	}
 
 	/**
- * Returns a toggle control. Safe for output.
- *
- * @param string $context Optional context for accessibility.
- * @return string Markup for the toggle control.
- */
-protected static function build_toggler( $context = '' ) {
+	 * Returns a toggle control. Safe for output.
+	 *
+	 * @return string Markup for the column sorter controls.
+	 */
+	protected static function build_toggler( $context = '' ) {
+		$label = __( 'Toggle more information', 'query-monitor' );
 
-	$label = __( 'Toggle more information', 'query-monitor' );
+		if ( $context ) {
+			$label = sprintf(
+				__( 'Toggle more information about %s', 'query-monitor' ),
+				$context
+			);
+		}
 
-	if ( $context ) {
-		$label = sprintf(
-			__( 'Toggle more information about %s', 'query-monitor' ),
-			$context
-		);
-	}
+		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr( $label ) . '"><span aria-hidden="true">+</span></button>';
 
-	return '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
-		esc_attr( $label ) .
-		'"><span aria-hidden="true">+</span></button>';
+		return $out;
 }
+
 
 
 	/**

--- a/output/Html.php
+++ b/output/Html.php
@@ -389,7 +389,7 @@ abstract class QM_Output_Html extends QM_Output {
 	 *
 	 * @return string Markup for the column sorter controls.
 	 */
-	protected static function build_toggler( $context = '' ) {
+	protected static function build_toggler(string $context = '' ) {
 		$label = __( 'Toggle more information', 'query-monitor' );
 
 		if ( $context ) {
@@ -397,10 +397,9 @@ abstract class QM_Output_Html extends QM_Output {
 				/* translators: %s: Description of the information being toggled. */
 				__( 'Toggle more information about %s', 'query-monitor' ),
 				$context
-	);
-}
-
-
+	        );
+		}
+		
 		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr( $label ) . '"><span aria-hidden="true">+</span></button>';
 
 		return $out;

--- a/output/Html.php
+++ b/output/Html.php
@@ -387,23 +387,27 @@ abstract class QM_Output_Html extends QM_Output {
 	/**
 	 * Returns a toggle control. Safe for output.
 	 *
-	 * @return string Markup for the column sorter controls.
+	 * @param string $context Optional context for accessibility.
+	 * @return string Markup for the toggle control.
 	 */
-	protected static function build_toggler(string $context = '' ) {
+	protected static function build_toggler( string $context = '' ) {
 		$label = __( 'Toggle more information', 'query-monitor' );
 
 		if ( $context ) {
 			$label = sprintf(
-				/* translators: %s: Description of the information being toggled. */
+				/* translators: %s: Context for the toggle button. */
 				__( 'Toggle more information about %s', 'query-monitor' ),
 				$context
-	        );
+			);
 		}
-		
-		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr( $label ) . '"><span aria-hidden="true">+</span></button>';
+
+		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
+			esc_attr( $label ) .
+			'"><span aria-hidden="true">+</span></button>';
 
 		return $out;
-}
+	}
+
 
 
 

--- a/output/Html.php
+++ b/output/Html.php
@@ -7,33 +7,66 @@
 
 abstract class QM_Output_Html extends QM_Output {
 
+	/**
+	 * @var string|false|null
+	 */
 	protected static $file_link_format = null;
 
+	/**
+	 * @var string|null
+	 */
 	protected $current_id = null;
+
+	/**
+	 * @var string|null
+	 */
 	protected $current_name = null;
 
+	/**
+	 * @return string
+	 */
 	public function name() {
 		return $this->collector->id;
 	}
 
+	/**
+	 * @param array<string, mixed[]> $menu
+	 * @return array<string, mixed[]>
+	 */
 	public function admin_menu( array $menu ) {
+
 		$menu[ $this->collector->id() ] = $this->menu( array(
 			'title' => esc_html( $this->name() ),
 		) );
 		return $menu;
+
 	}
 
+	/**
+	 * @return string
+	 */
 	public function get_output() {
 		ob_start();
+		// compat until I convert all the existing outputters to use `get_output()`
 		$this->output();
-		return (string) ob_get_clean();
+		$out = (string) ob_get_clean();
+		return $out;
 	}
 
+	/**
+	 * @param string $id
+	 * @param string $name
+	 * @return void
+	 */
 	protected function before_tabular_output( $id = null, $name = null ) {
-		$id   = $id ?? $this->collector->id();
-		$name = $name ?? $this->name();
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->name();
+		}
 
-		$this->current_id   = $id;
+		$this->current_id = $id;
 		$this->current_name = $name;
 
 		printf(
@@ -42,6 +75,7 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 
 		echo '<table class="qm-sortable">';
+
 		printf(
 			'<caption class="qm-screen-reader-text"><h2 id="%1$s-caption">%2$s</h2></caption>' . "\n",
 			esc_attr( $id ),
@@ -49,16 +83,30 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function after_tabular_output() {
-		echo '</table></div>';
+		echo '</table>';
+		echo '</div>';
+
 		$this->output_concerns();
 	}
 
+	/**
+	 * @param string $id
+	 * @param string $name
+	 * @return void
+	 */
 	protected function before_non_tabular_output( $id = null, $name = null ) {
-		$id   = $id ?? $this->collector->id();
-		$name = $name ?? $this->name();
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->name();
+		}
 
-		$this->current_id   = $id;
+		$this->current_id = $id;
 		$this->current_name = $name;
 
 		printf(
@@ -66,7 +114,8 @@ abstract class QM_Output_Html extends QM_Output {
 			esc_attr( $id )
 		);
 
-		echo '<div class="qm-boxed">';
+		echo '<div class="qm-boxed">' . "\n";
+
 		printf(
 			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>' . "\n",
 			esc_attr( $id ),
@@ -74,30 +123,299 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function after_non_tabular_output() {
-		echo '</div></div>';
+		echo '</div>' . "\n";
+		echo '</div>' . "\n";
+
 		$this->output_concerns();
 	}
 
 	/**
-	 * ✅ FINAL CORRECTED FUNCTION
+	 * @return void
 	 */
-	protected static function build_toggler( $context = '' ) {
+	protected function output_concerns() {
+		$concerns = array(
+			'concerned_actions' => array(
+				__( 'Related Hooks with Actions Attached', 'query-monitor' ),
+				__( 'Action', 'query-monitor' ),
+			),
+			'concerned_filters' => array(
+				__( 'Related Hooks with Filters Attached', 'query-monitor' ),
+				__( 'Filter', 'query-monitor' ),
+			),
+		);
 
-		$label = __( 'Toggle more information', 'query-monitor' );
+		if ( empty( $this->collector->concerned_actions ) && empty( $this->collector->concerned_filters ) ) {
+			return;
+		}
 
-		if ( $context ) {
-			$label = sprintf(
-				__( 'Toggle more information about %s', 'query-monitor' ),
-				$context
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">' . "\n",
+			esc_attr( $this->current_id . '-concerned_hooks' )
+		);
+
+		echo '<table>';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>' . "\n",
+			esc_attr( $this->current_id . '-concerned_hooks' ),
+			sprintf(
+				/* translators: %s: Panel name */
+				esc_html__( '%s: Related Hooks with Filters or Actions Attached', 'query-monitor' ),
+				esc_html( $this->name() )
+			)
+		);
+
+		echo '<thead>' . "\n";
+		echo '<tr>' . "\n";
+		echo '<th scope="col">' . esc_html__( 'Hook', 'query-monitor' ) . '</th>' . "\n";
+		echo '<th scope="col">' . esc_html__( 'Type', 'query-monitor' ) . '</th>' . "\n";
+		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>' . "\n";
+		echo '<th scope="col">' . esc_html__( 'Callback', 'query-monitor' ) . '</th>' . "\n";
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>' . "\n";
+		echo '</tr>' . "\n";
+		echo '</thead>' . "\n";
+
+		echo '<tbody>' . "\n";
+
+		foreach ( $concerns as $key => $labels ) {
+			if ( empty( $this->collector->$key ) ) {
+				continue;
+			}
+
+			QM_Output_Html_Hooks::output_hook_table( $this->collector->$key, true );
+		}
+
+		echo '</tbody>' . "\n";
+		echo '</table>' . "\n";
+
+		echo '</div>' . "\n";
+	}
+
+	/**
+	 * @param string $id
+	 * @param string $name
+	 * @return void
+	 */
+	protected function before_debug_bar_output( $id = null, $name = null ) {
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->name();
+		}
+
+		printf(
+			'<div class="qm qm-debug-bar" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">' . "\n",
+			esc_attr( $id )
+		);
+
+		printf(
+			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>' . "\n",
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function after_debug_bar_output() {
+		echo '</div>' . "\n";
+	}
+
+	/**
+	 * @param string $notice
+	 * @return string
+	 */
+	protected function build_notice( $notice ) {
+		$return = '<section>' . "\n";
+		$return .= '<div class="qm-notice">' . "\n";
+		$return .= '<p>';
+		$return .= $notice;
+		$return .= '</p>' . "\n";
+		$return .= '</div>' . "\n";
+		$return .= '</section>' . "\n";
+
+		return $return;
+	}
+
+	/**
+	 * @param array<string, mixed> $vars
+	 * @return void
+	 */
+	public static function output_inner( array $vars ) {
+
+		echo '<table>' . "\n";
+
+		foreach ( $vars as $key => $value ) {
+			echo '<tr>' . "\n";
+			echo '<td>' . esc_html( $key ) . '</td>' . "\n";
+			if ( is_array( $value ) ) {
+				echo '<td>';
+				self::output_inner( $value );
+				echo '</td>' . "\n";
+			} elseif ( is_object( $value ) ) {
+				echo '<td>';
+				self::output_inner( get_object_vars( $value ) );
+				echo '</td>' . "\n";
+			} elseif ( is_bool( $value ) ) {
+				if ( $value ) {
+					echo '<td class="qm-true">true</td>' . "\n";
+				} else {
+					echo '<td class="qm-false">false</td>' . "\n";
+				}
+			} else {
+				echo '<td>';
+				echo nl2br( esc_html( $value ) );
+				echo '</td>' . "\n";
+			}
+			echo '</tr>' . "\n";
+		}
+		echo '</table>' . "\n";
+
+	}
+
+	/**
+	 * Returns the table filter controls. Safe for output.
+	 *
+	 * @param  string         $name   The name for the `data-` attributes that get filtered by this control.
+	 * @param  (string|int)[] $values Option values for this control.
+	 * @param  string         $label  Label text for the filter control.
+	 * @param  array          $args {
+	 *     @type string   $highlight The name for the `data-` attributes that get highlighted by this control.
+	 *     @type string[] $prepend   Associative array of options to prepend to the list of values.
+	 *     @type string[] $append    Associative array of options to append to the list of values.
+	 * }
+	 * @phpstan-param array{
+	 *   highlight?: string,
+	 *   prepend?: array<string, string>,
+	 *   append?: array<string, string>,
+	 * } $args
+	 * @return string Markup for the table filter controls.
+	 */
+	protected function build_filter( $name, $values, $label, $args = array() ) {
+
+		if ( empty( $values ) || ! is_array( $values ) ) {
+			return esc_html( $label ); // Return label text, without being marked up as a label element.
+		}
+
+		if ( ! is_array( $args ) ) {
+			$args = array(
+				'highlight' => $args,
 			);
 		}
 
-		return '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
-			esc_attr( $label ) .
-			'"><span aria-hidden="true">+</span></button>';
+		$args = array_merge( array(
+			'highlight' => '',
+			'prepend' => array(),
+			'append' => array(),
+			'all' => _x( 'All', '"All" option for filters', 'query-monitor' ),
+		), $args );
+
+		$core_val = __( 'WordPress Core', 'query-monitor' );
+		$core_key = array_search( $core_val, $values, true );
+
+		if ( 'component' === $name && count( $values ) > 1 && false !== $core_key ) {
+			$args['append'][ $core_val ] = $core_val;
+			$args['append']['non-core'] = __( 'Non-WordPress Core', 'query-monitor' );
+			unset( $values[ $core_key ] );
+		}
+
+		$filter_id = 'qm-filter-' . $this->collector->id . '-' . $name;
+
+		$out = '<div class="qm-filter-container">' . "\n";
+		$out .= '<label for="' . esc_attr( $filter_id ) . '">' . esc_html( $label ) . '</label>';
+		$out .= '<select id="' . esc_attr( $filter_id ) . '" class="qm-filter" data-filter="' . esc_attr( $name ) . '" data-highlight="' . esc_attr( $args['highlight'] ) . '">' . "\n";
+		$out .= '<option value="">' . esc_html( $args['all'] ) . '</option>' . "\n";
+
+		if ( ! empty( $args['prepend'] ) ) {
+			foreach ( $args['prepend'] as $value => $label ) {
+				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>' . "\n";
+			}
+		}
+
+		foreach ( $values as $key => $value ) {
+			if ( is_int( $key ) && $key >= 0 ) {
+				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $value ) . '</option>' . "\n";
+			} else {
+				$out .= '<option value="' . esc_attr( $key ) . '">' . esc_html( $value ) . '</option>' . "\n";
+			}
+		}
+
+		if ( ! empty( $args['append'] ) ) {
+			foreach ( $args['append'] as $value => $label ) {
+				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>' . "\n";
+			}
+		}
+
+		$out .= '</select>' . "\n";
+		$out .= '</div>' . "\n";
+
+		return $out;
+
 	}
 
+	/**
+	 * Returns the column sorter controls. Safe for output.
+	 *
+	 * @param string $heading Heading text for the column. Optional.
+	 * @return string Markup for the column sorter controls.
+	 */
+	protected function build_sorter( $heading = '' ) {
+		$out = '';
+		$out .= '<span class="qm-th">';
+		$out .= '<span class="qm-sort-heading">';
+
+		if ( '#' === $heading ) {
+			$out .= '<span class="qm-screen-reader-text">' . esc_html__( 'Sequence', 'query-monitor' ) . '</span>';
+		} elseif ( $heading ) {
+			$out .= esc_html( $heading );
+		}
+
+		$out .= '</span>';
+		$out .= '<button class="qm-sort-controls" aria-label="' . esc_attr__( 'Sort data by this column', 'query-monitor' ) . '">';
+		$out .= QueryMonitor::icon( 'arrow-down' );
+		$out .= '</button>';
+		$out .= '</span>';
+		return $out;
+	}
+
+	/**
+ * Returns a toggle control. Safe for output.
+ *
+ * @param string $context Optional context for accessibility.
+ * @return string Markup for the toggle control.
+ */
+protected static function build_toggler( $context = '' ) {
+
+	$label = __( 'Toggle more information', 'query-monitor' );
+
+	if ( $context ) {
+		$label = sprintf(
+			__( 'Toggle more information about %s', 'query-monitor' ),
+			$context
+		);
+	}
+
+	return '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' .
+		esc_attr( $label ) .
+		'"><span aria-hidden="true">+</span></button>';
+}
+
+
+	/**
+	 * Returns a filter trigger.
+	 *
+	 * @param string $target
+	 * @param string $filter
+	 * @param string $value
+	 * @param string $label
+	 * @return string
+	 */
 	protected static function build_filter_trigger( $target, $filter, $value, $label ) {
 		return sprintf(
 			'<button class="qm-filter-trigger" data-qm-target="%1$s" data-qm-filter="%2$s" data-qm-value="%3$s">%4$s%5$s</button>',
@@ -109,6 +427,13 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
+	/**
+	 * Returns a link.
+	 *
+	 * @param string $href
+	 * @param string $label
+	 * @return string
+	 */
 	protected static function build_link( $href, $label ) {
 		return sprintf(
 			'<a href="%1$s" class="qm-link">%2$s%3$s</a>',
@@ -118,10 +443,230 @@ abstract class QM_Output_Html extends QM_Output {
 		);
 	}
 
+	/**
+	 * @param array<string, mixed> $args
+	 * @return array<string, mixed>
+	 */
 	protected function menu( array $args ) {
+
 		return array_merge( array(
-			'id'   => esc_attr( "query-monitor-{$this->collector->id}" ),
+			'id' => esc_attr( "query-monitor-{$this->collector->id}" ),
 			'href' => esc_attr( '#' . $this->collector->id() ),
 		), $args );
+
 	}
+
+	/**
+	 * Returns the given SQL string in a nicely presented format. Safe for output.
+	 *
+	 * @param  string $sql An SQL query string.
+	 * @return string      The SQL formatted with markup.
+	 */
+	public static function format_sql( $sql ) {
+
+		$sql = str_replace( array( "\r\n", "\r", "\n", "\t" ), ' ', $sql );
+		$sql = esc_html( $sql );
+		$sql = trim( $sql );
+
+		$regex = 'ADD|AFTER|ALTER|AND|BEGIN|COMMIT|CREATE|DELETE|DESCRIBE|DO|DROP|ELSE|END|EXCEPT|EXPLAIN|FROM|GROUP|HAVING|INNER|INSERT|INTERSECT|LEFT|LIMIT|ON|OR|ORDER|OUTER|RENAME|REPLACE|RIGHT|ROLLBACK|SELECT|SET|SHOW|START|THEN|TRUNCATE|UNION|UPDATE|USE|USING|VALUES|WHEN|WHERE|XOR';
+		$sql = preg_replace( '# (' . $regex . ') #', '<br> $1 ', $sql );
+
+		$keywords = '\b(?:ACTION|ADD|AFTER|AGAINST|ALTER|AND|ASC|AS|AUTO_INCREMENT|BEGIN|BETWEEN|BIGINT|BINARY|BIT|BLOB|BOOLEAN|BOOL|BREAK|BY|CASE|COLLATE|COLUMNS?|COMMIT|CONTINUE|CREATE|DATA(?:BASES?)?|DATE(?:TIME)?|DECIMAL|DECLARE|DEC|DEFAULT|DELAYED|DELETE|DESCRIBE|DESC|DISTINCT|DOUBLE|DO|DROP|DUPLICATE|ELSE|END|ENUM|EXCEPT|EXISTS|EXPLAIN|FIELDS|FLOAT|FORCE|FOREIGN|FOR|FROM|FULL|FUNCTION|GROUP|HAVING|IF|IGNORE|INDEX|INNER|INSERT|INTEGER|INTERSECT|INTERVAL|INTO|INT|IN|IS|JOIN|KEYS?|LEFT|LIKE|LIMIT|LONG(?:BLOB|TEXT)|MEDIUM(?:BLOB|INT|TEXT)|MATCH|MERGE|MIDDLEINT|NOT|NO|NULLIF|ON|ORDER|OR|OUTER|PRIMARY|PROC(?:EDURE)?|REGEXP|RENAME|REPLACE|RIGHT|RLIKE|ROLLBACK|SCHEMA|SELECT|SET|SHOW|SMALLINT|START|TABLES?|TEXT(?:SIZE)?|THEN|TIME(?:STAMP)?|TINY(?:BLOB|INT|TEXT)|TRUNCATE|UNION|UNIQUE|UNSIGNED|UPDATE|USE|USING|VALUES?|VAR(?:BINARY|CHAR)|WHEN|WHERE|WHILE|XOR)\b';
+		$sql = preg_replace( '#' . $keywords . '#', '<b>$0</b>', $sql );
+
+		return '<code>' . $sql . '</code>';
+
+	}
+
+	/**
+	 * Returns the given URL in a nicely presented format. Safe for output.
+	 *
+	 * @param  string $url A URL.
+	 * @return string      The URL formatted with markup.
+	 */
+	public static function format_url( $url ) {
+		// If there's no query string or only a single query parameter, return the URL as is.
+		if ( ! str_contains( $url, '&' ) ) {
+			return $url;
+		}
+
+		return str_replace( array( '?', '&amp;' ), array( '<br>?', '<br>&amp;' ), esc_html( $url ) );
+	}
+
+	/**
+	 * Returns a file path, name, and line number, or a clickable link to the file. Safe for output.
+	 *
+	 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
+	 *
+	 * @param  string $text        The display text, such as a function name or file name.
+	 * @param  string $file        The full file path and name.
+	 * @param  int    $line        Optional. A line number, if appropriate.
+	 * @param  bool   $is_filename Optional. Is the text a plain file name? Default false.
+	 * @return string The fully formatted file link or file name, safe for output.
+	 */
+	public static function output_filename( $text, $file, $line = 0, $is_filename = false ) {
+		if ( empty( $file ) ) {
+			if ( $is_filename ) {
+				return esc_html( $text );
+			} else {
+				return '<code>' . esc_html( $text ) . '</code>';
+			}
+		}
+
+		$link_line = $line ?: 1;
+
+		if ( 0 === strpos( $text, '{closure:/' ) ) {
+			$text = sprintf(
+				/* translators: A closure is an anonymous PHP function. 1: Line number, 2: File name */
+				__( 'Closure on line %1$d of %2$s', 'query-monitor' ),
+				$line,
+				QM_Util::standard_dir( $file, '' )
+			);
+		}
+
+		if ( ! self::has_clickable_links() ) {
+			$fallback = QM_Util::standard_dir( $file, '' );
+			if ( $line ) {
+				$fallback .= ':' . $line;
+			}
+			if ( $is_filename ) {
+				$return = esc_html( $text );
+			} else {
+				$return = '<code>' . esc_html( $text ) . '</code>';
+			}
+			if ( $fallback !== $text ) {
+				$return .= '<br><span class="qm-info qm-supplemental">' . esc_html( $fallback ) . '</span>';
+			}
+			return $return;
+		}
+
+		$map = self::get_file_path_map();
+
+		if ( ! empty( $map ) ) {
+			foreach ( $map as $from => $to ) {
+				$file = str_replace( $from, $to, $file );
+			}
+		}
+
+		/** @var string */
+		$link_format = self::get_file_link_format();
+		$link = sprintf( $link_format, rawurlencode( $file ), intval( $link_line ) );
+
+		if ( $is_filename ) {
+			$format = '<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>';
+		} else {
+			$format = '<a href="%1$s" class="qm-edit-link"><code>%2$s</code>%3$s</a>';
+		}
+
+		return sprintf(
+			$format,
+			esc_attr( $link ),
+			esc_html( $text ),
+			QueryMonitor::icon( 'edit' )
+		);
+	}
+
+	/**
+	 * Provides a protocol URL for edit links in QM stack traces for various editors.
+	 *
+	 * @param string       $editor         The chosen code editor.
+	 * @param string|false $default_format A format to use if no editor is found.
+	 * @return string|false A protocol URL format or boolean false.
+	 */
+	public static function get_editor_file_link_format( $editor, $default_format ) {
+		switch ( $editor ) {
+			case 'phpstorm':
+				return 'phpstorm://open?file=%f&line=%l';
+			case 'vscode':
+				return 'vscode://file/%f:%l';
+			case 'sublime':
+				return 'subl://open/?url=file://%f&line=%l';
+			case 'textmate':
+				return 'txmt://open/?url=file://%f&line=%l';
+			case 'netbeans':
+				return 'nbopen://%f:%l';
+			case 'nova':
+				return 'nova://open?path=%f&line=%l';
+			default:
+				return $default_format;
+		}
+	}
+
+	/**
+	 * @return string|false
+	 */
+	public static function get_file_link_format() {
+		if ( ! isset( self::$file_link_format ) ) {
+			$format = ini_get( 'xdebug.file_link_format' );
+
+			if ( defined( 'QM_EDITOR_COOKIE' ) && isset( $_COOKIE[ QM_EDITOR_COOKIE ] ) ) {
+				$format = self::get_editor_file_link_format(
+					$_COOKIE[ QM_EDITOR_COOKIE ],
+					$format
+				);
+			}
+
+			/**
+			 * Filters the clickable file link format.
+			 *
+			 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
+			 * @since 3.0.0
+			 *
+			 * @param string|false $format The format of the clickable file link, or false if there is none.
+			 */
+			$format = apply_filters( 'qm/output/file_link_format', $format );
+			if ( empty( $format ) ) {
+				self::$file_link_format = false;
+			} else {
+				self::$file_link_format = str_replace( array( '%f', '%l' ), array( '%1$s', '%2$d' ), $format );
+			}
+		}
+
+		return self::$file_link_format;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public static function get_file_path_map() {
+		$map = array();
+
+		// WordPress core and Altis:
+		$host_path = getenv( 'HOST_PATH' );
+
+		if ( ! empty( $host_path ) ) {
+			$source = ABSPATH;
+			$replacement = trailingslashit( $host_path );
+			$map[ $source ] = $replacement;
+		}
+
+		// WordPress VIP on Lando:
+		$lando_path = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ? getenv( 'LANDO_APP_ROOT_BIND' ) : null;
+
+		if ( ! empty( $lando_path ) ) {
+			// https://github.com/Automattic/vip-cli/blob/2bf64a46b9d409a5683459d032d65c16a6eeac48/assets/dev-env.lando.template.yml.ejs#L288
+			$source = ABSPATH;
+			$replacement = trailingslashit( $lando_path ) . 'wordpress/';
+			$map[ $source ] = $replacement;
+		}
+
+		/**
+		 * Filters the file path mapping for clickable file links.
+		 *
+		 * @link https://querymonitor.com/help/clickable-stack-traces-and-function-names/
+		 * @since 3.0.0
+		 *
+		 * @param array<string, string> $file_map Array of file path mappings. Keys are the source paths and values are the replacement paths.
+		 */
+		return apply_filters( 'qm/output/file_path_map', $map );
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function has_clickable_links() {
+		return ( false !== self::get_file_link_format() );
+	}
+
+
 }

--- a/output/Html.php
+++ b/output/Html.php
@@ -394,10 +394,12 @@ abstract class QM_Output_Html extends QM_Output {
 
 		if ( $context ) {
 			$label = sprintf(
+				/* translators: %s: Description of the information being toggled. */
 				__( 'Toggle more information about %s', 'query-monitor' ),
 				$context
-			);
-		}
+	);
+}
+
 
 		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false" aria-label="' . esc_attr( $label ) . '"><span aria-hidden="true">+</span></button>';
 


### PR DESCRIPTION
### What this PR does

This pull request improves the accessibility of the "Toggle more information"
buttons used in the HTML output by making their aria-labels contextual and
descriptive.

---

### What was happening before

Previously, all toggle buttons were created using the following aria-label:

aria-label="Toggle more information"


Because this same label was used everywhere, screen readers announced
multiple buttons with identical text. This made it difficult for users
to understand what each toggle button would expand or control.

---

### What was changed

The `build_toggler()` method was updated to accept an optional `$context`
parameter.

**Before:**
```php
protected static function build_toggler() {
	$out = '<button class="qm-toggle" ... aria-label="Toggle more information">...</button>';
	return $out;
}
```

**After:**
```php
protected static function build_toggler( $context = '' ) {
	$label = __( 'Toggle more information', 'query-monitor' );

	if ( $context ) {
		$label = sprintf(
			__( 'Toggle more information about %s', 'query-monitor' ),
			$context
		);
	}

	return '<button class="qm-toggle" ... aria-label="' . esc_attr( $label ) . '">...</button>';
}
```

### Behavior after this change

If context is provided, the aria-label becomes descriptive  
(e.g. `Toggle more information about Jetpack hook callback`).

If no context is provided, the original behavior is preserved.

---

### Why this change is important

Screen reader users rely on aria-labels to understand interactive elements.  
Using repeated generic labels reduces accessibility and usability.

By introducing contextual aria-labels, each toggle button can now be
clearly distinguished, aligning with accessibility best practices.

---

### Scope and safety of change

- The change is limited to the `build_toggler()` method only.
- No visual or functional behavior has been altered.
- Existing functionality remains backward-compatible.
- No unrelated code was modified.

---
