### PR TITLE
Admin toolbar menu improvements

### DIFF
--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -10,14 +10,16 @@
 	--qm-menu-icon: #aaa;
 	--qm-menu-alert-bg: #f60;
 	--qm-menu-notice-bg: #740;
-	--qm-menu-notice-bg-hover: #5e3500;
+	--qm-menu-notice-bg-hover: #6a3c00;
 	--qm-menu-expensive-bg: #b60;
+	--qm-menu-expensive-bg-hover: #a25800;
 	--qm-menu-warning-bg: #c00;
 	--qm-menu-warning-bg-hover: #b30000;
 	--qm-menu-fg: #eee;
 	--qm-menu-true-fg: #8c8;
 	--qm-menu-true-fg-hover: #47a747;
 
+	/* True conditionals */
 	.quicklinks .menupop ul li.qm-true > a {
 		color: var( --qm-menu-true-fg ) !important;
 
@@ -27,96 +29,65 @@
 		}
 	}
 
-	#wp-admin-bar-query-monitor-doing_it_wrong a,
-	#wp-admin-bar-query-monitor-stricts a,
-	#wp-admin-bar-query-monitor-deprecateds a,
-	#wp-admin-bar-query-monitor-notices a,
+	/* Top and submenu items for PHP stricts, deprecateds, and notices */
 	.qm-strict,
 	.qm-deprecated,
 	.qm-notice {
-		background-color: var( --qm-menu-notice-bg );
+		background-color: var( --qm-menu-notice-bg ) !important;
+	}
+
+	/* Submenu item links for PHP stricts, deprecateds, and notices */
+	.ab-submenu .qm-strict a,
+	.ab-submenu .qm-deprecated a,
+	.ab-submenu .qm-notice a {
+		color: rgba( 255, 255, 255, 0.8 ) !important;
 
 		&:focus,
 		&:hover {
-			background-color: var( --qm-menu-notice-bg-hover );
+			background-color: var( --qm-menu-notice-bg-hover ) !important;
+			color: rgba( 255, 255, 255, 0.7 ) !important;
 		}
 	}
 
-	#wp-admin-bar-query-monitor-expensive a,
+	/* Top and submenu items for slow database queries */
 	.qm-expensive {
-		background-color: var( --qm-menu-expensive-bg );
+		background-color: var( --qm-menu-expensive-bg ) !important;
+	}
+
+	/* Submenu item links for slow database queries */
+	.ab-submenu .qm-expensive a {
+		color: rgba( 255, 255, 255, 0.8 ) !important;
 
 		&:focus,
 		&:hover {
-			background-color: #a25800;
+			background-color: var( --qm-menu-expensive-bg-hover );
+			color: rgba( 255, 255, 255, 0.7 ) !important;
 		}
 	}
 
-	.qm-alert {
-		background-color: var( --qm-menu-alert-bg );
-	}
-
-	#wp-admin-bar-query-monitor-logger-warning a,
-	#wp-admin-bar-query-monitor-warnings a,
-	#wp-admin-bar-query-monitor-errors a,
+	/* Top and submenu items for errors and warnings */
 	.qm-error,
 	.qm-warning {
-		background-color: var( --qm-menu-warning-bg );
+		background-color: var( --qm-menu-warning-bg ) !important;
+	}
+
+	/* Submenu item links for errors and warnings */
+	.ab-submenu .qm-error a,
+	.ab-submenu .qm-warning a {
+		color: rgba( 255, 255, 255, 0.9 ) !important;
 
 		&:focus,
 		&:hover {
-			background-color: var( --qm-menu-warning-bg-hover );
+			background-color: var( --qm-menu-warning-bg-hover ) !important;
+			color: rgba( 255, 255, 255, 0.8 ) !important;
 		}
 	}
 
-	#wp-admin-bar-query-monitor .ab-icon {
-		color: var( --qm-menu-icon ) !important;
-		display: none !important;
-		font: 18px/44px Arial !important;
-		padding: 0 10px !important;
-		width: auto !important;
-	}
-
-	@media screen and (max-width: 782px) {
-		/** force menu icon to show up */
-		#wp-admin-bar-query-monitor .ab-icon {
-			display: block !important;
-		}
-		/** hide menu text */
-		#wp-admin-bar-query-monitor .ab-label {
-			display: none !important;
+	#wp-admin-bar-query-monitor {
+		small {
+			font-size: 11px !important;
 		}
 	}
