### PR TITLE
Show badges in the toolbar menu

### DIFF
--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -47,17 +47,17 @@
 	--qm-warn-bg-dark:                 #fceced;
 	--qm-warn-bg-hover:                #fdeced;
 	--qm-warn-border:                  #facfd2;
-	--qm-notice-fg:                    #674e00;
+	--qm-notice-fg:                    #4d3a00;
 	--qm-notice-bg:                    #fcf6e1;
 	--qm-title-bg:                     #ececec;
 	--qm-selection-fg:                 #1e1e1e;
 	--qm-selection-bg:                 #B9D6FB;
-	--qm-badge-fg:                     #50575e;
-	--qm-badge-bg:                     #dcdcde;
-	--qm-badge-notice-fg:              #674e00;
-	--qm-badge-notice-bg:              #fcf6e1;
-	--qm-badge-warn-fg:                #8a2424;
-	--qm-badge-warn-bg:                #facfd2;
+	--qm-badge-fg:                     #1d2c49;
+	--qm-badge-bg:                     #c6d8fa;
+	--qm-badge-notice-fg:              #663900;
+	--qm-badge-notice-bg:              #fae3c6;
+	--qm-badge-warning-fg:             #660000;
+	--qm-badge-warning-bg:             #fac6c6;
 	--qm-sql-keyword-fg:               #33a;
 	--qm-sql-value-fg:                 #a44;
 
@@ -65,20 +65,20 @@
 		/* We can't use light-dark() yet due to some users on Chrome < 123 */
 		--qm-container-fg:                 #eaeef2;
 		--qm-container-bg:                 #32373c;
-		--qm-container-overflow:           #3e444a;
+		--qm-container-overflow:           #1d2327;
 		--qm-panel-border:                 #50626f;
 		--qm-panel-fg:                     #eaeef2;
 		--qm-panel-bg:                     #23282d;
 		--qm-panel-separator:              #50626f;
 		--qm-panel-menu-fg:                #eaeef2;
-		--qm-panel-menu-bg:                #3e444a;
+		--qm-panel-menu-bg:                #1d2327;
 		--qm-panel-menu-fg-hover:          #fff;
 		--qm-panel-menu-bg-selected:       var( --qm-wp-color );
 		--qm-panel-menu-bg-hover:          var( --qm-panel-menu-bg-selected );
 		--qm-panel-menu-shadow:            var( --qm-panel-menu-bg-selected );
 		--qm-panel-menu-fg-current:        #eaeef2;
 		--qm-panel-menu-bg-current:        #32373c;
-		--qm-panel-menu-bg-current-focus:  #3e444a;
+		--qm-panel-menu-bg-current-focus:  #1d2327;
 		--qm-panel-menu-fg-selected:       #fff;
 		--qm-cell-border:                  #23282d;
 		--qm-cell-bg-hover:                #373c42;
@@ -87,7 +87,7 @@
 		--qm-cell-bg-highlight-alt:        #4a4a24;
 		--qm-cell-bg-highlight-dark:       #353519;
 		--qm-cell-bg-stripe:               #32373c;
-		--qm-table-header-bg:              #3e444a;
+		--qm-table-header-bg:              #1d2327;
 		--qm-table-footer-bg:              #32373c;
 		--qm-link-fg:                      #30ceff;
 		--qm-link-fg-hover:                oklch(from var( --qm-link-fg ) calc( l - 0.2 ) c h);
@@ -111,13 +111,15 @@
 		--qm-warn-border:                  #ffd6d6;
 		--qm-notice-fg:                    #fbf3d0;
 		--qm-notice-bg:                    #5c4a14;
-		--qm-title-bg:                     #3e444a;
+		--qm-title-bg:                     #1d2327;
 		--qm-selection-fg:                 #32373c;
 		--qm-selection-bg:                 #B9D6FB;
-		--qm-badge-fg:                     #c3c4c7;
-		--qm-badge-bg:                     #50626f;
-		--qm-badge-warn-fg:                #f0c0c0;
-		--qm-badge-warn-bg:                #6c2424;
+		--qm-badge-fg:                     #ddd;
+		--qm-badge-bg:                     #235;
+		--qm-badge-notice-fg:              #fff;
+		--qm-badge-notice-bg:              #950;
+		--qm-badge-warning-fg:             #fff;
+		--qm-badge-warning-bg:             #d00;
 		--qm-sql-keyword-fg:               #bdf;
 		--qm-sql-value-fg:                 #dcb;
 	}
@@ -572,21 +574,6 @@ i {
 				top: 50%;
 				width: 0;
 			}
-
-			.qm-menu-badge {
-				background: rgba( 255, 255, 255, 0.25 );
-				color: #fff;
-			}
-
-			.qm-menu-badge-notice {
-				background: var( --qm-badge-notice-bg );
-				color: var( --qm-badge-notice-fg );
-			}
-
-			.qm-menu-badge-warning {
-				background: var( --qm-badge-warn-bg );
-				color: var( --qm-badge-warn-fg );
-			}
 		}
 
 		.qm-menu-badge {
@@ -598,14 +585,19 @@ i {
 			line-height: 1;
 			margin-left: auto;
 			min-width: 18px;
-			padding: 3px 7px;
+			padding: 3px 5px;
 			text-align: center;
 			text-shadow: none;
 		}
 
+		.qm-menu-badge-notice {
+			background: var( --qm-badge-notice-bg );
+			color: var( --qm-badge-notice-fg );
+		}
+
 		.qm-menu-badge-warning {
-			background: var( --qm-badge-warn-bg );
-			color: var( --qm-badge-warn-fg );
+			background: var( --qm-badge-warning-bg );
+			color: var( --qm-badge-warning-fg );
 			margin-left: auto;
 		}
 

--- a/assets/query-monitor.css
+++ b/assets/query-monitor.css
@@ -54,6 +54,8 @@
 	--qm-selection-bg:                 #B9D6FB;
 	--qm-badge-fg:                     #50575e;
 	--qm-badge-bg:                     #dcdcde;
+	--qm-badge-notice-fg:              #674e00;
+	--qm-badge-notice-bg:              #fcf6e1;
 	--qm-badge-warn-fg:                #8a2424;
 	--qm-badge-warn-bg:                #facfd2;
 	--qm-sql-keyword-fg:               #33a;
@@ -576,6 +578,11 @@ i {
 				color: #fff;
 			}
 
+			.qm-menu-badge-notice {
+				background: var( --qm-badge-notice-bg );
+				color: var( --qm-badge-notice-fg );
+			}
+
 			.qm-menu-badge-warning {
 				background: var( --qm-badge-warn-bg );
 				color: var( --qm-badge-warn-fg );
@@ -607,7 +614,7 @@ i {
 			color: var( --qm-panel-menu-fg-hover );
 		}
 
-		.qm-menu-badge + .qm-menu-badge-warning {
+		.qm-menu-badge + .qm-menu-badge {
 			margin-left: 0;
 		}
 	}

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -29,63 +29,62 @@
 		}
 	}
 
