### PR TITLE
Switch to identifying duplicate queries client-side

### DIFF
--- a/collectors/db_queries.php
+++ b/collectors/db_queries.php
@@ -48,11 +48,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 	 */
 	public $wpdb;
 
-	/**
-	 * @var ?array<string, array<int, int>>
-	 */
-	protected $dupes = array();
-
 	public function get_storage(): QM_Data {
 		return new QM_Data_DB_Queries();
 	}
@@ -171,8 +166,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 
 			$sql = trim( $sql );
 
-			$this->maybe_log_dupe( $sql, $i );
-
 			$row = compact( 'sql', 'ltime' );
 
 			if ( false !== strpos( $stack, ' WP->main,' ) ) {
@@ -214,74 +207,6 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 		$this->data->has_result = $has_result;
 		$this->data->has_trace = $has_trace;
 
-		// Filter out queries that do not have duplicates
-		$this->dupes = array_filter( $this->dupes, array( $this, 'filter_dupe_items' ) );
-
-		// Ignore duplicates from `WP_Query->set_found_posts()`
-		unset( $this->dupes['SELECT FOUND_ROWS()'] );
-
-		$stacks = array();
-
-		// Iterate all queries that have duplicates
-		foreach ( $this->dupes as $sql => $query_ids ) {
-			$dupe_data = array(
-				'query' => $sql,
-				'count' => count( $query_ids ),
-				'ltime' => 0,
-				'callers' => array(),
-				'components' => array(),
-				'sources' => array(),
-			);
-
-			foreach ( $query_ids as $query_id ) {
-				if ( isset( $this->data->rows[ $query_id ]['trace'] ) ) {
-					$trace = $this->data->rows[ $query_id ]['trace'];
-					$stack = $trace->get_stack();
-					$component = $trace->get_component();
-
-					// Populate the component counts for this query
-					if ( isset( $dupe_data['components'][ $component->name ] ) ) {
-						$dupe_data['components'][ $component->name ]++;
-					} else {
-						$dupe_data['components'][ $component->name ] = 1;
-					}
-				} else {
-					$stack = $this->data->rows[ $query_id ]['stack'] ?? array();
-				}
-
-				// Populate the caller counts for this query
-				if ( isset( $dupe_data['callers'][ $stack[0] ] ) ) {
-					$dupe_data['callers'][ $stack[0] ]++;
-				} else {
-					$dupe_data['callers'][ $stack[0] ] = 1;
-				}
-
-				// Populate the stack for this query
-				$stacks[ $sql ][] = $stack;
-
-				// Populate the time for this query
-				$dupe_data['ltime'] += $this->data->rows[ $query_id ]['ltime'];
-			}
-
-			// Get the callers which are common to all stacks for this query
-			$common = call_user_func_array( 'array_intersect', $stacks[ $sql ] );
-
-			// Remove callers which are common to all stacks for this query
-			foreach ( $stacks[ $sql ] as $i => $stack ) {
-				$stacks[ $sql ][ $i ] = array_values( array_diff( $stack, $common ) );
-
-				// No uncommon callers within the stack? Just use the topmost caller.
-				if ( empty( $stacks[ $sql ][ $i ] ) ) {
-					$stacks[ $sql ][ $i ] = array_keys( $dupe_data['callers'] );
-				}
-			}
-
-			// Count the occurrences of each primary caller across duplicate queries
-			$dupe_data['sources'] = array_count_values( array_column( $stacks[ $sql ], 0 ) );
-
-			$this->data->dupes[] = $dupe_data;
-		}
-
 		/**
 		 * Filter whether to show the QM extended query information prompt.
 		 *
@@ -307,23 +232,12 @@ class QM_Collector_DB_Queries extends QM_DataCollector {
 	}
 
 	/**
+	 * @deprecated No longer used.
 	 * @param string $sql
 	 * @param int $i
 	 * @return void
 	 */
 	protected function maybe_log_dupe( $sql, $i ) {
-		// Replace all newlines with a single space
-		$sql = str_replace( array( "\r\n", "\r", "\n" ), ' ', $sql );
-		// Remove all tabs and backticks
-		$sql = str_replace( array( "\t", '`' ), '', $sql );
-		// Replace all instance of multiple spaces with a single space
-		$sql = preg_replace( '/ +/', ' ', $sql );
-		// Trim the SQL
-		$sql = trim( $sql );
-		// Remove trailing semicolon
-		$sql = rtrim( $sql, ';' );
-
-		$this->dupes[ $sql ][] = $i;
 	}
 }
 

