### PR TITLE
Add support for the SQLite Database Integration plugin

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -337,10 +337,23 @@ i {
 	}
 }
 
+.qm-sqlite-params {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 0 1em;
+	margin: 0;
+
+	dt,
+	dd {
+		margin: 0;
+	}
+}
+
 .qm-cell-sql b {
 	color: var( --qm-sql-keyword-fg );
 }
 
+.qm-cell-sql-params .qm-sql-value,
 .qm-cell-sql .qm-sql-value {
 	color: var( --qm-sql-value-fg );
 }

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -326,6 +326,17 @@ i {
 	font-style: italic;
 }
 
+.qm-cell-sql ol {
+	padding-left: 2em;
+
+	li {
+		list-style: decimal;
+		font-family: var( --qm-font-code-face );
+		font-size: var( --qm-font-code-size );
+		line-height: var( --qm-font-code-line-height );
+	}
+}
+
 .qm-cell-sql b {
 	color: var( --qm-sql-keyword-fg );
 }

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -239,6 +239,17 @@ i {
 	font-style: italic;
 }
 
+.qm-cell-sql ol {
+	padding-left: 2em;
+
+	li {
+		list-style: decimal;
+		font-family: var( --qm-font-code-face );
+		font-size: var( --qm-font-code-size );
+		line-height: var( --qm-font-code-line-height );
+	}
+}
+
 .qm-cell-sql b {
 	color: var( --qm-sql-keyword-fg );
 }

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -21,13 +21,15 @@ if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
 }
 
 /**
+ * @phpstan-import-type SQLiteQuery from QM_Data_DB_Queries
+ *
  * @phpstan-type QueryStandard array{
  *   0: string,
  *   1: float,
  *   2: string,
  *   trace?: QM_Backtrace,
  *   result?: int|bool|WP_Error,
- *   sqlite_queries?: array<int, array{sql: string, params: array<string, mixed>}>,
+ *   sqlite_queries?: array<int, SQLiteQuery>,
  * }
  * @phpstan-type QueryVIP array{
  *   query: string,

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -130,7 +130,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$types = array();
 		$has_result = false;
 		$has_trace = false;
-		$has_sqlite = false;
 		$i = 0;
 		$request = trim( $wp_the_query->request ?: '' );
 
@@ -164,7 +163,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				}
 				// SQLite Database Integration plugin.
 				if ( ! empty( $query['sqlite_queries'] ) ) {
-					$has_sqlite = true;
 					$sqlite_queries = $query['sqlite_queries'];
 				}
 			} else {
@@ -226,7 +224,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$this->data->total_qs = count( $this->data->rows );
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;
-		$this->data->has_sqlite = $has_sqlite;
 
 		// Filter out queries that do not have duplicates
 		$this->dupes = array_filter( $this->dupes, array( $this, 'filter_dupe_items' ) );

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -27,6 +27,7 @@ if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
  *   2: string,
  *   trace?: QM_Backtrace,
  *   result?: int|bool|WP_Error,
+ *   sqlite_queries?: array<int, array{sql: string, params: array<string, mixed>}>,
  * }
  * @phpstan-type QueryVIP array{
  *   query: string,
@@ -127,6 +128,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$types = array();
 		$has_result = false;
 		$has_trace = false;
+		$has_sqlite = false;
 		$i = 0;
 		$request = trim( $wp_the_query->request ?: '' );
 
@@ -159,6 +161,11 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				if ( isset( $query['result'] ) ) {
 					$has_result = true;
 					$result = $query['result'];
+				}
+				// SQLite Database Integration plugin.
+				if ( ! empty( $query['sqlite_queries'] ) ) {
+					$has_sqlite = true;
+					$sqlite_queries = $query['sqlite_queries'];
 				}
 			} else {
 				// ¯\_(ツ)_/¯
@@ -207,6 +214,10 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				}
 			}
 
+			if ( isset( $sqlite_queries ) ) {
+				$row['sqlite_queries'] = $sqlite_queries;
+			}
+
 			if ( self::is_expensive( $row ) ) {
 				$this->data->expensive[] = $i;
 			}
@@ -222,6 +233,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$this->data->total_qs = count( $this->data->rows );
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;
+		$this->data->has_sqlite = $has_sqlite;
 		$this->data->has_main_query = ! empty( $has_main_query );
 
 		// Filter out queries that do not have duplicates

--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -27,6 +27,7 @@ if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
  *   2: string,
  *   trace?: QM_Backtrace,
  *   result?: int|bool|WP_Error,
+ *   sqlite_queries?: array<int, array{sql: string, params: array<string, mixed>}>,
  * }
  * @phpstan-type QueryVIP array{
  *   query: string,
@@ -127,6 +128,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$types = array();
 		$has_result = false;
 		$has_trace = false;
+		$has_sqlite = false;
 		$i = 0;
 		$request = trim( $wp_the_query->request ?: '' );
 
@@ -157,6 +159,11 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				if ( isset( $query['result'] ) ) {
 					$has_result = true;
 					$result = $query['result'];
+				}
+				// SQLite Database Integration plugin.
+				if ( ! empty( $query['sqlite_queries'] ) ) {
+					$has_sqlite = true;
+					$sqlite_queries = $query['sqlite_queries'];
 				}
 			} else {
 				// ¯\_(ツ)_/¯
@@ -202,6 +209,10 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 				}
 			}
 
+			if ( isset( $sqlite_queries ) ) {
+				$row['sqlite_queries'] = $sqlite_queries;
+			}
+
 			if ( self::is_expensive( $row ) ) {
 				$this->data->expensive[] = $i;
 			}
@@ -213,6 +224,7 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$this->data->total_qs = count( $this->data->rows );
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;
+		$this->data->has_sqlite = $has_sqlite;
 
 		// Filter out queries that do not have duplicates
 		$this->dupes = array_filter( $this->dupes, array( $this, 'filter_dupe_items' ) );

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -13,6 +13,10 @@
  */
 
 /**
+ * @phpstan-type SQLiteQuery array{
+ *   sql: string,
+ *   params?: array<string, mixed>,
+ * }
  * @phpstan-type QueryRow array{
  *   stack?: array<int, string>,
  *   sql: string,
@@ -21,6 +25,7 @@
  *   type: string,
  *   trace?: QM_Backtrace,
  *   is_main_query?: bool,
+ *   sqlite_queries?: array<int, SQLiteQuery>,
  * }
  */
 class QM_Data_DB_Queries extends QM_Data {
@@ -53,6 +58,11 @@ class QM_Data_DB_Queries extends QM_Data {
 	 * @var bool
 	 */
 	public $has_trace;
+
+	/**
+	 * @var bool
+	 */
+	public $has_sqlite;
 
 	/**
 	 * @var bool

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -59,11 +59,6 @@ class QM_Data_DB_Queries extends QM_Data {
 	public $has_trace;
 
 	/**
-	 * @var bool
-	 */
-	public $has_sqlite;
-
-	/**
 	 * @phpstan-var array<int, array{
 	 *   query: string,
 	 *   count: int,

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -13,6 +13,10 @@
  */
 
 /**
+ * @phpstan-type SQLiteQuery array{
+ *   sql: string,
+ *   params?: array<string, mixed>,
+ * }
  * @phpstan-type QueryRow array{
  *   stack?: array<int, string>,
  *   sql: string,
@@ -20,6 +24,7 @@
  *   result?: int|bool|WP_Error,
  *   trace?: QM_Backtrace,
  *   is_main_query?: bool,
+ *   sqlite_queries?: array<int, SQLiteQuery>,
  * }
  */
 class QM_Data_DB_Queries extends QM_Data {
@@ -52,6 +57,11 @@ class QM_Data_DB_Queries extends QM_Data {
 	 * @var bool
 	 */
 	public $has_trace;
+
+	/**
+	 * @var bool
+	 */
+	public $has_sqlite;
 
 	/**
 	 * @phpstan-var array<int, array{

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -15,7 +15,7 @@
 /**
  * @phpstan-type SQLiteQuery array{
  *   sql: string,
- *   params?: array<string, string|int|float>,
+ *   params?: array<string, mixed>,
  * }
  * @phpstan-type QueryRow array{
  *   stack?: array<int, string>,

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -15,7 +15,7 @@
 /**
  * @phpstan-type SQLiteQuery array{
  *   sql: string,
- *   params?: array<string, mixed>,
+ *   params?: array<string, string|int|float>,
  * }
  * @phpstan-type QueryRow array{
  *   stack?: array<int, string>,

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -234,6 +234,7 @@ export interface DB_Queries {
 	rows?: QueryRow[];
 	has_result: boolean;
 	has_trace: boolean;
+	has_sqlite: boolean;
 	dupes: {
 		query: string;
 		count: number;
@@ -256,6 +257,13 @@ export interface QueryRow {
 	result?: number | boolean | WP_Error;
 	trace?: Backtrace;
 	is_main_query?: boolean;
+	sqlite_queries?: SQLiteQuery[];
+}
+export interface SQLiteQuery {
+	sql: string;
+	params?: {
+		[k: string]: string | number;
+	};
 }
 /**
  * Doing it Wrong data transfer object.

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -234,7 +234,6 @@ export interface DB_Queries {
 	rows?: QueryRow[];
 	has_result: boolean;
 	has_trace: boolean;
-	has_sqlite: boolean;
 	dupes: {
 		query: string;
 		count: number;

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -250,6 +250,7 @@ export interface DB_Queries {
 	rows?: QueryRow[];
 	has_result: boolean;
 	has_trace: boolean;
+	has_sqlite: boolean;
 	has_main_query: boolean;
 	dupes: {
 		query: string;
@@ -274,6 +275,13 @@ export interface QueryRow {
 	type: string;
 	trace?: Backtrace;
 	is_main_query?: boolean;
+	sqlite_queries?: SQLiteQuery[];
+}
+export interface SQLiteQuery {
+	sql: string;
+	params?: {
+		[k: string]: string | number;
+	};
 }
 /**
  * Doing it Wrong data transfer object.

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -85,22 +85,38 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 			sql: {
 				className: ( row ) => Utils.getQueryType( row.sql ) !== 'SELECT' ? 'qm-nonselectsql' : '',
 				heading: __( 'Query', 'query-monitor' ),
-				render: ( row ) => (
-					<>
+				render: ( row ) => {
+					const sql = row.sqlite_queries?.length ? (
+						<ol>
+							{ row.sqlite_queries.map( ( q, j ) => (
+								<li>
+									<code key={ j }>
+										{ Utils.formatSQL( q.sql ) }
+									</code>
+								</li>
+							) ) }
+						</ol>
+					) : (
 						<code>
 							{ Utils.formatSQL( row.sql ) }
 						</code>
-						{ Utils.isWPError( row.result ) && (
-							<>
-								<br />
-								<br />
-								<Warning>
-									{ Utils.getErrorMessage( row.result ) }
-								</Warning>
-							</>
-						) }
-					</>
-				),
+					);
+
+					return (
+						<>
+							{ sql }
+							{ Utils.isWPError( row.result ) && (
+								<>
+									<br />
+									<br />
+									<Warning>
+										{ Utils.getErrorMessage( row.result ) }
+									</Warning>
+								</>
+							) }
+						</>
+					);
+				},
 				filters: {
 					options: ( () => {
 						const filters = Object.keys( types ).map( ( type ) => ( {

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -89,8 +89,8 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 					const sql = row.sqlite_queries?.length ? (
 						<ol>
 							{ row.sqlite_queries.map( ( q, j ) => (
-								<li>
-									<code key={ j }>
+								<li key={ j }>
+									<code>
 										{ Utils.formatSQL( q.sql ) }
 									</code>
 								</li>

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -72,22 +72,38 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 			sql: {
 				className: ( row ) => row.type !== 'SELECT' ? 'qm-nonselectsql' : '',
 				heading: __( 'Query', 'query-monitor' ),
-				render: ( row ) => (
-					<>
+				render: ( row ) => {
+					const sql = row.sqlite_queries?.length ? (
+						<ol>
+							{ row.sqlite_queries.map( ( q, j ) => (
+								<li>
+									<code key={ j }>
+										{ Utils.formatSQL( q.sql ) }
+									</code>
+								</li>
+							) ) }
+						</ol>
+					) : (
 						<code>
 							{ Utils.formatSQL( row.sql ) }
 						</code>
-						{ Utils.isWPError( row.result ) && (
-							<>
-								<br />
-								<br />
-								<Warning>
-									{ Utils.getErrorMessage( row.result ) }
-								</Warning>
-							</>
-						) }
-					</>
-				),
+					);
+
+					return (
+						<>
+							{ sql }
+							{ Utils.isWPError( row.result ) && (
+								<>
+									<br />
+									<br />
+									<Warning>
+										{ Utils.getErrorMessage( row.result ) }
+									</Warning>
+								</>
+							) }
+						</>
+					);
+				},
 				filters: {
 					options: ( () => {
 						const filters = Object.keys( data.types ).map( ( type ) => ( {

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -9,6 +9,7 @@ import { TotalTime } from '../components/total-time';
 import { DataTypes } from '../data-types';
 import { PanelProps } from '../types';
 import { useContext } from 'preact/hooks';
+import { Fragment } from 'preact';
 
 import {
 	__,
@@ -64,6 +65,7 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 
 	const types = Utils.getQueryTypes( data.rows );
 	const promptReason = ! data.has_trace ? settings.extended_query_prompt_reason : null;
+	const hasSQLite = data.rows.some( ( row ) => row.sqlite_queries?.length );
 
 	return <TabularPanel
 		title={ __( 'Database Queries', 'query-monitor' ) }
@@ -150,6 +152,34 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 				},
 				wrap: true
 			},
+			'sql-params': hasSQLite ? {
+				heading: __( 'Parameters', 'query-monitor' ),
+				render: ( row ) => {
+					if ( ! row.sqlite_queries?.length ) {
+						return null;
+					}
+
+					return (
+						row.sqlite_queries.map( ( q ) => {
+							const params = q.params ? Object.entries( q.params ) : [];
+
+							return (
+								params.length ? (
+									<dl className="qm-sqlite-params">
+										{ params.map( ( [ name, value ] ) => (
+											<Fragment key={ name }>
+												<dt><code className="qm-sql-value">{ name }</code></dt>
+												<dd><code>{ value }</code></dd>
+											</Fragment>
+										) ) }
+									</dl>
+								) : null
+							);
+						} )
+					);
+				},
+				wrap: true,
+			} : null,
 			caller: data.has_trace ? getCallerCol( data.rows, settings ) : getStackCol( data.rows ),
 			component: data.has_trace ? getComponentCol( data.rows ) : null,
 			result: data.has_result ? {

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -165,14 +165,17 @@ export const DBQueries = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 
 							return (
 								params.length ? (
-									<dl className="qm-sqlite-params">
-										{ params.map( ( [ name, value ] ) => (
-											<Fragment key={ name }>
-												<dt><code className="qm-sql-value">{ name }</code></dt>
-												<dd><code>{ value }</code></dd>
-											</Fragment>
-										) ) }
-									</dl>
+									<>
+										<dl className="qm-sqlite-params">
+											{ params.map( ( [ name, value ] ) => (
+												<Fragment key={ name }>
+													<dt><code className="qm-sql-value">{ name }</code></dt>
+													<dd><code>{ value }</code></dd>
+												</Fragment>
+											) ) }
+										</dl>
+										<br/>
+									</>
 								) : null
 							);
 						} )

--- a/output/utils.tsx
+++ b/output/utils.tsx
@@ -50,7 +50,7 @@ export const qm_l10n = {
 };
 
 function highlightStrings( text: string ): ( string | JSX.Element )[] {
-	const parts = text.split( /('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")/ );
+	const parts = text.split( /('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|:\w+)/ );
 
 	return parts.map( ( part, i ) =>
 		i % 2 === 1
@@ -78,7 +78,7 @@ export function formatSQL( sql: string ): JSX.Element[] {
 		trimmed = trimmed.slice( 0, -trailingMatch[0].length );
 	}
 
-	const formatted = ' ' + trimmed;
+	const formatted = ' ' + trimmed + ' ';
 	const lineRegex = ' (ADD|AFTER|ALTER|AND|BEGIN|CASE|COMMIT|CREATE|DELETE|DESCRIBE|DO|DROP|ELSE|END|EXCEPT|EXPLAIN|FROM|GROUP BY|GROUP|HAVING|INNER JOIN|INSERT|INTERSECT|JOIN|LEFT JOIN|LIMIT|ON|OR|ORDER BY|ORDER|OUTER JOIN|RENAME|REPLACE|RIGHT JOIN|ROLLBACK|SELECT|SET|SHOW|START|THEN|TRUNCATE|UNION|UPDATE|USE|USING|VALUES|WHEN|WHERE|XOR) ';
 	const lines = formatted.split( new RegExp( lineRegex ) );
 	const collection: JSX.Element[] = [];

--- a/output/utils.tsx
+++ b/output/utils.tsx
@@ -52,6 +52,14 @@ export function formatSQL( sql: string ): JSX.Element[] {
 		return '';
 	} );
 
+	if ( collection.length === 0 ) {
+		collection.push(
+			<Fragment key={ 0 }>
+				<b>{ sql }</b>
+			</Fragment>
+		);
+	}
+
 	return collection;
 }
 

--- a/src/schemas/data/db_queries.json
+++ b/src/schemas/data/db_queries.json
@@ -5,6 +5,27 @@
 	"description": "Database queries data transfer object.",
 	"type": "object",
 	"definitions": {
+		"SQLiteQuery": {
+			"type": "object",
+			"required": [
+				"sql"
+			],
+			"properties": {
+				"sql": {
+					"type": "string"
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": {
+						"oneOf": [
+							{ "type": "string" },
+							{ "type": "number" }
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"QueryRow": {
 			"type": "object",
 			"required": [
@@ -55,6 +76,12 @@
 				},
 				"is_main_query": {
 					"type": "boolean"
+				},
+				"sqlite_queries": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/SQLiteQuery"
+					}
 				}
 			},
 			"additionalProperties": false
@@ -64,6 +91,7 @@
 		"total_qs",
 		"has_result",
 		"has_trace",
+		"has_sqlite",
 		"dupes",
 		"errors"
 	],
@@ -98,6 +126,9 @@
 			"type": "boolean"
 		},
 		"has_trace": {
+			"type": "boolean"
+		},
+		"has_sqlite": {
 			"type": "boolean"
 		},
 		"dupes": {

--- a/src/schemas/data/db_queries.json
+++ b/src/schemas/data/db_queries.json
@@ -91,7 +91,6 @@
 		"total_qs",
 		"has_result",
 		"has_trace",
-		"has_sqlite",
 		"dupes",
 		"errors"
 	],
@@ -126,9 +125,6 @@
 			"type": "boolean"
 		},
 		"has_trace": {
-			"type": "boolean"
-		},
-		"has_sqlite": {
 			"type": "boolean"
 		},
 		"dupes": {

--- a/src/schemas/data/db_queries.json
+++ b/src/schemas/data/db_queries.json
@@ -5,6 +5,27 @@
 	"description": "Database queries data transfer object.",
 	"type": "object",
 	"definitions": {
+		"SQLiteQuery": {
+			"type": "object",
+			"required": [
+				"sql"
+			],
+			"properties": {
+				"sql": {
+					"type": "string"
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": {
+						"oneOf": [
+							{ "type": "string" },
+							{ "type": "number" }
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"QueryRow": {
 			"type": "object",
 			"required": [
@@ -59,6 +80,12 @@
 				},
 				"is_main_query": {
 					"type": "boolean"
+				},
+				"sqlite_queries": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/SQLiteQuery"
+					}
 				}
 			},
 			"additionalProperties": false
@@ -68,6 +95,7 @@
 		"total_qs",
 		"has_result",
 		"has_trace",
+		"has_sqlite",
 		"has_main_query",
 		"dupes",
 		"errors"
@@ -103,6 +131,9 @@
 			"type": "boolean"
 		},
 		"has_trace": {
+			"type": "boolean"
+		},
+		"has_sqlite": {
 			"type": "boolean"
 		},
 		"has_main_query": {


### PR DESCRIPTION
[The SQLite Database Integration plugin](https://github.com/WordPress/sqlite-database-integration) includes some functionality that overrides the Database Queries panel output to includes SQLite query information. This doesn't work with the new client side rendering. I think it makes sense for Query Monitor to officially support the SQLite Database Integration plugin

## Screenshot

<img alt="" src="https://github.com/user-attachments/assets/e21185d3-87bc-4008-8dbd-a6791b6b99cf" />