-}
-
-#wp-admin-bar-query-monitor *,
-#wp-admin-bar-query-monitor {
-	direction: ltr !important;
-	text-align: left !important;
-}
-
-body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover) .ab-label,
-#wp-admin-bar-query-monitor-default .qm-alert a,
-#wp-admin-bar-query-monitor-default .qm-error a,
-#wp-admin-bar-query-monitor-default .qm-warning a,
-#wp-admin-bar-query-monitor-doing_it_wrong a,
-#wp-admin-bar-query-monitor-deprecateds a,
-#wp-admin-bar-query-monitor-stricts a,
-#wp-admin-bar-query-monitor-notices a,
-#wp-admin-bar-query-monitor-expensive a,
-#wp-admin-bar-query-monitor-logger-warning a,
-#wp-admin-bar-query-monitor-warnings a,
-#wp-admin-bar-query-monitor-errors a {
-	color: var( --qm-menu-fg ) !important;
-}
-
-#wp-admin-bar-query-monitor small {
-	font-size: 11px !important;
-}
-
-#wp-admin-bar-query-monitor.hover a small,
-#wp-admin-bar-query-monitor.hover a .ab-label {
-	text-shadow: none !important;
 }
 
 /** === Fatal Error Panel === */
@@ -165,7 +136,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 	a.qm-edit-link svg {
 		display: none;
 	}
-
 }
 
 body#error-page {