--- a/data/db_queries.php
+++ b/data/db_queries.php
@@ -57,16 +57,4 @@ class QM_Data_DB_Queries extends QM_Data {
 	 * @var ?'conflict'|'disabled'|'failed'
 	 */
 	public $extended_query_prompt_reason;
-
-	/**
-	 * @phpstan-var array<int, array{
-	 *   query: string,
-	 *   count: int,
-	 *   ltime: float,
-	 *   callers: array<string, int>,
-	 *   components: array<string, int>,
-	 *   sources: array<string, int>,
-	 * }>
-	 */
-	public $dupes;
 }

--- a/output/data-types.ts
+++ b/output/data-types.ts
@@ -235,20 +235,6 @@ export interface DB_Queries {
 	has_result: boolean;
 	has_trace: boolean;
 	extended_query_prompt_reason?: "conflict" | "disabled" | "failed";
-	dupes: {
-		query: string;
-		count: number;
-		ltime: number;
-		callers: {
-			[k: string]: number;
-		};
-		components: {
-			[k: string]: number;
-		};
-		sources: {
-			[k: string]: number;
-		};
-	}[];
 }
 export interface QueryRow {
 	stack?: string[];

--- a/output/html/db_dupes.tsx
+++ b/output/html/db_dupes.tsx
@@ -2,6 +2,7 @@ import { FilterLink } from '../components/filter-link';
 import { TabularPanel } from '../panels/tabular-panel';
 import { Duration } from '../components/duration';
 import * as Utils from '../utils';
+import { getDupes } from './db_queries';
 import { DataTypes } from '../data-types';
 import { PanelProps } from '../types';
 import { Fragment } from 'preact';
@@ -13,7 +14,9 @@ import {
 } from '@wordpress/i18n';
 
 export const DBDupes = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
-	if ( ! data.dupes.length ) {
+	const dupes = data.rows?.length ? getDupes( data.rows ) : [];
+
+	if ( ! dupes.length ) {
 		return null;
 	}
 
@@ -101,6 +104,6 @@ export const DBDupes = ( { data }: PanelProps<DataTypes['db_queries']> ) => {
 				),
 			},
 		} }
-		data={ data.dupes }
+		data={ dupes }
 	/>
 };

--- a/output/html/db_queries.tsx
+++ b/output/html/db_queries.tsx
@@ -6,7 +6,8 @@ import { Warning } from '../components/warning';
 import { getCallerCol, getComponentCol, getStackCol, getTimeCol } from '../table';
 import { PanelFooter } from '../panels/panel-footer';
 import { TotalTime } from '../components/total-time';
-import { DataTypes } from '../data-types';
+import { DataTypes, QueryRow } from '../data-types';
+import { resolveFrames } from '../frame-lookup';
 import { PanelProps } from '../types';
 import { PanelMenuItem } from '../panels/panel-registry';
 import { useContext } from 'preact/hooks';
@@ -17,6 +18,131 @@ import {
 	_x,
 	sprintf,
 } from '@wordpress/i18n';