-	/* Top and submenu items for PHP stricts, deprecateds, and notices */
-	.qm-strict,
-	.qm-deprecated,
-	.qm-notice {
-		background-color: var( --qm-menu-notice-bg ) !important;
-	}
-
-	/* Submenu item links for PHP stricts, deprecateds, and notices */
-	.ab-submenu .qm-strict a,
-	.ab-submenu .qm-deprecated a,
-	.ab-submenu .qm-notice a {
-		color: rgba( 255, 255, 255, 0.8 ) !important;
-
+	/* Submenu item badges */
+	.ab-submenu a {
 		&:focus,
 		&:hover {
-			background-color: var( --qm-menu-notice-bg-hover ) !important;
-			color: rgba( 255, 255, 255, 0.7 ) !important;
-		}
-	}
-
-	/* Top and submenu items for slow database queries */
-	.qm-expensive {
-		background-color: var( --qm-menu-expensive-bg ) !important;
-	}
-
-	/* Submenu item links for slow database queries */
-	.ab-submenu .qm-expensive a {
-		color: rgba( 255, 255, 255, 0.8 ) !important;
-
-		&:focus,
-		&:hover {
-			background-color: var( --qm-menu-expensive-bg-hover );
-			color: rgba( 255, 255, 255, 0.7 ) !important;
-		}
-	}
-
-	/* Top and submenu items for errors and warnings */
-	.qm-error,
-	.qm-warning {
-		background-color: var( --qm-menu-warning-bg ) !important;
-	}
-
-	/* Submenu item links for errors and warnings */
-	.ab-submenu .qm-error a,
-	.ab-submenu .qm-warning a {
-		color: rgba( 255, 255, 255, 0.9 ) !important;
-
-		&:focus,
-		&:hover {
-			background-color: var( --qm-menu-warning-bg-hover ) !important;
-			color: rgba( 255, 255, 255, 0.8 ) !important;
+			.qm-menu-badge {
+				opacity: 0.8;
+			}
 		}
 	}
 
 	#wp-admin-bar-query-monitor {
+		/* Top-level toolbar item for notices */
+		&.qm-notice {
+			background-color: var( --qm-menu-notice-bg ) !important;
+		}
+
+		/* Top-level toolbar item for errors and warnings */
+		&.qm-error,
+		&.qm-warning {
+			background-color: var( --qm-menu-warning-bg ) !important;
+		}
+
 		small {
 			font-size: 11px !important;
+		}
+
+		.ab-submenu .ab-item {
+			display: flex !important;
+			align-items: center;
+		}
+
+		.qm-menu-badge {
+			background: #50626f;
+			border-radius: 99px;
+			color: #eee;
+			font-size: 10.5px;
+			font-weight: 600;
+			line-height: 1;
+			margin-left: auto;
+			/* min-width: 18px; */
+			padding: 3px 7px;
+			text-align: center;
+		}
+
+		.qm-menu-badge-notice {
+			background: var( --qm-menu-notice-bg );
+			color: #eee;
+		}
+
+		.qm-menu-badge-warning {
+			background: var( --qm-menu-warning-bg );
+			color: #eee;
+		}
+
+		.qm-menu-badge + .qm-menu-badge {
+			margin-left: 6px;
 		}
 	}
 }

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -20,7 +20,7 @@
 	--qm-menu-true-fg-hover: #47a747;
 
 	/* True conditionals */
