### PR TITLE
Allow non-UTF8 (ie binary) in json

### DIFF
--- a/classes/Util.php
+++ b/classes/Util.php
@@ -645,7 +645,7 @@ class QM_Util {
 	/**
 	 * Helper function for JSON encoding data and formatting it in a consistent manner.
 	 *
-	 * @deprecated Use json_encode() directly with the appropriate options instead.
+	 * @deprecated Use wp_json_encode() directly with the appropriate options instead.
 	 *
 	 * @param mixed $data The data to be JSON encoded.
 	 * @return string The JSON encoded data.
@@ -653,7 +653,7 @@ class QM_Util {
 	public static function json_format( $data ) {
 		$json_options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
 
-		$json = json_encode( $data, $json_options );
+		$json = wp_json_encode( $data, $json_options );
 
 		if ( false === $json ) {
 			return '';

--- a/dispatchers/AJAX.php
+++ b/dispatchers/AJAX.php
@@ -128,7 +128,6 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 			header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
 		}
 
-		// @TODO
 		echo wp_json_encode(
 			array(
 				'code' => 'qm_fatal',

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -414,10 +414,12 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		$this->output_assets();
 
+		$encoded = wp_json_encode( $json, JSON_UNESCAPED_SLASHES );
+
 		wp_print_inline_script_tag(
 			sprintf(
 				'var QueryMonitorData = %s;',
-				json_encode( $json, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE )
+				false !== $encoded ? $encoded : 'false'
 			),
 			array(
 				'id' => 'query-monitor-inline-data',

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -417,7 +417,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		wp_print_inline_script_tag(
 			sprintf(
 				'var QueryMonitorData = %s;',
-				json_encode( $json, JSON_UNESCAPED_SLASHES )
+				json_encode( $json, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE )
 			),
 			array(
 				'id' => 'query-monitor-inline-data',

--- a/dispatchers/REST.php
+++ b/dispatchers/REST.php
@@ -94,7 +94,7 @@ class QM_Dispatcher_REST extends QM_Dispatcher {
 			header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
 		}
 
-		echo json_encode(
+		echo wp_json_encode(
 			array(
 				'code' => 'qm_fatal',
 				'message' => $message,

--- a/output/Headers.php
+++ b/output/Headers.php
@@ -16,7 +16,7 @@ abstract class QM_Output_Headers extends QM_Output {
 
 		foreach ( $this->get_output() as $key => $value ) {
 			if ( ! is_scalar( $value ) ) {
-				$value = json_encode( $value );
+				$value = wp_json_encode( $value );
 			}
 
 			# Remove illegal characters (Header value may not contain NUL bytes)

--- a/output/headers/php_errors.php
+++ b/output/headers/php_errors.php
@@ -49,7 +49,7 @@ class QM_Output_Headers_PHP_Errors extends QM_Output_Headers {
 			);
 
 			$key = sprintf( 'error-%d', $count );
-			$headers[ $key ] = json_encode( $output_error );
+			$headers[ $key ] = wp_json_encode( $output_error );
 		}
 
 		return array_merge(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,19 @@ type iQM = {
 	locale_data?: Record<string, unknown> | null;
 }
 
-declare const QueryMonitorData: iQM;
+declare const QueryMonitorData: iQM | false;
+
+if ( QueryMonitorData === false ) {
+	document.addEventListener( 'DOMContentLoaded', function () {
+		const adminMenuElement = document.getElementById( 'wp-admin-bar-query-monitor' );
+
+		if ( adminMenuElement ) {
+			adminMenuElement.classList.add( 'qm-error' );
+		}
+
+		console.error( 'Query Monitor: Failed to encode output data.' );
+	} );
+} else {
 
 // Initialise lookup tables before anything renders.
 setFrameLookup( QueryMonitorData.frames );
@@ -397,4 +409,6 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	const bodyObserver = new MutationObserver( renderQM );
 	bodyObserver.observe( document.body, { attributes: true, attributeFilter: [ 'class' ] } );
 } );
+
+} // QueryMonitorData !== false
 

--- a/tests/acceptance/DBQueries.spec.ts
+++ b/tests/acceptance/DBQueries.spec.ts
@@ -1,0 +1,17 @@
+import { test } from './utils/test-setup';
+
+test.describe( 'Database Queries', () => {
+	test.beforeAll( async ( { globalUtils } ) => {
+		globalUtils.installWordPress();
+	} );
+
+	test.beforeEach( async ( { QueryMonitor } ) => {
+		await QueryMonitor.loginViaPage( 'admin', 'password' );
+	} );
+
+	test( 'Non-UTF8 query should be displayed', async ( { QueryMonitor } ) => {
+		await QueryMonitor.amOnAPageThatTriggersDBQuery( 'non_utf8' );
+		await QueryMonitor.seeQMMenu();
+		await QueryMonitor.seeInQMPanel( 'Database Queries', 'qm_binary_ip_test' );
+	} );
+} );

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -115,6 +115,13 @@ export class QueryMonitorUtils {
 	}
 
 	/**
+	 * Navigate to a page that triggers a database query scenario
+	 */
+	async amOnAPageThatTriggersDBQuery( test: string ) {
+		await this.page.goto( `/?_qm_acceptance_group=db_queries&_qm_acceptance_test=${test}` );
+	}
+
+	/**
 	 * Navigate to a page that loads the third-party panel test plugin
 	 */
 	async amOnAPageWithThirdPartyPanel() {

--- a/tests/mu-plugins/acceptance.php
+++ b/tests/mu-plugins/acceptance.php
@@ -182,6 +182,37 @@ add_action( 'init', function() {
 					break;
 			}
 			break;
+		case 'db_queries':
+			switch ( $_GET['_qm_acceptance_test'] ) {
+				case 'non_utf8':
+					global $wpdb;
+
+					// Insert binary IP address data which produces non-UTF8
+					// bytes in the logged SQL queries. This tests that QM can
+					// gracefully encode the query data as JSON.
+					$table = $wpdb->prefix . 'qm_binary_ip_test';
+
+					$wpdb->query(
+						"CREATE TABLE IF NOT EXISTS `{$table}` (
+							`ip` varbinary(16) NOT NULL
+						);"
+					);
+
+					$wpdb->insert(
+						$table,
+						array(
+							'ip' => inet_pton( '192.168.1.0' ),
+						),
+						array( '%s' )
+					);
+
+					$wpdb->query( "DROP TABLE IF EXISTS `{$table}`" );
+					break;
+				default:
+					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
+					break;
+			}
+			break;
 		default:
 			throw new \InvalidArgumentException( 'Unknown group: ' . $_GET['_qm_acceptance_group'] );
 			break;


### PR DESCRIPTION
Fixes situations where raw binary is used in database-queries (ie for efficiently storing IP adresses) 

Previously the encode would fail, causing the panel to not render at all.