### PR TITLE
Clarify the pre_http_request short-circuit warning text

### DIFF
--- a/output/html/http.tsx
+++ b/output/html/http.tsx
@@ -80,7 +80,7 @@ export const HTTP = ( { data }: PanelProps<DataTypes['http']> ) => {
 								<Warning>
 									{ sprintf(
 										/* translators: %s: WordPress filter name */
-										__( 'Request was short-circuited by the %s filter and was not sent', 'query-monitor' ),
+										__( 'Request was not sent because the %s filter returned a response', 'query-monitor' ),
 										'pre_http_request'
 									) }
 								</Warning>


### PR DESCRIPTION
Implements the more specific wording suggested in #1043.

The HTTP panel warning now reads "Request was not sent because the `pre_http_request` filter returned a response" instead of "…was short-circuited by…", so it describes what actually happened. Single i18n string in `output/html/http.tsx`; no other occurrences.

AI assistance disclosure: this change was prepared with the help of an AI coding agent (Claude) and reviewed before submitting. I haven't run the JS typecheck/lint locally (string-only change), so CI is relied on for that.

Fixes #1043