-	.quicklinks .menupop ul li.qm-true > a {
+	.quicklinks .menupop ul li.qm-item-conditionals > a {
 		color: var( --qm-menu-true-fg ) !important;
 
 		&:focus,

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -7,17 +7,19 @@
 /** === Admin Toolbar === */
 
 #wpadminbar {
-	--qm-menu-icon: #aaa;
-	--qm-menu-alert-bg: #f60;
-	--qm-menu-notice-bg: #740;
-	--qm-menu-notice-bg-hover: #6a3c00;
-	--qm-menu-expensive-bg: #b60;
-	--qm-menu-expensive-bg-hover: #a25800;
+	--qm-menu-notice-bg: #b45309;
 	--qm-menu-warning-bg: #c00;
-	--qm-menu-warning-bg-hover: #b30000;
-	--qm-menu-fg: #eee;
+	--qm-menu-warning-fg: #fff;
 	--qm-menu-true-fg: #8c8;
 	--qm-menu-true-fg-hover: #47a747;
+
+	/* Badge colours: */
+	--qm-badge-fg:         #ddd;
+	--qm-badge-bg:         #235;
+	--qm-badge-notice-fg:  #fff;
+	--qm-badge-notice-bg:  #950;
+	--qm-badge-warning-fg: #fff;
+	--qm-badge-warning-bg: #d00;
 
 	/* True conditionals */
 	.quicklinks .menupop ul li.qm-item-conditionals > a {
@@ -34,7 +36,7 @@
 		&:focus,
 		&:hover {
 			.qm-menu-badge {
-				opacity: 0.8;
+				opacity: 0.9;
 			}
 		}
 	}
@@ -49,6 +51,7 @@
 		&.qm-error,
 		&.qm-warning {
 			background-color: var( --qm-menu-warning-bg ) !important;
+			color: var( --qm-menu-warning-fg ) !important;
 		}
 
 		small {
@@ -58,33 +61,33 @@
 		.ab-submenu .ab-item {
 			display: flex !important;
 			align-items: center;
+			gap: 4px;
 		}
 
 		.qm-menu-badge {
-			background: #50626f;
+			background: var( --qm-badge-bg );
 			border-radius: 99px;
-			color: #eee;
+			color: var( --qm-badge-fg );
 			font-size: 10.5px;
-			font-weight: 600;
+			font-weight: 500;
 			line-height: 1;
 			margin-left: auto;
-			/* min-width: 18px; */
-			padding: 3px 7px;
+			padding: 3px 6px;
 			text-align: center;
 		}
 
 		.qm-menu-badge-notice {
-			background: var( --qm-menu-notice-bg );
-			color: #eee;
+			background: var( --qm-badge-notice-bg );
+			color: var( --qm-badge-notice-fg );
 		}
 
 		.qm-menu-badge-warning {
-			background: var( --qm-menu-warning-bg );
-			color: #eee;
+			background: var( --qm-badge-warning-bg );
+			color: var( --qm-badge-warning-fg );
 		}
 
 		.qm-menu-badge + .qm-menu-badge {
-			margin-left: 6px;
+			margin-left: 0px;
 		}
 	}
 }

--- a/output/assets.tsx
+++ b/output/assets.tsx
@@ -14,23 +14,19 @@ type AssetsPanelId = 'assets_scripts' | 'assets_styles';
 
 type AssetsData = DataTypes[AssetsPanelId];
 
-const assetsWarningCount = ( data: AssetsData ): number =>
-	( data.assets ?? [] ).filter( ( asset ) => asset.warning ).length;
-
 export const assetsMenu = ( id: AssetsPanelId, label: string, data: AssetsData ): PanelMenuItem[] => {
-	const warningCount = assetsWarningCount( data );
+	const warningCount = ( data.assets ?? [] ).filter( ( asset ) => asset.warning ).length;
 
 	return [ {
 		id,
 		panel: id,
 		title: label,
-		count: Object.values( data.types ?? {} ).reduce( ( sum, value ) => sum + value, 0 ),
-		...( warningCount ? { warning_count: warningCount, classname: 'qm-error' } : {} ),
+		ok_count: Object.values( data.types ?? {} ).reduce( ( sum, value ) => sum + value, 0 ),
+		...( warningCount ? {
+			warning_count: warningCount,
+		} : {} ),
 	} ];
 };
-
-export const assetsMenuClass = ( data: AssetsData ): string[] =>
-	assetsWarningCount( data ) > 0 ? [ 'qm-error' ] : [];
 
 type myProps = PanelProps<DataTypes['assets_scripts'] | DataTypes['assets_styles']> & {
 	labels: {

--- a/output/assets.tsx
+++ b/output/assets.tsx
@@ -16,15 +16,14 @@ type AssetsData = DataTypes[AssetsPanelId];
 
 export const assetsMenu = ( id: AssetsPanelId, label: string, data: AssetsData ): PanelMenuItem[] => {
 	const warningCount = ( data.assets ?? [] ).filter( ( asset ) => asset.warning ).length;
+	const totalCount = Object.values( data.types ?? {} ).reduce( ( sum, value ) => sum + value, 0 );
 
 	return [ {
 		id,
 		panel: id,
 		title: label,
-		ok_count: Object.values( data.types ?? {} ).reduce( ( sum, value ) => sum + value, 0 ),
-		...( warningCount ? {
-			warning_count: warningCount,
-		} : {} ),
+		ok_count: ( totalCount - warningCount ),
+		warning_count: warningCount || null,
 	} ];
 };
 

--- a/output/html/assets_scripts.tsx
+++ b/output/html/assets_scripts.tsx
@@ -6,12 +6,10 @@ import {
 } from '@wordpress/i18n';
 import { PanelMenuItem } from '../panels/panel-registry';
 
-import Assets, { assetsMenu, assetsMenuClass } from '../assets';
+import Assets, { assetsMenu } from '../assets';
 
 export const scriptsMenu = ( data: DataTypes['assets_scripts'] ): PanelMenuItem[] =>
 	assetsMenu( 'assets_scripts', _x( 'Scripts', 'Enqueued scripts', 'query-monitor' ), data );
-
-export const scriptsMenuClass = assetsMenuClass;
 
 export const Scripts = ( props: PanelProps<DataTypes['assets_scripts']> ) => {
 	return (

--- a/output/html/assets_styles.tsx
+++ b/output/html/assets_styles.tsx
@@ -6,12 +6,10 @@ import {
 } from '@wordpress/i18n';
 import { PanelMenuItem } from '../panels/panel-registry';
 
-import Assets, { assetsMenu, assetsMenuClass } from '../assets';
+import Assets, { assetsMenu } from '../assets';
 
 export const stylesMenu = ( data: DataTypes['assets_styles'] ): PanelMenuItem[] =>
 	assetsMenu( 'assets_styles', _x( 'Styles', 'Enqueued styles', 'query-monitor' ), data );
-
-export const stylesMenuClass = assetsMenuClass;
 
 export const Styles = ( props: PanelProps<DataTypes['assets_styles']> ) => {
 	return (

--- a/output/html/conditionals.tsx
+++ b/output/html/conditionals.tsx
@@ -11,7 +11,6 @@ export const conditionalsMenu = ( data: DataTypes['conditionals'] ): PanelMenuIt
 		id: `conditionals-${ cond }`,
 		panel: 'conditionals',
 		title: `${ cond }()`,
-		classname: 'qm-true qm-ltr',
 		nav: false,
 	} ) );
 

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -44,7 +44,7 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 			id: 'db_dupes',
 			panel: 'db_dupes',
 			title: __( 'Duplicate Queries', 'query-monitor' ),
-			ok_count: data.dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
+			notice_count: data.dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
 			adminBar: false,
 		} );
 	}

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -27,7 +27,6 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 			panel: 'db_errors',
 			title: __( 'Database Errors', 'query-monitor' ),
 			warning_count: data.errors.length,
-			classname: 'qm-warning',
 		} );
 	}
 
@@ -36,8 +35,7 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 			id: 'db_expensive',
 			panel: 'db_expensive',
 			title: __( 'Slow Queries', 'query-monitor' ),
-			warning_count: data.expensive.length,
-			classname: 'qm-expensive',
+			notice_count: data.expensive.length,
 		} );
 	}
 
@@ -46,7 +44,7 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 			id: 'db_dupes',
 			panel: 'db_dupes',
 			title: __( 'Duplicate Queries', 'query-monitor' ),
-			count: data.dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
+			ok_count: data.dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
 			adminBar: false,
 		} );
 	}
@@ -69,12 +67,17 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 		} );
 	}
 
