### PR TITLE
Fix capitalisation of NetBeans

### DIFF
--- a/docs/help/clickable-stack-traces-and-function-names.md
+++ b/docs/help/clickable-stack-traces-and-function-names.md
@@ -15,7 +15,7 @@ You just need to open up the Settings panel in Query Monitor (click the cog next
 If you use one of the following editors you may need to configure its URL scheme handler:
 
 * Sublime Text: [Install the Sublime Text URL handler](https://github.com/inopinatus/sublime_url)
-* Netbeans: [Enable clickable stack traces with Netbeans](https://simonwheatley.co.uk/2012/08/clickable-stack-traces-with-netbeans/)
+* NetBeans: [Enable clickable stack traces with NetBeans](https://simonwheatley.co.uk/2012/08/clickable-stack-traces-with-netbeans/)
 
 ## Remote File Path Mapping
 

--- a/output/utils.tsx
+++ b/output/utils.tsx
@@ -239,7 +239,7 @@ export function getEditors(): { label: string, name: string; format: string; }[]
 			format: 'cursor://file/%1$s:%2$s',
 		},
 		{
-			label: 'Netbeans',
+			label: 'NetBeans',
 			name: 'netbeans',
 			format: 'nbopen://%1$s:%2$s',
 		},


### PR DESCRIPTION
Fixes the capitalisation of NetBeans in the editor label (`output/utils.tsx`) and the docs (`docs/help/clickable-stack-traces-and-function-names.md`). The internal `name` slug is left as `netbeans` to avoid breaking any persisted user preferences.

Closes #784

---
*Assisted by Claude (Anthropic) — [CONTRIBUTING.md disclosure](https://github.com/johnbillion/query-monitor/blob/develop/CONTRIBUTING.md#ai-assisted-development)*