+
+export interface DupeQuery {
+	query: string;
+	count: number;
+	ltime: number;
+	callers: Record<string, number>;
+	components: Record<string, number>;
+	sources: Record<string, number>;
+}
+
+/**
+ * Normalises a SQL string for duplicate grouping: collapses all whitespace to
+ * single spaces, strips tabs and backticks, and removes any trailing semicolon.
+ */
+const normalizeDupeSQL = ( sql: string ): string => (
+	sql
+		// Replace all newlines with a single space:
+		.replace( /\r\n|\r|\n/g, ' ' )
+		// Remove all tabs and backticks:
+		.replace( /[\t`]/g, '' )
+		// Replace all instance of multiple spaces with a single space:
+		.replace( / +/g, ' ' )
+		// Trim the SQL:
+		.trim()
+		// Remove trailing semicolon:
+		.replace( /;+$/, '' )
+);
+
+/**
+ * Returns the stack of callers used for duplicate grouping. For rows with a
+ * full backtrace this mirrors QM_Backtrace::get_stack(); otherwise it uses the
+ * pre-filtered stack captured server-side.
+ */
+const getDupeStack = ( row: QueryRow ): string[] => {
+	if ( row.trace ) {
+		return resolveFrames( row.trace.frames ).map( ( frame ) => Utils.frameDisplay( frame ) );
+	}
+
+	return row.stack ?? [];
+};
+
+/**
+ * Detects duplicate database queries from the collected query rows.
+ *
+ * This reproduces the duplicate-query analysis that Query Monitor previously
+ * performed server-side: queries are grouped by their normalised SQL, groups
+ * with only a single occurrence are discarded, and the callers, components and
+ * potential troublemakers for each duplicated query are tallied up.
+ */
+export const getDupes = ( rows: QueryRow[] ): DupeQuery[] => {
+	// Group the query rows by their normalised SQL.
+	const groups = new Map<string, QueryRow[]>();
+
+	for ( const row of rows ) {
+		const sql = normalizeDupeSQL( row.sql );
+		const group = groups.get( sql );
+
+		if ( group ) {
+			group.push( row );
+		} else {
+			groups.set( sql, [ row ] );
+		}
+	}
+
+	// Ignore duplicates from `WP_Query->set_found_posts()`.
+	groups.delete( 'SELECT FOUND_ROWS()' );
+
+	const dupes: DupeQuery[] = [];
+
+	for ( const [ query, group ] of groups ) {
+		// Skip queries that do not have duplicates.
+		if ( group.length < 2 ) {
+			continue;
+		}
+
+		const callers: Record<string, number> = {};
+		const components: Record<string, number> = {};
+		const stacks: string[][] = [];
+		let ltime = 0;
+
+		for ( const row of group ) {
+			const component = row.trace ? row.trace.component.name : null;
+			const stack = getDupeStack( row );
+
+			if ( component !== null ) {
+				components[ component ] = ( components[ component ] || 0 ) + 1;
+			}
+
+			if ( stack.length ) {
+				const caller = stack[0];
+				callers[ caller ] = ( callers[ caller ] || 0 ) + 1;
+			}
+
+			stacks.push( stack );
+			ltime += row.ltime;
+		}
+
+		// The callers which are common to all stacks for this query.
+		const common = new Set( Utils.arrayIntersect( stacks ) );
+		const callerKeys = Object.keys( callers );
+
+		// Remove the common callers, leaving only what differs between stacks.
+		// If nothing differs, fall back to the primary callers.
+		const trimmed = stacks.map( ( stack ) => {
+			const diff = stack.filter( ( caller ) => ! common.has( caller ) );
+			return diff.length ? diff : callerKeys;
+		} );
+
+		// Count the occurrences of each primary caller across the duplicates.
+		const primary = trimmed
+			.map( ( stack ) => stack[0] )
+			.filter( ( caller ): caller is string => caller !== undefined );
+
+		dupes.push( {
+			query,
+			count: group.length,
+			ltime,
+			callers,
+			components,
+			sources: Utils.arrayCountValues( primary ),
+		} );
+	}
+
+	return dupes;
+};
 
 export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] => {
 	const children: PanelMenuItem[] = [];
@@ -39,12 +165,14 @@ export const dbQueriesMenu = ( data: DataTypes['db_queries'] ): PanelMenuItem[] 
 		} );
 	}
 
-	if ( data.dupes?.length ) {
+	const dupes = data.rows?.length ? getDupes( data.rows ) : [];
+
+	if ( dupes.length ) {
 		children.push( {
 			id: 'db_dupes',
 			panel: 'db_dupes',
 			title: __( 'Duplicate Queries', 'query-monitor' ),
-			notice_count: data.dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
+			notice_count: dupes.reduce( ( sum, dupe ) => sum + dupe.count, 0 ),
 			adminBar: false,
 		} );
 	}

--- a/output/utils.tsx
+++ b/output/utils.tsx
@@ -489,3 +489,32 @@ export function getQueryTypes( rows: { sql: string }[] ): Record<string, number>
 
 	return types;
 }
+
+/**
+ * Values present in every one of the given arrays, preserving the order and any
+ * repeats of the first array. Mirrors PHP's array_intersect().
+ */
+export function arrayIntersect( arrays: string[][] ): string[] {
+	if ( arrays.length === 0 ) {
+		return [];
+	}
+
+	const [ first, ...rest ] = arrays;
+	const restSets = rest.map( ( arr ) => new Set( arr ) );
+
+	return first.filter( ( value ) => restSets.every( ( set ) => set.has( value ) ) );
+}
+
+/**
+ * Counts the number of occurrences of each value. Mirrors PHP's
+ * array_count_values().
+ */
+export function arrayCountValues( values: string[] ): Record<string, number> {
+	const counts: Record<string, number> = {};
+
+	for ( const value of values ) {
+		counts[ value ] = ( counts[ value ] || 0 ) + 1;
+	}
+
+	return counts;
+}

--- a/src/schemas/data/db_queries.json
+++ b/src/schemas/data/db_queries.json
@@ -64,7 +64,6 @@
 		"total_qs",
 		"has_result",
 		"has_trace",
-		"dupes",
 		"errors"
 	],
 	"properties": {
@@ -107,50 +106,6 @@
 				"disabled",
 				"failed"
 			]
-		},
-		"dupes": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"query": {
-						"type": "string"
-					},
-					"count": {
-						"type": "integer"
-					},
-					"ltime": {
-						"type": "number"
-					},
-					"callers": {
-						"type": "object",
-						"additionalProperties": {
-							"type": "integer"
-						}
-					},
-					"components": {
-						"type": "object",
-						"additionalProperties": {
-							"type": "integer"
-						}
-					},
-					"sources": {
-						"type": "object",
-						"additionalProperties": {
-							"type": "integer"
-						}
-					}
-				},
-				"required": [
-					"query",
-					"count",
-					"ltime",
-					"callers",
-					"components",
-					"sources"
-				],
-				"additionalProperties": false
-			}
 		}
 	},
 	"additionalProperties": false

--- a/tests/acceptance/DBQueries.spec.ts
+++ b/tests/acceptance/DBQueries.spec.ts
@@ -14,4 +14,14 @@ test.describe( 'Database Queries', () => {
 		await QueryMonitor.seeQMMenu();
 		await QueryMonitor.seeInQMPanel( 'Database Queries', 'qm_binary_ip_test' );
 	} );
+
+	test( 'Duplicate queries should be detected', async ( { QueryMonitor } ) => {
+		await QueryMonitor.amOnAPageThatTriggersDBQuery( 'duplicate' );
+		await QueryMonitor.seeQMMenu();
+		await QueryMonitor.openQMPanel( 'Database Queries' );
+		await QueryMonitor.seeTableRowInQMPanel( 'Duplicate Queries', {
+			Query: 'SELECT 123',
+			Count: '2',
+		} );
+	} );
 } );

--- a/tests/mu-plugins/acceptance.php
+++ b/tests/mu-plugins/acceptance.php
@@ -251,6 +251,14 @@ add_action( 'init', function() {
 
 					$wpdb->query( "DROP TABLE IF EXISTS `{$table}`" );
 					break;
+				case 'duplicate':
+					global $wpdb;
+
+					// Run an identical query more than once to trigger the
+					// duplicate query detection.
+					$wpdb->query( "SELECT 123 FROM {$wpdb->posts}" );
+					$wpdb->query( "SELECT 123 FROM {$wpdb->posts}" );
+					break;
 				default:
 					throw new \InvalidArgumentException( 'Unknown test: ' . $_GET['_qm_acceptance_test'] );
 					break;


### PR DESCRIPTION
## Summary

Server-side duplicate query detection is blocking some work I'm doing on lazy-loading data in QM because it requires re-reading the entire collected query data just to populate the `dupes` property. We can shift it all client-side to avoid this.

## Testing

- [x] I have tested this change on a real installation of WordPress (required)

Steps to test:

1. Open a page that performs two duplicate queries, for example:
   ```
   $wpdb->query( 'SELECT * FROM wp_posts LIMIT 10' );
   $wpdb->query( 'SELECT * FROM wp_posts LIMIT 10' );
   ```
2. Confirm the Duplicate Queries menu appears and lists both the queries

## AI assistance

<!-- AI assistance is welcome and encouraged, but must be disclosed. Please check any that apply. -->

- [x] I have used AI assistance to produce this pull request
- [ ] I am an AI agent acting on behalf of a human

## Screenshots

<img alt="" src="https://github.com/user-attachments/assets/8cbe2d12-9df5-40cc-bb26-e1bc298b6aca" />
