### PR TITLE
Prevent fatal error when request value is null

### DIFF
--- a/collectors/request.php
+++ b/collectors/request.php
@@ -310,9 +310,12 @@ class QM_Collector_Request extends QM_DataCollector {
 		$rewrite_rules = $wp_rewrite->rules;
 
 		foreach ( $rewrite_rules as $match => $query ) {
-			if ( preg_match( "#^{$match}#", $this->data->request['request'] ) ) {
-				$matching[ $match ] = $query;
-			}
+		        $request = $this->data->request['request'] ?? '';
+
+                if ( is_string( $request ) && preg_match( "#^{$match}#", $request ) ) {
+                       $matching[ $match ] = $query;
+              }
+
 		}
 
 		$this->data->matching_rewrites = $matching;


### PR DESCRIPTION
This PR prevents a PHP fatal error by ensuring the request value is a string before passing it to preg_match().

Fixes a case where a null value could be encountered, particularly on PHP 8+.
