### PR TITLE
Add support for the SQLite Database Integration plugin

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -239,6 +239,17 @@ i {
 	font-style: italic;
 }
 
+.qm-cell-sql ol {
+	padding-left: 2em;
+
+	li {
+		list-style: decimal;
+		font-family: var( --qm-font-code-face );
+		font-size: var( --qm-font-code-size );
+		line-height: var( --qm-font-code-line-height );
+	}
+}
+
 .qm-cell-sql b {
 	color: var( --qm-sql-keyword-fg );
 }

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -27,6 +27,7 @@ if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
  *   2: string,
  *   trace?: QM_Backtrace,
  *   result?: int|bool|WP_Error,
+ *   sqlite_queries?: array<int, array{sql: string, params: array<string, mixed>}>,
  * }
  * @phpstan-type QueryVIP array{
  *   query: string,
@@ -127,6 +128,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$types = array();
 		$has_result = false;
 		$has_trace = false;
+		$has_sqlite = false;
 		$i = 0;
 		$request = trim( $wp_the_query->request ?: '' );
 
@@ -159,6 +161,11 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				if ( isset( $query['result'] ) ) {
 					$has_result = true;
 					$result = $query['result'];
+				}
+				// SQLite Database Integration plugin.
+				if ( ! empty( $query['sqlite_queries'] ) ) {
+					$has_sqlite = true;
+					$sqlite_queries = $query['sqlite_queries'];
 				}
 			} else {
 				// ¯\_(ツ)_/¯
@@ -207,6 +214,10 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				}
 			}
 
+			if ( isset( $sqlite_queries ) ) {
+				$row['sqlite_queries'] = $sqlite_queries;
+			}
+
 			if ( self::is_expensive( $row ) ) {
 				$this->data->expensive[] = $i;
 			}
@@ -222,6 +233,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$this->data->total_qs = count( $this->data->rows );
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;
+		$this->data->has_sqlite = $has_sqlite;
 		$this->data->has_main_query = ! empty( $has_main_query );
 
 		// Filter out queries that do not have duplicates

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -13,6 +13,10 @@
  */
 
 /**
+ * @phpstan-type SQLiteQuery array{
+ *   sql: string,
+ *   params?: array<string, mixed>,
+ * }
  * @phpstan-type QueryRow array{
  *   stack?: array<int, string>,
  *   sql: string,
@@ -21,6 +25,7 @@
  *   type: string,
  *   trace?: QM_Backtrace,
  *   is_main_query?: bool,
+ *   sqlite_queries?: array<int, SQLiteQuery>,
  * }
  */
 class QM_Data_DB_Queries extends QM_Data {
@@ -53,6 +58,11 @@ class QM_Data_DB_Queries extends QM_Data {
 	 * @var bool
 	 */
 	public $has_trace;
+
+	/**
+	 * @var bool
+	 */
+	public $has_sqlite;
 
 	/**
 	 * @var bool

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -250,6 +250,7 @@ export interface DB_Queries {
 	rows?: QueryRow[];
 	has_result: boolean;
 	has_trace: boolean;
+	has_sqlite: boolean;
 	has_main_query: boolean;
 	dupes: {
 		query: string;
@@ -274,6 +275,13 @@ export interface QueryRow {
 	type: string;
 	trace?: Backtrace;
 	is_main_query?: boolean;
+	sqlite_queries?: SQLiteQuery[];
+}
+export interface SQLiteQuery {
+	sql: string;
+	params?: {
+		[k: string]: string | number;
+	};
 }
 /**
  * Doing it Wrong data transfer object.

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -72,22 +72,38 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 			sql: {
 				className: ( row ) => row.type !== 'SELECT' ? 'qm-nonselectsql' : '',
 				heading: __( 'Query', 'query-monitor' ),
-				render: ( row ) => (
-					<>
+				render: ( row ) => {
+					const sql = row.sqlite_queries?.length ? (
+						<ol>
+							{ row.sqlite_queries.map( ( q, j ) => (
+								<li>
+									<code key={ j }>
+										{ Utils.formatSQL( q.sql ) }
+									</code>
+								</li>
+							) ) }
+						</ol>
+					) : (
 						<code>
 							{ Utils.formatSQL( row.sql ) }
 						</code>
-						{ Utils.isWPError( row.result ) && (
-							<>
-								<br />
-								<br />
-								<Warning>
-									{ Utils.getErrorMessage( row.result ) }
-								</Warning>
-							</>
-						) }
-					</>
-				),
+					);
+
+					return (
+						<>
+							{ sql }
+							{ Utils.isWPError( row.result ) && (
+								<>
+									<br />
+									<br />
+									<Warning>
+										{ Utils.getErrorMessage( row.result ) }
+									</Warning>
+								</>
+							) }
+						</>
+					);
+				},
 				filters: {
 					options: ( () => {
 						const filters = Object.keys( data.types ).map( ( type ) => ( {

--- a/output/utils.tsx
+++ b/output/utils.tsx
@@ -52,6 +52,14 @@ export function formatSQL( sql: string ): JSX.Element[] {
 		return '';
 	} );
 
+	if ( collection.length === 0 ) {
+		collection.push(
+			<Fragment key={ 0 }>
+				<b>{ sql }</b>
+			</Fragment>
+		);
+	}
+
 	return collection;
 }
 

--- a/src/schemas/data/db_queries.json
+++ b/src/schemas/data/db_queries.json
@@ -5,6 +5,27 @@
 	"description": "Database queries data transfer object.",
 	"type": "object",
 	"definitions": {
+		"SQLiteQuery": {
+			"type": "object",
+			"required": [
+				"sql"
+			],
+			"properties": {
+				"sql": {
+					"type": "string"
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": {
+						"oneOf": [
+							{ "type": "string" },
+							{ "type": "number" }
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"QueryRow": {
 			"type": "object",
 			"required": [
@@ -59,6 +80,12 @@
 				},
 				"is_main_query": {
 					"type": "boolean"
+				},
+				"sqlite_queries": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/SQLiteQuery"
+					}
 				}
 			},
 			"additionalProperties": false
@@ -68,6 +95,7 @@
 		"total_qs",
 		"has_result",
 		"has_trace",
+		"has_sqlite",
 		"has_main_query",
 		"dupes",
 		"errors"
@@ -103,6 +131,9 @@
 			"type": "boolean"
 		},
 		"has_trace": {
+			"type": "boolean"
+		},
+		"has_sqlite": {
 			"type": "boolean"
 		},
 		"has_main_query": {


### PR DESCRIPTION
[The SQLite Database Integration plugin](https://github.com/WordPress/sqlite-database-integration) includes some functionality that overrides the Database Queries panel output to includes SQLite query information. This doesn't work with the new client side rendering. I think it makes sense for Query Monitor to officially support the SQLite Database Integration plugin

## Screenshot

<img alt="" src="https://github.com/user-attachments/assets/97e3099d-e363-4954-89a6-cb08cf07e19a" />