+	const warningCount = data.errors?.length ?? 0;
+	const noticeCount = ( data.expensive?.length ?? 0 ) + ( data.dupes?.length ?? 0 );
+	const okCount = Math.max( ( data.total_qs ?? 0 ) - warningCount - noticeCount, 0 );
+
 	return [ {
 		id: 'db_queries',
 		panel: 'db_queries',
 		title: __( 'Database Queries', 'query-monitor' ),
-		count: data.total_qs ?? 0,
-		warning_count: data.errors?.length ?? 0,
+		ok_count: okCount || null,
+		notice_count: noticeCount || null,
+		warning_count: warningCount ?? null,
 		children,
 	} ];
 };
@@ -106,19 +109,6 @@ export const dbQueriesTitle = ( data: DataTypes['db_queries'] ): string[] => {
 	}
 
 	return titles;
-};
-
-export const dbQueriesMenuClass = ( data: DataTypes['db_queries'] ): string[] => {
-	const classes: string[] = [];
-
-	if ( data.errors?.length ) {
-		classes.push( 'qm-error' );
-	}
-	if ( data.expensive?.length ) {
-		classes.push( 'qm-expensive' );
-	}
-
-	return classes;
 };
 
 const getExtendedQueryPromptMessage = ( reason: 'conflict' | 'disabled' | 'failed' ) => {

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -67,17 +67,13 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 		} );
 	}
 
-	const warningCount = data.errors?.length ?? 0;
-	const noticeCount = ( data.expensive?.length ?? 0 ) + ( data.dupes?.length ?? 0 );
-	const okCount = Math.max( ( data.total_qs ?? 0 ) - warningCount - noticeCount, 0 );
+	const okCount = ( data.total_qs ?? 0 );
 
 	return [ {
 		id: 'db_queries',
 		panel: 'db_queries',
 		title: __( 'Database Queries', 'query-monitor' ),
 		ok_count: okCount || null,
-		notice_count: noticeCount || null,
-		warning_count: warningCount ?? null,
 		children,
 	} ];
 };

--- a/output/html/doing_it_wrong.tsx
+++ b/output/html/doing_it_wrong.tsx
@@ -16,13 +16,8 @@ export const doingItWrongMenu = ( data: DataTypes['doing_it_wrong'] ): PanelMenu
 		id: 'doing_it_wrong',
 		panel: 'doing_it_wrong',
 		title: _x( 'Doing it Wrong', 'Doing it Wrong', 'query-monitor' ),
-		warning_count: data.actions.length,
-		classname: 'qm-notice',
+		notice_count: data.actions.length,
 	} ] : []
-);
-
-export const doingItWrongMenuClass = ( data: DataTypes['doing_it_wrong'] ): string[] => (
-	data.actions?.length ? [ 'qm-notice' ] : []
 );
 
 export const DoingItWrong = ( { data }: PanelProps<DataTypes['doing_it_wrong']> ) => {

--- a/output/html/http.tsx
+++ b/output/html/http.tsx
@@ -29,15 +29,10 @@ export const httpMenu = ( data: DataTypes['http'] ): PanelMenuItem[] => {
 		id: 'http',
 		panel: 'http',
 		title: __( 'HTTP API Calls', 'query-monitor' ),
-		count: count || null,
+		ok_count: count || null,
 		warning_count: errorCount || null,
-		...( errorCount ? { classname: 'qm-warning' } : {} ),
 	} ];
 };
-
-export const httpMenuClass = ( data: DataTypes['http'] ): string[] => (
-	Object.keys( data.errors ?? {} ).length ? [ 'qm-warning' ] : []
-);
 
 const hasHttpsWarning = ( row: DataTypes['http']['http'][0] ): boolean => {
 	return ( ! row.url.startsWith( 'https://' ) ) && ( 'localhost' !== row.host );

--- a/output/html/http.tsx
+++ b/output/html/http.tsx
@@ -29,7 +29,7 @@ export const httpMenu = ( data: DataTypes['http'] ): PanelMenuItem[] => {
 		id: 'http',
 		panel: 'http',
 		title: __( 'HTTP API Calls', 'query-monitor' ),
-		ok_count: count || null,
+		ok_count: ( count - errorCount ) || null,
 		warning_count: errorCount || null,
 	} ];
 };

--- a/output/html/logger.tsx
+++ b/output/html/logger.tsx
@@ -25,7 +25,7 @@ export const loggerMenu = ( data: DataTypes['logger'] ): PanelMenuItem[] => {
 		panel: 'logger',
 		title: __( 'Logs', 'query-monitor' ),
 		warning_count: warningCount || null,
-		ok_count: logs.length || null,
+		ok_count: ( logs.length - warningCount ) || null,
 	} ];
 };
 

--- a/output/html/logger.tsx
+++ b/output/html/logger.tsx
@@ -25,13 +25,9 @@ export const loggerMenu = ( data: DataTypes['logger'] ): PanelMenuItem[] => {
 		panel: 'logger',
 		title: __( 'Logs', 'query-monitor' ),
 		warning_count: warningCount || null,
-		count: logs.length || null,
+		ok_count: logs.length || null,
 	} ];
 };
