### PR TITLE
fix: Pods plugin link in documentation

### DIFF
--- a/docs/help/add-on-plugins.md
+++ b/docs/help/add-on-plugins.md
@@ -32,7 +32,7 @@ Adds a panel for debugging Yoast SEO metadata and options
 Integrates with Query Monitor when using the Chargebee API
 * [Fluent Query Logger](https://wordpress.org/plugins/fluent-query-logger/)  
 Log Database Queries and analyze plugin database performance
-* [Pods][https://wordpress.org/plugins/pods/]  
+* [Pods](https://wordpress.org/plugins/pods/)  
 Shows configuration and debugging information relating to Pods
 * Any plugin that uses the Freemius SDK provides a Freemius panel in Query Monitor
 


### PR DESCRIPTION
Fixed Markdown link to Pods plugin on https://querymonitor.com/help/add-on-plugins/.