### PR TITLE
Fix fatal error when pre_http_request response is never logged

### DIFF
--- a/collectors/http.php
+++ b/collectors/http.php
@@ -327,7 +327,21 @@ class QM_Collector_HTTP extends QM_DataCollector {
 		$home_host = (string) parse_url( home_url(), PHP_URL_HOST );
 
 		foreach ( $this->http_requests as $key => $request ) {
-			$response = $this->http_responses[ $key ];
+			if ( ! isset( $this->http_responses[ $key ] ) ) {
+				// The response was never logged. This can happen when a `pre_http_request` filter
+				// callback intercepts the request at a priority higher than QM's hook (9999), so
+				// QM's `filter_pre_http_request` already ran (saw no interception) and WordPress
+				// then short-circuits the request, meaning `http_api_debug` never fires either.
+				$response = array(
+					'response'    => new WP_Error( 'http_request_not_executed' ),
+					'end'         => $request['start'],
+					'args'        => $request['args'],
+					'info'        => null,
+					'intercepted' => false,
+				);
+			} else {
+				$response = $this->http_responses[ $key ];
+			}
 
 			if ( empty( $response['response'] ) ) {
 				// Timed out


### PR DESCRIPTION
Fixes #811

## Root cause

QM hooks both `http_request_args` and `pre_http_request` at priority **9999**. When a plugin hooks `pre_http_request` at a **higher** priority (e.g. 10000), the execution order is:

1. QM's `filter_pre_http_request` runs at priority 9999 → sees `$response === false`, returns early without logging
2. The other plugin's callback runs at priority 10000 → intercepts, returns a non-false value
3. WordPress short-circuits the actual HTTP request → `http_api_debug` never fires

Result: the request is stored in `$this->http_requests` (via `http_request_args`) but nothing is ever written to `$this->http_responses`. When `process()` accesses `$this->http_responses[$key]`, PHP 8.x throws `ErrorException: Undefined array key`.

Known triggers: [wp-china-yes](https://github.com/litepress/wp-china-yes), Polylang Pro update checks, security plugins that block external requests.

## Fix

Check whether a response was captured before accessing it. If not, synthesise a fallback with `http_request_not_executed` the same `WP_Error` code already used for nested-request edge cases (line 297) and already in the default `qm/collect/silent_http_errors` list, so it won't generate a spurious alert.

## How to reproduce

Drop this in `mu-plugins/qm-bug-repro.php` and visit `/?trigger_qm_bug=1`:

```php
<?php
add_filter( 'pre_http_request', function( $preempt, $args, $url ) {
    if ( str_contains( $url, 'qm-bug-test' ) ) {
        return new WP_Error( 'intercepted', 'Simulated late interception' );
    }
    return $preempt;
}, 10000, 3 );

add_action( 'init', function() {
    if ( isset( $_GET['trigger_qm_bug'] ) ) {
        wp_remote_get( 'https://example.com/qm-bug-test' );
    }
} );
```

`Co-authored with Claude` ^ 