### PR TITLE
Re-enable testing on PHP 8.5.

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -62,8 +62,8 @@ jobs:
           - '7.4'
         include:
           # Latest WordPress on latest PHP
-          # - wp: '6.9'
-          #   php: '8.5'
+          - wp: '6.9'
+            php: '8.5'
           # Oldest supported WordPress on its newest supported PHP, plus 7.4:
           - wp: '6.1'
             php: '8.2'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,8 +57,8 @@ jobs:
           - '7.4'
         include:
           # Latest WordPress on latest PHP
-          # - wp: '6.9'
-          #   php: '8.5'
+          - wp: '6.9'
+            php: '8.5'
           # Oldest supported WordPress on its newest supported PHP, plus 7.4:
           - wp: '6.1'
             php: '8.2'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -43,7 +43,7 @@ jobs:
           - 'acceptance'
         php:
           # Newest and oldest supported versions of PHP
-          - '8.4'
+          - '8.5'
           - '7.4'
       fail-fast: false
     uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@bb606d520dfe6131697c80bfe0f4eabc7b8a46a6 # 2.8.0
@@ -64,7 +64,7 @@ jobs:
           - 'integration'
         php:
           # Newest and oldest supported versions of PHP
-          - '8.4'
+          - '8.5'
           - '7.4'
       fail-fast: false
     with:

--- a/readme.txt
+++ b/readme.txt
@@ -86,7 +86,7 @@ Query Monitor aims to be fully accessible to all of its users. [Query Monitor's 
 
 ### Does this plugin work with PHP 8?
 
-Yes, it's actively tested and working up to PHP 8.4.
+Yes, it's actively tested and working up to PHP 8.5.
 
 ### Who can see Query Monitor's output?
 

--- a/tests/integration/CollectorBlockEditorTest.php
+++ b/tests/integration/CollectorBlockEditorTest.php
@@ -80,7 +80,7 @@ class CollectorBlockEditorTest extends Test {
 	 */
 	private function getBlockTimingArray(): array {
 		$ref = new \ReflectionProperty( $this->collector, 'block_timing' );
-		$ref->setAccessible( true );
+		( \PHP_VERSION_ID < 80100 ) && $ref->setAccessible( true );
 		return $ref->getValue( $this->collector );
 	}
 


### PR DESCRIPTION
Now Codeception and wp-browser has been replaced with Playwright and vanilla PHPUnit, we can re-enable testing on PHP 8.5.

This wasn't done sooner because in order to support PHP 7.4 we needed to use wp-browser 3.2 which uses Codeception 4 which doesn't fully support PHP 8.5. See 82f5f039 and 16f78a13.