### PR TITLE
Fixes the issue raw html in frontend by adding JSON_HEX_TAG

### DIFF
--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -417,7 +417,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		$this->output_assets();
 
-		$encoded = wp_json_encode( $json, JSON_UNESCAPED_SLASHES );
+		$encoded = wp_json_encode( $json, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG );
 
 		wp_print_inline_script_tag(
 			sprintf(

--- a/tests/acceptance/HtmlBlock.spec.ts
+++ b/tests/acceptance/HtmlBlock.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from './utils/test-setup';
+import { GlobalUtils } from './utils/global-utils';
+
+test.describe( 'HTML Block', () => {
+	let postUrl: string;
+
+	test.beforeAll( async ( { globalUtils } ) => {
+		globalUtils.installWordPress();
+
+		// Create a post with a wp:html block containing a script tag.
+		// The </script> closing tag within the block innerHTML ends up in
+		// the QM JSON data. Without proper encoding this breaks out of the
+		// inline script tag that delivers QueryMonitorData.
+		const postId = GlobalUtils.runWPCLICommand(
+			'post create --post_status=publish --post_title="HTML Block Test" --post_content="<!-- wp:html -->\n<script src=\"https://player.vimeo.com/api/player.js\"></script>\n<!-- /wp:html -->" --porcelain'
+		);
+		postUrl = GlobalUtils.runWPCLICommand( `post url ${postId.trim()}` );
+
+		// Convert absolute URL to relative path
+		const url = new URL( postUrl );
+		postUrl = url.pathname;
+	} );
+
+	test.beforeEach( async ( { QueryMonitor } ) => {
+		await QueryMonitor.loginViaPage( 'admin', 'password' );
+	} );
+
+	test( 'Post with HTML block containing script tag should not break QM output', async ( { page } ) => {
+		await page.goto( postUrl );
+
+		// The QueryMonitorData variable should be a valid object.
+		// If the </script> in the block innerHTML broke out of the
+		// inline script tag, this variable will be undefined.
+		const qmData = await page.evaluate( () => typeof window.QueryMonitorData );
+		expect( qmData ).toBe( 'object' );
+	} );
+} );

--- a/tests/acceptance/HtmlBlock.spec.ts
+++ b/tests/acceptance/HtmlBlock.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './utils/test-setup';
 import { GlobalUtils } from './utils/global-utils';
 
 test.describe( 'HTML Block', () => {
-	let postUrl: string;
+	let postId: string;
 
 	test.beforeAll( async ( { globalUtils } ) => {
 		globalUtils.installWordPress();
@@ -11,14 +11,9 @@ test.describe( 'HTML Block', () => {
 		// The </script> closing tag within the block innerHTML ends up in
 		// the QM JSON data. Without proper encoding this breaks out of the
 		// inline script tag that delivers QueryMonitorData.
-		const postId = GlobalUtils.runWPCLICommand(
+		postId = GlobalUtils.runWPCLICommand(
 			'post create --post_status=publish --post_title="HTML Block Test" --post_content="<!-- wp:html -->\n<script src=\"https://player.vimeo.com/api/player.js\"></script>\n<!-- /wp:html -->" --porcelain'
-		);
-		postUrl = GlobalUtils.runWPCLICommand( `post url ${postId.trim()}` );
-
-		// Convert absolute URL to relative path
-		const url = new URL( postUrl );
-		postUrl = url.pathname;
+		).trim();
 	} );
 
 	test.beforeEach( async ( { QueryMonitor } ) => {
@@ -26,7 +21,7 @@ test.describe( 'HTML Block', () => {
 	} );
 
 	test( 'Post with HTML block containing script tag should not break QM output', async ( { page } ) => {
-		await page.goto( postUrl );
+		await page.goto( `/?p=${postId}` );
 
 		// The QueryMonitorData variable should be a valid object.
 		// If the </script> in the block innerHTML broke out of the


### PR DESCRIPTION
Fixes the issue where raw html was sent to the footer of the page (Ref. #1087 )

For us the issue was this block:
```
<!-- wp:html -->
<script src="https://player.vimeo.com/api/player.js"></script>
<!-- /wp:html -->
```

HTML:
`<script src="https://player.vimeo.com/api/player.js"></script>`