-
-export const loggerMenuClass = ( data: DataTypes['logger'] ): string[] => (
-	( data.logs ?? [] ).some( ( log ) => isWarningLog( log.level ) ) ? [ 'qm-warning' ] : []
-);
 
 export const Logger = ( { data }: PanelProps<DataTypes['logger']> ) => {
 	const { settings } = useContext( MainContext );

--- a/output/html/php_errors.tsx
+++ b/output/html/php_errors.tsx
@@ -7,36 +7,9 @@ import { DataTypes } from '../data-types';
 import { PanelProps } from '../types';
 import * as Utils from '../utils';
 import { useContext } from 'preact/hooks';
-import { __, _nx, sprintf } from '@wordpress/i18n';
+import { __, _nx } from '@wordpress/i18n';
 import { Icon } from '../components/icon';
 import { PanelMenuItem } from '../panels/panel-registry';
-
-export const phpErrorsMenuClass = ( data: DataTypes['php_errors'] ): string[] => {
-	const classes = new Set<string>();
-
-	for ( const error of Object.values( data.errors ?? {} ) ) {
-		if ( ! error.suppressed ) {
-			classes.add( `qm-${ error.level }` );
-		}
-	}
-
-	return Array.from( classes );
-};
-
-const phpErrorPluralLabels: Record<string, ( count: number ) => string> = {
-	deprecated: ( count ) =>
-		/* translators: %s: Number of deprecated PHP errors */
-		_nx( '%s Deprecated', '%s Deprecated', count, 'PHP error level', 'query-monitor' ),
-	strict: ( count ) =>
-		/* translators: %s: Number of strict PHP errors */
-		_nx( '%s Strict', '%s Stricts', count, 'PHP error level', 'query-monitor' ),
-	notice: ( count ) =>
-		/* translators: %s: Number of PHP notices */
-		_nx( '%s Notice', '%s Notices', count, 'PHP error level', 'query-monitor' ),
-	warning: ( count ) =>
-		/* translators: %s: Number of PHP warnings */
-		_nx( '%s Warning', '%s Warnings', count, 'PHP error level', 'query-monitor' ),
-};
 
 export const phpErrorsMenu = ( data: DataTypes['php_errors'] ): PanelMenuItem[] => {
 	const errors = Object.values( data.errors ?? {} );
@@ -45,54 +18,28 @@ export const phpErrorsMenu = ( data: DataTypes['php_errors'] ): PanelMenuItem[] 
 		return [];
 	}
 
-	const counts: Record<string, number> = {};
+	let notice_count = 0;
+	let warning_count = 0;
 
 	for ( const error of errors ) {
-		if ( ! error.suppressed ) {
-			counts[ error.level ] = ( counts[ error.level ] ?? 0 ) + error.count;
-		}
-	}
-
-	const parts: string[] = [];
-	let total = 0;
-
-	for ( const [ level, getLabel ] of Object.entries( phpErrorPluralLabels ) ) {
-		const count = counts[ level ];
-
-		if ( ! count ) {
+		if ( error.suppressed ) {
 			continue;
 		}
 
-		total += count;
-		parts.push( sprintf( getLabel( count ), Utils.numberFormat( count ) ) );
+		if ( error.level == 'warning' ) {
+			warning_count += error.count;
+		} else {
+			notice_count += error.count;
+		}
 	}
-
-	const title = parts.length
-		? sprintf(
-			/* translators: %s: List of PHP error types */
-			__( 'PHP Errors (%s)', 'query-monitor' ),
-			/* translators: used between list items, there is a space after the comma */
-			parts.reverse().join( __( ', ', 'query-monitor' ) ),
-		)
-		: __( 'PHP Errors', 'query-monitor' );
-
-	const classes = phpErrorsMenuClass( data );
 
 	return [
 		{
 			id: 'php_errors',
 			panel: 'php_errors',
-			title,
-			warning_count: total,
-			...( classes.length ? { classname: classes.join( ' ' ) } : {} ),
-			nav: false,
-		},
-		{
-			id: 'php_errors',
-			panel: 'php_errors',
 			title: __( 'PHP Errors', 'query-monitor' ),
-			warning_count: Object.values( data.types ?? {} ).reduce( ( sum, value ) => sum + value, 0 ),
-			adminBar: false,
+			notice_count: ( notice_count || null ),
+			warning_count: ( warning_count || null ),
 		},
 	];
 };

--- a/output/html/timing.tsx
+++ b/output/html/timing.tsx
@@ -19,7 +19,7 @@ export const timingMenu = ( data: DataTypes['timing'] ): PanelMenuItem[] => {
 		id: 'timing',
 		panel: 'timing',
 		title: __( 'Timings', 'query-monitor' ),
-		ok_count: count || null,
+		ok_count: ( count - warningCount ) || null,
 		warning_count: warningCount || null,
 	} ];
 };

--- a/output/html/timing.tsx
+++ b/output/html/timing.tsx
@@ -19,7 +19,7 @@ export const timingMenu = ( data: DataTypes['timing'] ): PanelMenuItem[] => {
 		id: 'timing',
 		panel: 'timing',
 		title: __( 'Timings', 'query-monitor' ),
-		count: count || null,
+		ok_count: count || null,
 		warning_count: warningCount || null,
 	} ];
 };

--- a/output/html/transients.tsx
+++ b/output/html/transients.tsx
@@ -16,7 +16,7 @@ export const transientsMenu = ( data: DataTypes['transients'] ): PanelMenuItem[]
 	id: 'transients',
 	panel: 'transients',
 	title: __( 'Transient Updates', 'query-monitor' ),
