### PR TITLE
Switch from a layout effect to a portal for the admin menu

### DIFF
--- a/output/qm.tsx
+++ b/output/qm.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 import { Icon, IconDefs } from './components/icon';
 import { MainContext, MainContextType, DurationUnit } from './contexts/main-context';
-import { type ComponentChildren, render } from 'preact';
-import { useState, useEffect, useRef, useMemo, useLayoutEffect } from 'preact/hooks';
+import { type ComponentChildren } from 'preact';
+import { createPortal } from 'preact/compat';
+import { useState, useEffect, useRef, useMemo } from 'preact/hooks';
 
 import { __ } from '@wordpress/i18n';
 
@@ -413,10 +414,5 @@ const AdminMenu = ( props: iAdminMenuProps ) => {
 		return true;
 	}, [props.element]);
 
-	useLayoutEffect(() => {
-		render( <>{ props.children }</>, props.element );
-		return () => render( null, props.element );
-	});
-
-	return null;
+	return createPortal( <>{ props.children }</>, props.element );
 }


### PR DESCRIPTION
This prevents the body class mutation observer triggering a full re-render.

This fixes compatibility with GeneratePress which [includes an accessibility script](https://themes.trac.wordpress.org/browser/generatepress/3.6.1/inc/general.php?marks=490#L481) that adjusts the body class on `pointerdown`, which means whenever one of the admin menu items in QM are clicked, it re-renders instead of triggering the menu item handler.