### PR TITLE
Guard QM_Timer against reading an unstopped timer

### DIFF
--- a/classes/Timer.php
+++ b/classes/Timer.php
@@ -140,6 +140,9 @@ class QM_Timer {
 	 * @return float
 	 */
 	public function get_time() {
+		if ( ! is_array( $this->end ) ) {
+			return 0.0;
+		}
 		return $this->end['time'] - $this->start['time'];
 	}
 
@@ -147,6 +150,9 @@ class QM_Timer {
 	 * @return int
 	 */
 	public function get_memory() {
+		if ( ! is_array( $this->end ) ) {
+			return 0;
+		}
 		return $this->end['memory'] - $this->start['memory'];
 	}
 


### PR DESCRIPTION
Guards `QM_Timer::get_time()` and `get_memory()` against being read before the timer is stopped, fixing the `Trying to access array offset on value of type null` warning in #1118.

`$end` is null until `stop()` runs, so reading a started-but-never-stopped timer triggered the warning. This can happen via a `qm/start` without a matching `qm/stop`, and also internally when a block timer is started in `block_editor.php` but `render_block` never fires for that block. Both delta methods now return `0` when the timer hasn't stopped; the stopped path is unchanged.

`get_end_time()` / `get_end_memory()` are intentionally left as-is: they return absolute values, so a `0` sentinel would mislead rather than help.

AI-assisted: prepared with the help of an AI coding agent (Claude) and reviewed before submitting.

Fixes #1118
