### PR TITLE
Improve the fallback support for PHP panels

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -726,6 +726,10 @@ i {
 		padding: 4px 6px;
 	}
 
+	.qm-toggled {
+		display: none;
+	}
+
 	.qm-has-inner .qm-toggled > table {
 		border-bottom: none;
 		border-top: 1px solid var( --qm-cell-border );

--- a/output/panels/panels.tsx
+++ b/output/panels/panels.tsx
@@ -100,8 +100,41 @@ const PhpPanelFallback = ( { panelId }: { panelId: string } ) => {
 			containerRef.current.appendChild( phpPanel );
 		}
 
+		const handleToggle = ( e: Event ) => {
+			const button = ( e.target as HTMLElement ).closest( '.qm-toggle' ) as HTMLButtonElement | null;
+
+			if ( ! button ) {
+				return;
+			}
+
+			const expanded = button.getAttribute( 'aria-expanded' ) === 'true';
+			const cell = button.closest( '.qm-has-toggle' );
+
+			if ( ! cell ) {
+				return;
+			}
+
+			const toggled = cell.querySelectorAll< HTMLElement >( '.qm-toggled' );
+
+			toggled.forEach( ( el ) => {
+				el.style.display = expanded ? 'none' : 'block';
+			} );
+
+			button.setAttribute( 'aria-expanded', expanded ? 'false' : 'true' );
+
+			const span = button.querySelector( 'span' );
+
+			if ( span ) {
+				span.textContent = expanded ? ( button.dataset.on ?? '+' ) : ( button.dataset.off ?? '-' );
+			}
+		};
+
+		phpPanel.addEventListener( 'click', handleToggle );
+
 		// Cleanup: move the element back to its original location
 		return () => {
+			phpPanel.removeEventListener( 'click', handleToggle );
+
 			if ( phpPanel && originalParentRef.current ) {
 				const { parent, nextSibling } = originalParentRef.current;
 				if ( nextSibling ) {

--- a/output/panels/panels.tsx
+++ b/output/panels/panels.tsx
@@ -76,6 +76,12 @@ const PhpPanelFallback = ( { panelId }: { panelId: string } ) => {
 	const containerRef = useRef<HTMLDivElement>( null );
 	const originalParentRef = useRef<{ parent: ParentNode; nextSibling: ChildNode | null } | null>( null );
 	const [ phpPanelExists, setPhpPanelExists ] = useState<boolean | null>( null );
+	const { switchToPanel } = useContext( MainContext );
+	const switchToPanelRef = useRef( switchToPanel );
+
+	useEffect( () => {
+		switchToPanelRef.current = switchToPanel;
+	}, [ switchToPanel ] );
 
 	useEffect( () => {
 		const phpPanel = document.getElementById( `qm-${ panelId }-container` );
@@ -129,11 +135,28 @@ const PhpPanelFallback = ( { panelId }: { panelId: string } ) => {
 			}
 		};
 
+		const handleFilterTrigger = ( e: Event ) => {
+			const button = ( e.target as HTMLElement ).closest( '.qm-filter-trigger' ) as HTMLButtonElement | null;
+
+			if ( ! button ) {
+				return;
+			}
+
+			const target = button.dataset.qmTarget;
+
+			if ( target ) {
+				e.preventDefault();
+				switchToPanelRef.current( target );
+			}
+		};
+
 		phpPanel.addEventListener( 'click', handleToggle );
+		phpPanel.addEventListener( 'click', handleFilterTrigger );
 
 		// Cleanup: move the element back to its original location
 		return () => {
 			phpPanel.removeEventListener( 'click', handleToggle );
+			phpPanel.removeEventListener( 'click', handleFilterTrigger );
 
 			if ( phpPanel && originalParentRef.current ) {
 				const { parent, nextSibling } = originalParentRef.current;


### PR DESCRIPTION
The fallback support for existing PHP rendered panels is good but it doesn't cover the toggles, filters, etc. We can add some event handlers and styling that reintroduces support for these.