### PR TITLE
Add function property to resolve php deprecated notice

### DIFF
--- a/data/frame.php
+++ b/data/frame.php
@@ -35,4 +35,9 @@ class QM_Data_Stack_Frame implements \ArrayAccess {
 	 * @var ?int|null
 	 */
 	public $line;
+
+	/**
+	 * @var ?string|null
+	 */
+	public $function;
 }

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -408,6 +408,7 @@ export interface StackFrame {
 	args?: string | null;
 	file: string | null;
 	line?: number | null;
+	function?: string | null;
 }
 /**
  * Logger data transfer object.

--- a/src/schemas/stack-frame.json
+++ b/src/schemas/stack-frame.json
@@ -31,6 +31,12 @@
 				"integer",
 				"null"
 			]
+		},
+		"function": {
+			"type": [
+				"string",
+				"null"
+			]
 		}
 	},
 	"additionalProperties": false


### PR DESCRIPTION
Closes #1110.

~(Apologies, as I have no idea what to change in `generate.mjs`.)~