-	count: data.trans?.length || null,
+	ok_count: data.trans?.length || null,
 } ];
 
 export const Transients = ( { data }: PanelProps<DataTypes['transients']> ) => {

--- a/output/nav.tsx
+++ b/output/nav.tsx
@@ -20,7 +20,8 @@ export type iNavMenu = {
 export interface iNavMenuItem {
 	panel: string;
 	title: string;
-	count?: number | null;
+	ok_count?: number | null;
+	notice_count?: number | null;
 	warning_count?: number | null;
 	new: boolean;
 	children?: iNavMenu;
@@ -28,11 +29,11 @@ export interface iNavMenuItem {
 
 /**
  * Normalises a menu item that uses a legacy "Title (n)" format by extracting
- * the count into the dedicated `count` property. This provides backwards
- * compatibility with third-party plugins that haven't adopted the new format.
+ * the count into the dedicated `ok_count` property. This provides
+ * compatibility with third-party plugins that use server-side menus.
  */
 function normaliseMenuItem( item: iNavMenuItem ): iNavMenuItem {
-	if ( item.count != null ) {
+	if ( item.ok_count != null ) {
 		return item;
 	}
 
@@ -45,7 +46,7 @@ function normaliseMenuItem( item: iNavMenuItem ): iNavMenuItem {
 	return {
 		...item,
 		title: match[1],
-		count: parseInt( match[2], 10 ) || null,
+		ok_count: parseInt( match[2], 10 ) || null,
 	};
 }
 
@@ -63,16 +64,29 @@ export function normaliseMenu( menu: iNavMenu ): iNavMenu {
 	return result;
 }
 
-const Badges = ( { item, seen }: { item: iNavMenuItem; seen: boolean } ) => (
+export const Badges = ( { item, seen }: {
+	item: {
+		new?: boolean;
+		ok_count?: number | null;
+		notice_count?: number | null,
+		warning_count?: number | null,
+	};
+	seen: boolean,
+} ) => (
 	<>
 		{ item.new && ! seen && (
 			<span aria-hidden="true" className="qm-menu-badge qm-menu-badge-new">
 				{ _x( 'New', 'badge', 'query-monitor' ) }
 			</span>
 		) }
-		{ item.count != null && item.count !== item.warning_count && (
-			<span aria-hidden="true" className="qm-menu-badge">
-				{ Utils.numberFormat( item.count ) }
+		{ item.ok_count != null && (
+			<span aria-hidden="true" className="qm-menu-badge qm-menu-badge-ok">
+				{ Utils.numberFormat( item.ok_count ) }
+			</span>
+		) }
+		{ !! item.notice_count && (
+			<span aria-hidden="true" className="qm-menu-badge qm-menu-badge-notice">
+				{ Utils.numberFormat( item.notice_count ) }
 			</span>
 		) }
 		{ !! item.warning_count && (
@@ -86,17 +100,15 @@ const Badges = ( { item, seen }: { item: iNavMenuItem; seen: boolean } ) => (
 function selectLabel( item: iNavMenuItem ): string {
 	const parts = [ item.title ];
 
-	if ( item.count || item.warning_count ) {
+	if ( item.notice_count || item.warning_count ) {
 		const counts = [];
+		const alert_count = ( item.warning_count ?? 0 ) + ( item.notice_count ?? 0 );
 
-		if ( item.warning_count ) {
-			counts.push( `${ item.warning_count }!` );
-		}
-		if ( item.count && item.count !== item.warning_count ) {
-			counts.push( `${ item.count }` );
+		if ( alert_count ) {
+			counts.push( `${ alert_count }!` );
 		}
 
-		parts.push( `(${ counts.join( ', ' ) })` );
+		parts.push( `(${ counts.join( ') (' ) })` );
 	}
 
 	return parts.join( ' ' );

--- a/output/panels/panel-registry.tsx
+++ b/output/panels/panel-registry.tsx
@@ -24,7 +24,6 @@ export interface PanelMenuItem {
 	ok_count?: number | null;
 	notice_count?: number | null;
 	warning_count?: number | null;
-	classname?: string;
 	/** Entries nested beneath this one in the nav menu, in display order. */
 	children?: PanelMenuItem[];
 	/** id of the item this entry should be nested beneath as a child. */

--- a/output/panels/panel-registry.tsx
+++ b/output/panels/panel-registry.tsx
@@ -21,7 +21,8 @@ export interface PanelMenuItem {
 	id: string;
 	panel: string;
 	title: string;
-	count?: number | null;
+	ok_count?: number | null;
+	notice_count?: number | null;
 	warning_count?: number | null;
 	classname?: string;
 	/** Entries nested beneath this one in the nav menu, in display order. */
@@ -43,7 +44,6 @@ interface Panel<TDataKey extends keyof DataTypes> {
 	order?: number;
 	menu?: ( data: DataTypes[ TDataKey ], enabled: boolean ) => PanelMenuItem[];
 	menuTitle?: ( data: DataTypes[ TDataKey ] ) => string[];
-	menuClass?: ( data: DataTypes[ TDataKey ] ) => string[];
 }
 
 interface OverviewPanel<TDataKey extends keyof DataTypes> {
@@ -89,7 +89,7 @@ export const registerPanel = <
 				panel: `${id}-concerned_hooks`,
 				parent: id,
 				title: __( 'Hooks in Use', 'query-monitor' ),
-				count,
+				ok_count: count,
 				adminBar: false,
 			} ];
 		},
@@ -149,7 +149,6 @@ export const collectMenuContributions = (
 ) => {
 	const items: PanelMenuItem[] = [];
 	const menuTitle: string[] = [];
-	const menuClass: string[] = [];
 
 	for ( const panel of Object.values( panels ) ) {
 		if ( panel.type === 'overview' ) {
@@ -184,9 +183,6 @@ export const collectMenuContributions = (
 		if ( panel.menuTitle ) {
 			menuTitle.push( ...panel.menuTitle( panelData ) );
 		}
-		if ( panel.menuClass ) {
-			menuClass.push( ...panel.menuClass( panelData ) );
-		}
 	}
 
 	// Nest any item that declared a parent beneath that parent's entry. An item
@@ -206,5 +202,5 @@ export const collectMenuContributions = (
 		return false;
 	} );
 
-	return { items: topLevel, menuTitle, menuClass };
+	return { items: topLevel, menuTitle };
 }

--- a/output/qm.tsx
+++ b/output/qm.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useRef, useMemo } from 'preact/hooks';
 
 import { __ } from '@wordpress/i18n';
 
-import { Nav, iNavMenu, NavSelect } from './nav';
+import { Nav, iNavMenu, NavSelect, Badges } from './nav';
 import { Panels, iPanelData, iSettings } from './panels/panels';
 
 const devCssUrl = import.meta.env.DEV
@@ -40,6 +40,9 @@ type Props = {
 				id: string;
 				panel: string;
 				title: string;
+				count?: number | null;
+				notice_count?: number | null;
+				warning_count?: number | null;
 				meta?: {
 					classname: string;
 				}
@@ -201,7 +204,7 @@ export const QM = ( props: Props ) => {
 		},
 	};
 
-	// Apply the menu class (qm-warning, qm-notice, etc.) to the admin bar element
+	// Apply the menu class (qm-warning, qm-notice, or qm-error) to the admin bar element
 	useEffect( () => {
 		if ( ! inWP ) {
 			return;
@@ -426,6 +429,7 @@ export const QM = ( props: Props ) => {
 										} }
 									>
 										{ menu.title }
+										<Badges item={ menu } seen={ true } />
 									</a>
 								</li>
 							) ) }

--- a/output/qm.tsx
+++ b/output/qm.tsx
@@ -40,7 +40,7 @@ type Props = {
 				id: string;
 				panel: string;
 				title: string;
-				count?: number | null;
+				ok_count?: number | null;
 				notice_count?: number | null;
 				warning_count?: number | null;
 				meta?: {

--- a/output/qm.tsx
+++ b/output/qm.tsx
@@ -43,9 +43,6 @@ type Props = {
 				ok_count?: number | null;
 				notice_count?: number | null;
 				warning_count?: number | null;
-				meta?: {
-					classname: string;
-				}
 			}
 		}
 	};
@@ -418,7 +415,7 @@ export const QM = ( props: Props ) => {
 					<div className="ab-sub-wrapper">
 						<ul className="ab-submenu">
 							{ Object.values( props.menu.sub ).map( ( menu ) => (
-								<li key={ menu.id } className={ clsx( menu.meta && menu.meta.classname ) }>
+								<li key={ menu.id } className={ `qm-item-${menu.panel}` }>
 									<a
 										className="ab-item"
 										href={ `#qm-${ menu.panel }` }

--- a/src/panels.tsx
+++ b/src/panels.tsx
@@ -56,9 +56,6 @@ export type iQMMenuItem = {
 	ok_count?: number | null;
 	notice_count?: number | null;
 	warning_count?: number | null;
-	meta?: {
-		classname: string;
-	};
 };
 
 /**
@@ -177,7 +174,6 @@ function buildSub( items: PanelMenuItem[] ): iQMMenu[ 'sub' ] {
 				ok_count: item.ok_count ?? null,
 				notice_count: item.notice_count ?? null,
 				warning_count: item.warning_count ?? null,
-				...( item.classname ? { meta: { classname: item.classname } } : {} ),
 			};
 		}
 

--- a/src/panels.tsx
+++ b/src/panels.tsx
@@ -16,22 +16,22 @@ import { DBComponents } from '../output/html/db_components';
 import { DBDupes } from '../output/html/db_dupes';
 import { DBErrors } from '../output/html/db_errors';
 import { DBExpensive } from '../output/html/db_expensive';
-import { DBQueries, dbQueriesMenu, dbQueriesTitle, dbQueriesMenuClass } from '../output/html/db_queries';
-import { DoingItWrong, doingItWrongMenu, doingItWrongMenuClass } from '../output/html/doing_it_wrong';
+import { DBQueries, dbQueriesMenu, dbQueriesTitle } from '../output/html/db_queries';
+import { DoingItWrong, doingItWrongMenu } from '../output/html/doing_it_wrong';
 import { Environment, environmentMenu } from '../output/html/environment';
 import { Hooks, hooksMenu } from '../output/html/hooks';
-import { HTTP, httpMenu, httpMenuClass } from '../output/html/http';
+import { HTTP, httpMenu } from '../output/html/http';
 import { Languages, languagesMenu } from '../output/html/languages';
-import { Logger, loggerMenu, loggerMenuClass } from '../output/html/logger';
+import { Logger, loggerMenu } from '../output/html/logger';
 import { Multisite, multisiteMenu } from '../output/html/multisite';
 import { Overview, overviewTitle, overviewMenu } from '../output/html/overview';
 import { Timeline, timelineMenu } from '../output/html/timeline';
-import { PHPErrors, phpErrorsMenu, phpErrorsMenuClass } from '../output/html/php_errors';
+import { PHPErrors, phpErrorsMenu } from '../output/html/php_errors';
 import { Request, requestMenu } from '../output/html/request';
 import { Headers } from '../output/html/headers';
 import { Settings } from '../output/html/settings';
-import { Scripts, scriptsMenu, scriptsMenuClass } from '../output/html/assets_scripts';
-import { Styles, stylesMenu, stylesMenuClass } from '../output/html/assets_styles';
+import { Scripts, scriptsMenu } from '../output/html/assets_scripts';
+import { Styles, stylesMenu } from '../output/html/assets_styles';
 import { Theme, themeMenu } from '../output/html/theme';
 import { Timing, timingMenu } from '../output/html/timing';
 import { Transients, transientsMenu } from '../output/html/transients';
@@ -53,6 +53,9 @@ export type iQMMenuItem = {
 	id: string;
 	panel: string;
 	title: string;
+	count?: number | null;
+	notice_count?: number | null;
+	warning_count?: number | null;
 	meta?: {
 		classname: string;
 	};
@@ -128,7 +131,8 @@ function toNavItem( item: PanelMenuItem, children: iNavMenu ): iNavMenuItem {
 	const navItem: iNavMenuItem = {
 		panel: item.panel,
 		title: item.title,
-		count: item.count ?? null,
+		ok_count: item.ok_count ?? null,
+		notice_count: item.notice_count ?? null,
 		warning_count: item.warning_count ?? null,
 		new: item.new ?? false,
 	};
@@ -170,6 +174,9 @@ function buildSub( items: PanelMenuItem[] ): iQMMenu[ 'sub' ] {
 				id: item.id,
 				panel: item.panel,
 				title: item.title,
+				count: item.ok_count ?? null,
+				notice_count: item.notice_count ?? null,
+				warning_count: item.warning_count ?? null,
 				...( item.classname ? { meta: { classname: item.classname } } : {} ),
 			};
 		}
@@ -186,7 +193,7 @@ function buildSub( items: PanelMenuItem[] ): iQMMenu[ 'sub' ] {
  * panels using the PHP filters) are appended to the bottom in their server order.
  */
 export function buildMenus( server: iQM ): { menu: iQMMenu; panel_menu: iNavMenu } {
-	const { items, menuTitle, menuClass } = collectMenuContributions(
+	const { items, menuTitle } = collectMenuContributions(
 		server.data as PanelDataMap,
 	);
 
@@ -199,11 +206,19 @@ export function buildMenus( server: iQM ): { menu: iQMMenu; panel_menu: iNavMenu
 	const panel_menu: iNavMenu = { ...buildNav( tops ), ...normaliseMenu( server.panel_menu ) };
 	const sub: iQMMenu[ 'sub' ] = { ...buildSub( tops ), ...server.menu.sub };
 
+	let menuClass = '';
+
+	if ( Object.values( sub ).some( ( item ) => item.warning_count && item.warning_count > 0 ) ) {
+		menuClass = 'qm-warning';
+	} else if ( Object.values( sub ).some( ( item ) => item.notice_count && item.notice_count > 0 ) ) {
+		menuClass = 'qm-notice';
+	}
+
 	return {
 		menu: {
 			top: {
 				title: [ ...menuTitle, ...server.menu.top.title ],
-				classname: [ server.menu.top.classname, ...menuClass ].join( ' ' ),
+				classname: [ server.menu.top.classname, menuClass ].join( ' ' ),
 			},
 			sub,
 		},
@@ -320,7 +335,6 @@ export function registerAllPanels(): void {
 			order: 20,
 			menu: dbQueriesMenu,
 			menuTitle: dbQueriesTitle,
-			menuClass: dbQueriesMenuClass
 		}
 	);
 	registerPanel(
@@ -330,7 +344,6 @@ export function registerAllPanels(): void {
 			data: 'doing_it_wrong',
 			order: 15,
 			menu: doingItWrongMenu,
-			menuClass: doingItWrongMenuClass
 		}
 	);
 	registerPanel(
@@ -358,7 +371,6 @@ export function registerAllPanels(): void {
 			data: 'http',
 			order: 90,
 			menu: httpMenu,
-			menuClass: httpMenuClass
 		}
 	);
 	registerPanel(
@@ -377,7 +389,6 @@ export function registerAllPanels(): void {
 			data: 'logger',
 			order: 47,
 			menu: loggerMenu,
-			menuClass: loggerMenuClass
 		}
 	);
 	registerPanel(
@@ -396,7 +407,6 @@ export function registerAllPanels(): void {
 			data: 'php_errors',
 			order: 10,
 			menu: phpErrorsMenu,
-			menuClass: phpErrorsMenuClass
 		}
 	);
 	registerPanel(
@@ -429,7 +439,6 @@ export function registerAllPanels(): void {
 			data: 'assets_scripts',
 			order: 70,
 			menu: scriptsMenu,
-			menuClass: scriptsMenuClass
 		}
 	);
 	registerPanel(
@@ -439,7 +448,6 @@ export function registerAllPanels(): void {
 			data: 'assets_styles',
 			order: 71,
 			menu: stylesMenu,
-			menuClass: stylesMenuClass
 		}
 	);
 	registerPanel(

--- a/src/panels.tsx
+++ b/src/panels.tsx
@@ -53,7 +53,7 @@ export type iQMMenuItem = {
 	id: string;
 	panel: string;
 	title: string;
-	count?: number | null;
+	ok_count?: number | null;
 	notice_count?: number | null;
 	warning_count?: number | null;
 	meta?: {
@@ -174,7 +174,7 @@ function buildSub( items: PanelMenuItem[] ): iQMMenu[ 'sub' ] {
 				id: item.id,
 				panel: item.panel,
 				title: item.title,
-				count: item.ok_count ?? null,
+				ok_count: item.ok_count ?? null,
 				notice_count: item.notice_count ?? null,
 				warning_count: item.warning_count ?? null,
 				...( item.classname ? { meta: { classname: item.classname } } : {} ),

--- a/tests/acceptance/EnqueuedScripts.spec.ts
+++ b/tests/acceptance/EnqueuedScripts.spec.ts
@@ -89,8 +89,8 @@ test.describe( 'Enqueued Scripts', () => {
 	test( 'Missing dependencies should be flagged', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageWithEnqueuedScripts( 'missing-dependency' );
 
-		// The toolbar menu shows an error indicator.
-		await QueryMonitor.seeQMMenuWithError();
+		// The toolbar menu shows a warning indicator.
+		await QueryMonitor.seeQMMenuWithWarning();
 
 		// The Scripts panel menu entry shows a warning count bubble.
 		await QueryMonitor.seeWarningBubbleInQMPanelMenu( 'Scripts' );

--- a/tests/acceptance/PhpErrors.spec.ts
+++ b/tests/acceptance/PhpErrors.spec.ts
@@ -12,14 +12,16 @@ test.describe( 'PHP Errors', () => {
 	test( 'Warning should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'warning' );
 		await QueryMonitor.seeQMMenuWithWarning();
-		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-warning', 'PHP Errors (1 Warning)' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'php_errors', 'PHP Errors' );
+		await QueryMonitor.seeQMSubMenuItemWithBadge( 'php_errors', 'warning', '1' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test warning' );
 	} );
 
 	test( 'Notice should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'notice' );
 		await QueryMonitor.seeQMMenuWithNotice();
-		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-notice', 'PHP Errors (1 Notice)' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'php_errors', 'PHP Errors' );
+		await QueryMonitor.seeQMSubMenuItemWithBadge( 'php_errors', 'notice', '1' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );
 	} );
 
@@ -40,7 +42,9 @@ test.describe( 'PHP Errors', () => {
 	test( 'Assortment of errors should be handled', async ( { QueryMonitor } ) => {
 		await QueryMonitor.amOnAPageThatTriggersPhpError( 'buffet' );
 		await QueryMonitor.seeQMMenuWithWarning();
-		await QueryMonitor.seeQMSubMenuItemWithText( 'qm-warning', 'PHP Errors (3 Warnings, 1 Notice)' );
+		await QueryMonitor.seeQMSubMenuItemWithText( 'php_errors', 'PHP Errors' );
+		await QueryMonitor.seeQMSubMenuItemWithBadge( 'php_errors', 'warning', '3' );
+		await QueryMonitor.seeQMSubMenuItemWithBadge( 'php_errors', 'notice', '1' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a single test warning' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a repeated test warning' );
 		await QueryMonitor.seeInQMPanel( 'PHP Errors', 'This is a test notice' );

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -160,11 +160,20 @@ export class QueryMonitorUtils {
 	}
 
 	/**
-	 * Assert that a submenu item in the admin bar dropdown with the given class contains the given text.
+	 * Assert that the submenu item for the given panel contains the given text.
 	 */
-	async seeQMSubMenuItemWithText( className: string, text: string ) {
-		const item = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.${className}` );
+	async seeQMSubMenuItemWithText( panel: string, text: string ) {
+		const item = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.qm-item-${ panel }` );
 		await expect( item ).toContainText( text );
+	}
+
+	/**
+	 * Assert that the submenu item for the given panel displays a badge of the
+	 * given type (ok, notice, warning, new) containing the given text.
+	 */
+	async seeQMSubMenuItemWithBadge( panel: string, type: string, text: string ) {
+		const badge = this.page.locator( `#wp-admin-bar-query-monitor .ab-submenu li.qm-item-${ panel } .qm-menu-badge-${ type }` );
+		await expect( badge ).toHaveText( text );
 	}
 
 	/**

--- a/tests/acceptance/utils/query-monitor.ts
+++ b/tests/acceptance/utils/query-monitor.ts
@@ -150,10 +150,11 @@ export class QueryMonitorUtils {
 	}
 
 	/**
-	 * Assert that the QM menu is visible without any warning/notice indicators
+	 * Assert that the QM menu is visible without any error/warning/notice indicators
 	 */
 	async seeQMMenu() {
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor' ) ).toBeVisible();
+		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-error' ) ).not.toBeVisible();
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-warning' ) ).not.toBeVisible();
 		await expect( this.page.locator( '#wp-admin-bar-query-monitor.qm-notice' ) ).not.toBeVisible();
 	}


### PR DESCRIPTION
The styling of the toolbar menu items has gotten a bit messy. This removes the custom class name handling, removes menu item background colours, and adds badges to the menu items for consistency with the panel menu.

<img width="250" alt="" src="https://github.com/user-attachments/assets/606f2e39-acae-4413-b3d3-4b72265857a7" />
