### PR TITLE
Implement ArrayAccess on all data collectors for further back-compat

### DIFF
--- a/classes/ArrayAccess.php
+++ b/classes/ArrayAccess.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+/**
+ * Array access trait for data transfer objects.
+ *
+ * Provides backwards compatibility for third party code that accesses
+ * QM data objects using array syntax.
+ */
+
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+trait QM_ArrayAccess {
+	/**
+	 * @param mixed $offset
+	 * @param mixed $value
+	 * @return void
+	 */
+	#[ReturnTypeWillChange]
+	final public function offsetSet( $offset, $value ) {
+		if ( is_string( $offset ) ) {
+			$this->$offset = $value;
+		}
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return bool
+	 */
+	#[ReturnTypeWillChange]
+	final public function offsetExists( $offset ) {
+		return is_string( $offset ) && isset( $this->$offset );
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return void
+	 */
+	#[ReturnTypeWillChange]
+	final public function offsetUnset( $offset ) {
+		if ( is_string( $offset ) ) {
+			unset( $this->$offset );
+		}
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return mixed
+	 */
+	#[ReturnTypeWillChange]
+	final public function &offsetGet( $offset ) {
+		if ( is_string( $offset ) ) {
+			return $this->$offset;
+		}
+		$null = null;
+		return $null;
+	}
+}

--- a/classes/Data.php
+++ b/classes/Data.php
@@ -8,6 +8,8 @@
  */
 #[AllowDynamicProperties]
 abstract class QM_Data implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var array<string, mixed>
 	 */
@@ -22,50 +24,4 @@ abstract class QM_Data implements \ArrayAccess {
 	 * @var ?array<mixed>
 	 */
 	public $concerned_actions = null;
-
-	/**
-	 * @param mixed $offset
-	 * @param mixed $value
-	 * @return void
-	 */
-	#[ReturnTypeWillChange]
-	final public function offsetSet( $offset, $value ) {
-		if ( is_string( $offset ) ) {
-			$this->$offset = $value;
-		}
-	}
-
-	/**
-	 * @param mixed $offset
-	 * @return bool
-	 */
-	#[ReturnTypeWillChange]
-	final public function offsetExists( $offset ) {
-		return is_string( $offset ) && isset( $this->$offset );
-	}
-
-	/**
-	 * @param mixed $offset
-	 * @return void
-	 */
-	#[ReturnTypeWillChange]
-	final public function offsetUnset( $offset ) {
-		// @TODO might be able to no-op this
-		if ( is_string( $offset ) ) {
-			unset( $this->$offset );
-		}
-	}
-
-	/**
-	 * @param mixed $offset
-	 * @return mixed
-	 */
-	#[ReturnTypeWillChange]
-	final public function &offsetGet( $offset ) {
-		if ( is_string( $offset ) ) {
-			return $this->$offset;
-		}
-		$null = null;
-		return $null;
-	}
 }

--- a/data/block_editor/post_block.php
+++ b/data/block_editor/post_block.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_Post_Block {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_Post_Block implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var string|null
 	 */

--- a/data/callback.php
+++ b/data/callback.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_Callback {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_Callback implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var 'function'|'method'|'static_method'|'closure'|'invokable'|'lambda'|'unknown'|'unknown_closure'
 	 */

--- a/data/callsite.php
+++ b/data/callsite.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_Callsite {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_Callsite implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var string
 	 */

--- a/data/frame.php
+++ b/data/frame.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_Stack_Frame {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_Stack_Frame implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var string
 	 */

--- a/data/http/http_request.php
+++ b/data/http/http_request.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_HTTP_Request {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_HTTP_Request implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @phpstan-var array{
 	 *   method: string,

--- a/data/http/http_response.php
+++ b/data/http/http_response.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_HTTP_Response {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_HTTP_Response implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var int
 	 */

--- a/data/php_error.php
+++ b/data/php_error.php
@@ -10,7 +10,12 @@
  * @package query-monitor
  */
 
-class QM_Data_PHP_Error {
+/**
+ * @implements \ArrayAccess<string,mixed>
+ */
+class QM_Data_PHP_Error implements \ArrayAccess {
+	use QM_ArrayAccess;
+
 	/**
 	 * @var int
 	 */

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,6 +25,11 @@
 		<exclude-pattern>/dispatchers/Html\.php$</exclude-pattern>
 	</rule>
 
+	<!-- ArrayAccess method names are defined by the PHP interface -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
+		<exclude-pattern>/classes/ArrayAccess\.php$</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress-Extra">
 
 		<exclude name="WordPress.Files.FileName" />

--- a/src/generate.mjs
+++ b/src/generate.mjs
@@ -506,7 +506,15 @@ function printExtractedClass( node ) {
 
 	lines.push( '' );
 
-	lines.push( `class ${ node.name } {` );
+	lines.push( '/**' );
+	lines.push( ' * @implements \\ArrayAccess<string,mixed>' );
+	lines.push( ' */' );
+	lines.push( `class ${ node.name } implements \\ArrayAccess {` );
+	lines.push( '\tuse QM_ArrayAccess;' );
+
+	if ( node.properties.length > 0 ) {
+		lines.push( '' );
+	}
 
 	for ( let i = 0; i < node.properties.length; i++ ) {
 		const isLast = i === node.properties.length - 1;

--- a/tests/integration/ArrayAccessTest.php
+++ b/tests/integration/ArrayAccessTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace QM\Tests;
+
+class ArrayAccessTest extends Test {
+
+	public function testDataObjectSupportsArrayAccess(): void {
+		$data = new \QM_Data_Fallback();
+		$data->dummy = 'hello';
+
+		// Read via array access.
+		self::assertSame( 'hello', $data['dummy'] );
+
+		// Write via array access.
+		$data['dummy'] = 'world';
+		self::assertSame( 'world', $data->dummy );
+
+		// isset via array access.
+		self::assertTrue( isset( $data['dummy'] ) );
+		self::assertFalse( isset( $data['nonexistent'] ) );
+	}
+
+	public function testExtractedClassSupportsArrayAccess(): void {
+		$frame = new \QM_Data_Stack_Frame();
+		$frame->id = 'my_function';
+		$frame->file = '/app/test.php';
+		$frame->line = 42;
+
+		// Read via array access.
+		self::assertSame( 'my_function', $frame['id'] );
+		self::assertSame( '/app/test.php', $frame['file'] );
+		self::assertSame( 42, $frame['line'] );
+
+		// Write via array access.
+		$frame['file'] = '/app/other.php';
+		self::assertSame( '/app/other.php', $frame->file );
+
+		// isset via array access.
+		self::assertTrue( isset( $frame['id'] ) );
+		self::assertFalse( isset( $frame['nonexistent'] ) );
+	}
+
+	public function testStandaloneClassSupportsArrayAccess(): void {
+		$callback = new \QM_Data_Callback();
+		$callback->callback_type = 'function';
+		$callback->name = 'my_function';
+		$callback->file = '/app/test.php';
+		$callback->line = 10;
+
+		self::assertSame( 'function', $callback['callback_type'] );
+		self::assertSame( 'my_function', $callback['name'] );
+	}
+}


### PR DESCRIPTION
The top level `QM_Data` class implements ArrayAccess for backwards compatibility, but plugins such as Pods and Object Cache Pro read data that's now contained with nested properties that don't.

This adds `ArraayAccess` to all DTOs.