### PR TITLE
Reinstate the `qm-` prefix on menu IDs

### DIFF
--- a/classes/Collector.php
+++ b/classes/Collector.php
@@ -61,7 +61,7 @@ abstract class QM_Collector {
 	 * @return string
 	 */
 	final public function id() {
-		return $this->id;
+		return "qm-{$this->id}";
 	}
 
 	/**

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -328,11 +328,11 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 				);
 			}
 
-			if ( ( ! empty( $collector->concerned_filters ) || ! empty( $collector->concerned_actions ) ) && isset( $this->panel_menu[ $output_id ] ) ) {
+			if ( ( ! empty( $collector->concerned_filters ) || ! empty( $collector->concerned_actions ) ) && isset( $this->panel_menu[ $collector->id() ] ) ) {
 				$count = count( $collector->concerned_filters ) + count( $collector->concerned_actions );
-				$this->panel_menu[ $output_id ]['children'][ $output_id . '-concerned_hooks' ] = array(
-					'id' => $collector->id() . '-concerned_hooks',
-					'panel' => $collector->id() . '-concerned_hooks',
+				$this->panel_menu[ $collector->id() ]['children'][ $collector->id . '-concerned_hooks' ] = array(
+					'id' => $collector->id . '-concerned_hooks',
+					'panel' => $collector->id . '-concerned_hooks',
 					'title' => __( 'Hooks in Use', 'query-monitor' ),
 					'count' => $count,
 				);

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -231,10 +231,15 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		$this->before_output();
 
-		// Output non-client-side rendered panels outside the React container
+		// Output server-side rendered panels outside the React container.
+		// All outputters get a fallback container so that third-party plugins
+		// which extend a client-side rendered base class (e.g. QM_Output_Html_Logger)
+		// still have their PHP output available for the PhpPanelFallback component.
 		echo '<div id="query-monitor-fallbacks">';
 		foreach ( $this->outputters as $id => $output ) {
-			if ( ! $output::$client_side_rendered ) {
+			$html = $output->get_output();
+
+			if ( '' !== $html ) {
 				printf(
 					"\n" . '<!-- Begin %1$s output -->' . "\n",
 					esc_html( $id )
@@ -244,7 +249,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 					"\n" . '<div class="qm-panel-container" id="qm-%1$s-container">' . "\n",
 					esc_html( $id )
 				);
-				$output->output();
+				echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo "\n" . '</div>' . "\n";
 
 				printf(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,5 @@ include:
     path:
       - vendor/johnbillion/plugin-infrastructure/tests/docker-compose.yml
       - tests/mu-plugins/acceptance.yml
+      - tests/mu-plugins/third-party-panel.yml
     project_directory: .

--- a/output/html/db_callers.php
+++ b/output/html/db_callers.php
@@ -47,7 +47,7 @@ class QM_Output_Html_DB_Callers extends QM_Output_Html {
 			/** @var QM_Data_DB_Queries $dbq_data */
 			$dbq_data = $dbq->get_data();
 			if ( ! empty( $dbq_data->rows ) ) {
-				$menu['db_queries']['children'][] = $this->menu( array(
+				$menu['qm-db_queries']['children'][] = $this->menu( array(
 					'title' => esc_html__( 'Queries by Caller', 'query-monitor' ),
 				) );
 			}

--- a/output/html/db_components.php
+++ b/output/html/db_components.php
@@ -47,7 +47,7 @@ class QM_Output_Html_DB_Components extends QM_Output_Html {
 			/** @var QM_Data_DB_Queries $dbq_data */
 			$dbq_data = $dbq->get_data();
 			if ( ! empty( $dbq_data->rows ) && ! empty( $dbq_data->has_trace ) ) {
-				$menu['db_queries']['children'][] = $this->menu( array(
+				$menu['qm-db_queries']['children'][] = $this->menu( array(
 					'title' => esc_html__( 'Queries by Component', 'query-monitor' ),
 				) );
 			}

--- a/output/html/db_dupes.php
+++ b/output/html/db_dupes.php
@@ -64,7 +64,7 @@ class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 	public function panel_menu( array $menu ) {
 		$id = $this->collector->id();
 		if ( isset( $menu[ $id ] ) ) {
-			$menu['db_queries']['children'][] = $menu[ $id ];
+			$menu['qm-db_queries']['children'][] = $menu[ $id ];
 			unset( $menu[ $id ] );
 		}
 

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -127,20 +127,18 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 		) );
 
 		if ( $errors ) {
-			$id = 'db_errors';
-			$menu[ $id ] = $this->menu( array(
-				'id'    => $id,
-				'panel' => $id,
+			$menu['qm-db_errors'] = $this->menu( array(
+				'id'    => 'db_errors',
+				'panel' => 'db_errors',
 				'title' => esc_html__( 'Database Errors', 'query-monitor' ),
 				'warning_count' => count( $errors ),
 			) );
 		}
 
 		if ( $expensive ) {
-			$id = 'db_expensive';
-			$menu[ $id ] = $this->menu( array(
-				'id'    => $id,
-				'panel' => $id,
+			$menu['qm-db_expensive'] = $this->menu( array(
+				'id'    => 'db_expensive',
+				'panel' => 'db_expensive',
 				'title' => esc_html__( 'Slow Queries', 'query-monitor' ),
 				'warning_count' => count( $expensive ),
 			) );
@@ -156,9 +154,9 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 	 */
 	public function panel_menu( array $menu ) {
 		foreach ( array( 'errors', 'expensive' ) as $sub ) {
-			$id = 'db_' . $sub;
+			$id = 'qm-db_' . $sub;
 			if ( isset( $menu[ $id ] ) ) {
-				$menu['db_queries']['children'][] = $menu[ $id ];
+				$menu['qm-db_queries']['children'][] = $menu[ $id ];
 				unset( $menu[ $id ] );
 			}
 		}

--- a/output/html/headers.php
+++ b/output/html/headers.php
@@ -44,16 +44,16 @@ class QM_Output_Html_Headers extends QM_Output_Html {
 	 * @return array<string, mixed[]>
 	 */
 	public function panel_menu( array $menu ) {
-		if ( ! isset( $menu['request'] ) ) {
+		if ( ! isset( $menu['qm-request'] ) ) {
 			return $menu;
 		}
 
 		$ids = array(
-			$this->collector->id() => __( 'Request Headers', 'query-monitor' ),
-			$this->collector->id() . '-response' => __( 'Response Headers', 'query-monitor' ),
+			$this->collector->id => __( 'Request Headers', 'query-monitor' ),
+			$this->collector->id . '-response' => __( 'Response Headers', 'query-monitor' ),
 		);
 		foreach ( $ids as $id => $title ) {
-			$menu['request']['children'][] = array(
+			$menu['qm-request']['children'][] = array(
 				'id' => $id,
 				'panel' => $id,
 				'title' => esc_html( $title ),

--- a/tests/acceptance/ThirdPartyPanel.spec.ts
+++ b/tests/acceptance/ThirdPartyPanel.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from './utils/test-setup';
+
+test.describe( 'Third-Party Panel Menus', () => {
+	test.beforeAll( async ( { globalUtils } ) => {
+		globalUtils.installWordPress();
+	} );
+
+	test.beforeEach( async ( { QueryMonitor } ) => {
+		await QueryMonitor.loginViaPage( 'admin', 'password' );
+		await QueryMonitor.amOnAPageWithThirdPartyPanel();
+	} );
+
+	test( 'Third-party top-level menu appears in the panel menu', async ( { page, QueryMonitor } ) => {
+		await QueryMonitor.seeInQMPanel( 'Test Third Party', 'Test third-party parent panel content.' );
+	} );
+
+	test( 'Third-party child menu appears as a sub-menu item', async ( { page, QueryMonitor } ) => {
+		await QueryMonitor.openQMPanel( 'Test Third Party' );
+
+		// The child menu item should be visible as a nested item under the parent
+		const childButton = page.locator( '#qm-panel-menu li li button' ).filter( {
+			hasText: 'Test Child Panel',
+		} );
+		await expect( childButton ).toBeVisible();
+	} );
+
+	test( 'Third-party child panel content is accessible', async ( { page, QueryMonitor } ) => {
+		await QueryMonitor.seeInQMPanel( 'Test Child Panel', 'Test third-party child panel content.' );
+	} );
+} );

--- a/tests/acceptance/ThirdPartyPanel.spec.ts
+++ b/tests/acceptance/ThirdPartyPanel.spec.ts
@@ -10,11 +10,12 @@ test.describe( 'Third-Party Panel Menus', () => {
 		await QueryMonitor.amOnAPageWithThirdPartyPanel();
 	} );
 
-	test( 'Third-party top-level menu appears in the panel menu', async ( { page, QueryMonitor } ) => {
-		await QueryMonitor.seeInQMPanel( 'Test Third Party', 'Test third-party parent panel content.' );
+	test( 'Third-party top-level menu appears and its panel content is accessible', async ( { page, QueryMonitor } ) => {
+		await QueryMonitor.openQMPanel( 'Test Third Party' );
+		await expect( page.locator( '#qm-panels' ) ).toContainText( 'Test third-party parent panel content.' );
 	} );
 
-	test( 'Third-party child menu appears as a sub-menu item', async ( { page, QueryMonitor } ) => {
+	test( 'Third-party child sub-menu appears and its panel content is accessible', async ( { page, QueryMonitor } ) => {
 		await QueryMonitor.openQMPanel( 'Test Third Party' );
 
 		// The child menu item should be visible as a nested item under the parent
@@ -22,9 +23,9 @@ test.describe( 'Third-Party Panel Menus', () => {
 			hasText: 'Test Child Panel',
 		} );
 		await expect( childButton ).toBeVisible();
-	} );
 
-	test( 'Third-party child panel content is accessible', async ( { page, QueryMonitor } ) => {
-		await QueryMonitor.seeInQMPanel( 'Test Child Panel', 'Test third-party child panel content.' );
+		// Click the child and verify its panel content
+		await childButton.click();
+		await expect( page.locator( '#qm-panels' ) ).toContainText( 'Test third-party child panel content.' );
 	} );
 } );

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -115,6 +115,13 @@ export class QueryMonitorUtils {
 	}
 
 	/**
+	 * Navigate to a page that loads the third-party panel test plugin
+	 */
+	async amOnAPageWithThirdPartyPanel() {
+		await this.page.goto( '/?_qm_acceptance_group=third_party_panel' );
+	}
+
+	/**
 	 * Assert that the QM menu is visible with a warning indicator
 	 */
 	async seeQMMenuWithWarning() {

--- a/tests/mu-plugins/third-party-panel.php
+++ b/tests/mu-plugins/third-party-panel.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Simulates a third-party plugin that registers a top-level QM menu with child sub-menus.
+ *
+ * This mirrors the pattern used by plugins like Remote Data Blocks: a parent
+ * collector/outputter provides the top-level menu, and child outputters add
+ * sub-menu items using the parent's `qm-` prefixed menu key.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Only load when the acceptance test group requests it.
+if ( ! isset( $_GET['_qm_acceptance_group'] ) || 'third_party_panel' !== $_GET['_qm_acceptance_group'] ) {
+	return;
+}
+
+// Defer class definitions and registration until QM's classes are available.
+// The qm/collectors filter fires after QM is loaded, so classes are defined
+// inside the callbacks.
+
+add_filter( 'qm/collectors', function( array $collectors ) {
+	class QM_Test_Collector_ThirdParty extends QM_Collector {
+		public $id = 'test-third-party';
+	}
+
+	class QM_Test_Collector_ThirdParty_Child extends QM_Collector {
+		public $id = 'test-third-party-child';
+	}
+
+	$collectors['test-third-party'] = new QM_Test_Collector_ThirdParty();
+	$collectors['test-third-party-child'] = new QM_Test_Collector_ThirdParty_Child();
+
+	return $collectors;
+} );
+
+add_filter( 'qm/outputter/html', function( array $output, QM_Collectors $collectors ) {
+	// --- Parent Outputter (top-level menu) ---
+
+	class QM_Test_Output_ThirdParty extends QM_Output_Html {
+		public function __construct( QM_Collector $collector ) {
+			parent::__construct( $collector );
+			add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 200 );
+		}
+
+		public function name() {
+			return 'Test Third Party';
+		}
+
+		public function output() {
+			$this->before_non_tabular_output();
+			echo '<p>Test third-party parent panel content.</p>';
+			$this->after_non_tabular_output();
+		}
+	}
+
+	// --- Child Outputter (sub-menu under parent) ---
+
+	class QM_Test_Output_ThirdParty_Child extends QM_Output_Html {
+		public function __construct( QM_Collector $collector ) {
+			parent::__construct( $collector );
+			add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 201 );
+		}
+
+		public function name() {
+			return 'Test Child Panel';
+		}
+
+		/**
+		 * Register as a child of the parent menu using the qm- prefixed key.
+		 */
+		public function admin_menu( array $menu ) {
+			$menu['qm-test-third-party']['children'][ $this->collector->id() ] = $this->menu( array(
+				'title' => esc_html( $this->name() ),
+			) );
+			return $menu;
+		}
+
+		public function output() {
+			$this->before_non_tabular_output();
+			echo '<p>Test third-party child panel content.</p>';
+			$this->after_non_tabular_output();
+		}
+	}
+
+	$collector = QM_Collectors::get( 'test-third-party' );
+	if ( $collector ) {
+		$output['test-third-party'] = new QM_Test_Output_ThirdParty( $collector );
+	}
+
+	$collector = QM_Collectors::get( 'test-third-party-child' );
+	if ( $collector ) {
+		$output['test-third-party-child'] = new QM_Test_Output_ThirdParty_Child( $collector );
+	}
+
+	return $output;
+}, 200, 2 );

--- a/tests/mu-plugins/third-party-panel.yml
+++ b/tests/mu-plugins/third-party-panel.yml
@@ -1,0 +1,4 @@
+services:
+  php:
+    volumes:
+      - ./tests/mu-plugins/third-party-panel.php:/var/www/html/wp-content/mu-plugins/third-party-panel.php


### PR DESCRIPTION
This allows plugins that register their own sub-menus to still work as expected.

See:

- #1085
- https://wordpress.org/support/topic/error-after-update-4-0/