--- a/classes/Collector_Assets.php
+++ b/classes/Collector_Assets.php
@@ -244,6 +244,18 @@ abstract class QM_Collector_Assets extends QM_DataCollector {
 
 				$warning = ! in_array( $handle, $raw->done, true );
 
+				if ( $source instanceof WP_Error ) {
+					/** This filter is documented in collectors/http.php */
+					$silent = apply_filters( 'qm/collect/silent_http_errors', array(
+						'http_request_not_executed',
+						'airplane_mode_enabled',
+					) );
+
+					if ( ! in_array( $source->get_error_code(), $silent, true ) ) {
+						$warning = true;
+					}
+				}
+
 				$dependencies = array_values( $dependency->deps );
 
 				foreach ( $dependencies as $dep ) {

--- a/output/html/assets.php
+++ b/output/html/assets.php
@@ -30,14 +30,30 @@ abstract class QM_Output_Html_Assets extends QM_Output_Html {
 	abstract public function get_type_labels();
 
 	/**
+	 * Returns the number of assets with a problem, namely those that are missing or
+	 * that have missing dependencies. This matches the rows flagged as errors in the panel.
+	 *
+	 * @return int
+	 */
+	protected function get_warning_count() {
+		/** @var QM_Data_Assets $data */
+		$data = $this->collector->get_data();
+
+		if ( empty( $data->assets ) ) {
+			return 0;
+		}
+
+		return count( array_filter( $data->assets, static function( array $asset ) {
+			return ! empty( $asset['warning'] );
+		} ) );
+	}
+
+	/**
 	 * @param array<int, string> $class
 	 * @return array<int, string>
 	 */
 	public function admin_class( array $class ) {
-		/** @var QM_Data_Assets $data */
-		$data = $this->collector->get_data();
-
-		if ( ! empty( $data->broken ) || ! empty( $data->missing ) ) {
+		if ( $this->get_warning_count() > 0 ) {
 			$class[] = 'qm-error';
 		}
 
@@ -54,13 +70,15 @@ abstract class QM_Output_Html_Assets extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		$type_label = $this->get_type_labels();
+		$warning_count = $this->get_warning_count();
 
 		$args = array(
 			'title' => $type_label['label'],
 			'count' => array_sum( $data->types ),
 		);
 
-		if ( ! empty( $data->broken ) || ! empty( $data->missing ) ) {
+		if ( $warning_count > 0 ) {
+			$args['warning_count'] = $warning_count;
 			$args['meta']['classname'] = 'qm-error';
 		}
 

--- a/output/html/db_queries.php
+++ b/output/html/db_queries.php
@@ -98,7 +98,6 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 	 * @return array<int, string>
 	 */
 	public function admin_class( array $class ) {
-
 		if ( $this->collector->get_errors() ) {
 			$class[] = 'qm-error';
 		}
@@ -144,6 +143,9 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 				'panel' => 'db_expensive',
 				'title' => esc_html__( 'Slow Queries', 'query-monitor' ),
 				'warning_count' => count( $expensive ),
+				'meta' => [
+					'classname' => 'qm-expensive',
+				],
 			) );
 		}
 

--- a/output/html/http.php
+++ b/output/html/http.php
@@ -44,10 +44,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 		/** @var QM_Data_HTTP $data */
 		$data = $this->collector->get_data();
 
-		if ( isset( $data->errors['alert'] ) ) {
-			$class[] = 'qm-alert';
-		}
-		if ( isset( $data->errors['warning'] ) ) {
+		if ( ! empty( $data->errors ) ) {
 			$class[] = 'qm-warning';
 		}
 
@@ -64,7 +61,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		$count = ! empty( $data->http ) ? count( $data->http ) : 0;
-		$error_count = isset( $data->errors['alert'] ) ? count( $data->errors['alert'] ) : 0;
+		$error_count = ! empty( $data->errors ) ? count( $data->errors ) : 0;
 
 		$args = array(
 			'title' => __( 'HTTP API Calls', 'query-monitor' ),
@@ -72,10 +69,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 			'warning_count' => $error_count ?: null,
 		);
 
-		if ( isset( $data->errors['alert'] ) ) {
-			$args['meta']['classname'] = 'qm-alert';
-		}
-		if ( isset( $data->errors['warning'] ) ) {
+		if ( ! empty( $data->errors ) ) {
 			$args['meta']['classname'] = 'qm-warning';
 		}
 

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -111,12 +111,21 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 			return $data->types[ $type ] ?? 0;
 		}, array_keys( $types ) ) ) );
 
+		/* translators: used between list items, there is a space after the comma */
+		$sep = __( ', ', 'query-monitor' );
+
+		$title = sprintf(
+			/* translators: %s: List of PHP error types */
+			__( 'PHP Errors (%s)', 'query-monitor' ),
+			implode( $sep, array_reverse( $menu_label ) )
+		);
+
 		$menu[ $this->collector->id() ] = $this->menu( array(
-			'title' => esc_html__( 'PHP Errors', 'query-monitor' ),
+			'title' => $title,
 			'warning_count' => $count,
 		) );
-		return $menu;
 
+		return $menu;
 	}
 
 	/**

--- a/output/html/php_errors.php
+++ b/output/html/php_errors.php
@@ -64,6 +64,11 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 	public function admin_menu( array $menu ) {
 		/** @var QM_Data_PHP_Errors $data */
 		$data = $this->collector->get_data();
+
+		if ( empty( $data->errors ) ) {
+			return $menu;
+		}
+
 		$menu_label = array();
 
 		$types = array(
@@ -77,53 +82,59 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 			'warning' => _nx_noop( '%s Warning', '%s Warnings', 'PHP error level', 'query-monitor' ),
 		);
 
-		foreach ( $types as $type => $label ) {
-			$count = 0;
-			$has_errors = false;
+		// Count only non-suppressed errors, grouped by level.
+		$counts = array();
 
-			if ( isset( $data->types[ $type ] ) ) {
-				$has_errors = true;
-				$count += $data->types[ $type ];
-			}
-
-			if ( ! $has_errors ) {
+		foreach ( $data->errors as $error ) {
+			if ( $error->suppressed ) {
 				continue;
 			}
 
-			if ( $count ) {
-				$label = sprintf(
-					translate_nooped_plural(
-						$label,
-						$count,
-						'query-monitor'
-					),
-					number_format_i18n( $count )
-				);
-				$menu_label[] = $label;
+			$counts[ $error->level ] = ( $counts[ $error->level ] ?? 0 ) + $error->count;
+		}
+
+		foreach ( $types as $type => $label ) {
+			if ( empty( $counts[ $type ] ) ) {
+				continue;
 			}
+
+			$menu_label[] = sprintf(
+				translate_nooped_plural(
+					$label,
+					$counts[ $type ],
+					'query-monitor'
+				),
+				number_format_i18n( $counts[ $type ] )
+			);
 		}
 
-		if ( empty( $menu_label ) ) {
-			return $menu;
+		$count = array_sum( $counts );
+
+		if ( ! empty( $menu_label ) ) {
+			/* translators: used between list items, there is a space after the comma */
+			$sep = __( ', ', 'query-monitor' );
+
+			$title = sprintf(
+				/* translators: %s: List of PHP error types */
+				__( 'PHP Errors (%s)', 'query-monitor' ),
+				implode( $sep, array_reverse( $menu_label ) )
+			);
+		} else {
+			$title = __( 'PHP Errors', 'query-monitor' );
 		}
 
-		$count = array_sum( array_filter( array_map( function( $type ) use ( $data ) {
-			return $data->types[ $type ] ?? 0;
-		}, array_keys( $types ) ) ) );
-
-		/* translators: used between list items, there is a space after the comma */
-		$sep = __( ', ', 'query-monitor' );
-
-		$title = sprintf(
-			/* translators: %s: List of PHP error types */
-			__( 'PHP Errors (%s)', 'query-monitor' ),
-			implode( $sep, array_reverse( $menu_label ) )
-		);
-
-		$menu[ $this->collector->id() ] = $this->menu( array(
+		$args = array(
 			'title' => $title,
 			'warning_count' => $count,
-		) );
+		);
+
+		$classes = $this->admin_class( [] );
+
+		if ( ! empty( $classes ) ) {
+			$args['meta']['classname'] = implode( ' ', $classes );
+		}
+
+		$menu[ $this->collector->id() ] = $this->menu( $args );
 
 		return $menu;
 	}

--- a/tests/acceptance/PhpErrors.spec.ts
+++ b/tests/acceptance/PhpErrors.spec.ts
@@ -12,12 +12,16 @@ test.describe( 'PHP Errors', () => {
 	test( 'Warning should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'warning' );
 		await QueryMonitor.seeQMMenuWithWarning();
+		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-warning' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-warning', 'PHP Errors (1 Warning)' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test warning' );
 	} );
 
 	test( 'Notice should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'notice' );
 		await QueryMonitor.seeQMMenuWithNotice();
+		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-notice' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-notice', 'PHP Errors (1 Notice)' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );
 	} );
 
@@ -33,5 +37,14 @@ test.describe( 'PHP Errors', () => {
 		await QueryMonitor.seeQMMenu();
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'notice (suppressed)' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test suppressed notice' );
+	} );
+
+	test( 'Assortment of errors should be handled', async ( { QueryMonitor } ) => {
+		await QueryMonitor.amOnAPageThatTriggersPhpError( 'buffet' );
+		await QueryMonitor.seeQMMenuWithWarning();
+		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-warning' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-notice', 'PHP Errors (1 Warning, 1 Notice)' );
+		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test warning' );
+		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );
 	} );
 } );

--- a/tests/acceptance/PhpErrors.spec.ts
+++ b/tests/acceptance/PhpErrors.spec.ts
@@ -12,7 +12,6 @@ test.describe( 'PHP Errors', () => {
 	test( 'Warning should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'warning' );
 		await QueryMonitor.seeQMMenuWithWarning();
-		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-warning' );
 		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-warning', 'PHP Errors (1 Warning)' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test warning' );
 	} );
@@ -20,7 +19,6 @@ test.describe( 'PHP Errors', () => {
 	test( 'Notice should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'notice' );
 		await QueryMonitor.seeQMMenuWithNotice();
-		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-notice' );
 		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-notice', 'PHP Errors (1 Notice)' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );
 	} );
@@ -42,9 +40,9 @@ test.describe( 'PHP Errors', () => {
 	test( 'Assortment of errors should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'buffet' );
 		await QueryMonitor.seeQMMenuWithWarning();
-		await QueryMonitor.seeQMSubMenuItemHighlighted( 'PHP Errors', 'qm-warning' );
-		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-notice', 'PHP Errors (1 Warning, 1 Notice)' );
-		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test warning' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-warning', 'PHP Errors (3 Warnings, 1 Notice)' );
+		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a single test warning' );
+		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a repeated test warning' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );
 	} );
 } );

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -136,6 +136,13 @@ export class QueryMonitorUtils {
 	}
 
 	/**
+	 * Assert that the QM menu is visible with an error indicator
+	 */
+	async seeQMMenuWithError() {
+		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-error' ) ).toBeVisible();
+	}
+
+	/**
 	 * Assert that the QM menu is visible with a notice indicator
 	 */
 	async seeQMMenuWithNotice() {
@@ -149,6 +156,37 @@ export class QueryMonitorUtils {
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor' ) ).toBeVisible();
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-warning' ) ).not.toBeVisible();
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-notice' ) ).not.toBeVisible();
+	}
+
+	/**
+	 * Assert that a submenu item in the admin bar dropdown is highlighted with the given class.
+	 */
+	async seeQMSubMenuItemHighlighted( title: string, className: string ) {
+		const item = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.${className}` ).filter( {
+			hasText: title,
+		} );
+		await expect( item ).toHaveCount( 1 );
+	}
+
+	/**
+	 * Assert that a submenu item in the admin bar dropdown with the given class contains the given text.
+	 */
+	async seeQMSubMenuItemWithText( className: string, text: string ) {
+		const item = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.${className}` );
+		await expect( item ).toContainText( text );
+	}
+
+	/**
+	 * Assert that a panel menu item displays a warning count bubble.
+	 */
+	async seeWarningBubbleInQMPanelMenu( panel: string ) {
+		await this.openQMPanel( panel );
+
+		const button = this.page.locator( '#qm-panel-menu button:visible' ).filter( {
+			hasText: panel,
+		} );
+
+		await expect( button.locator( '.qm-menu-badge-warning' ) ).toBeVisible();
 	}
 
 	/**

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -159,16 +159,6 @@ export class QueryMonitorUtils {
 	}
 
 	/**
-	 * Assert that a submenu item in the admin bar dropdown is highlighted with the given class.
-	 */
-	async seeQMSubMenuItemHighlighted( title: string, className: string ) {
-		const item = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.${className}` ).filter( {
-			hasText: title,
-		} );
-		await expect( item ).toHaveCount( 1 );
-	}
-
-	/**
 	 * Assert that a submenu item in the admin bar dropdown with the given class contains the given text.
 	 */
 	async seeQMSubMenuItemWithText( className: string, text: string ) {

--- a/tests/mu-plugins/acceptance.php
+++ b/tests/mu-plugins/acceptance.php
@@ -51,7 +51,9 @@ add_action( 'init', function() {
 					@trigger_error( 'This is a test suppressed notice', E_USER_NOTICE );
 					break;
 				case 'buffet':
-					trigger_error( 'This is a test warning', E_USER_WARNING );
+					trigger_error( 'This is a single test warning', E_USER_WARNING );
+					_trigger_warning();
+					_trigger_warning();
 					trigger_error( 'This is a test notice', E_USER_NOTICE );
 					@trigger_error( 'This is a test suppressed warning', E_USER_WARNING );
 					@trigger_error( 'This is a test suppressed notice', E_USER_NOTICE );
@@ -229,3 +231,7 @@ add_action( 'init', function() {
 			break;
 	}
 } );
+
+function _trigger_warning() {
+	trigger_error( 'This is a repeated test warning', E_USER_WARNING );
+}

--- a/tests/mu-plugins/acceptance.php
+++ b/tests/mu-plugins/acceptance.php
@@ -50,6 +50,12 @@ add_action( 'init', function() {
 				case 'suppressed-notice':
 					@trigger_error( 'This is a test suppressed notice', E_USER_NOTICE );
 					break;
+				case 'buffet':
+					trigger_error( 'This is a test warning', E_USER_WARNING );
+					trigger_error( 'This is a test notice', E_USER_NOTICE );
+					@trigger_error( 'This is a test suppressed warning', E_USER_WARNING );
+					@trigger_error( 'This is a test suppressed notice', E_USER_NOTICE );
+					break;
 				default:
 					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
 					break;


### PR DESCRIPTION
- Fixes some styling regressions
- Reinstates the counts for each PHP error type (see https://wordpress.org/support/topic/please-bring-back-number-of-warnings-errors/)
- Promotes asset problems to warnings for visibility
