### PR TITLE
Guard against non-array query log entries in QM_DB::query()

### DIFF
--- a/classes/DB.php
+++ b/classes/DB.php
@@ -35,7 +35,11 @@ class QM_DB extends wpdb {
 			$this->queries = array();
 		}
 
-		if ( ! isset( $this->queries[ $i ] ) ) {
+		// In some environments `$this->queries[ $i ]` can hold a non-array value.
+		// Writing an array offset to it is a fatal error on PHP 8, so treat that
+		// the same as a missing entry and bail.
+		// See https://github.com/johnbillion/query-monitor/issues/1120.
+		if ( ! is_array( $this->queries[ $i ] ?? null ) ) {
 			return $result;
 		}
 


### PR DESCRIPTION
## Summary

`QM_DB::query()` annotates each logged query by writing array offsets (`['trace']`, `['result']`) onto `$this->queries[ $i ]`. That entry is normally the array the parent class logs, but in some environments it can hold a non-array value, and writing an array offset to a non-array is a fatal `Error` on PHP 8 (`Cannot access offset of type string on string`), as reported in #1120. The existing `isset()` guard doesn't catch it, because a string offset still counts as "set".

This widens the guard to bail when the entry isn't an array, treating it the same as a missing entry. It's a defensive guard so QM doesn't fatal the site it's observing; it doesn't change why an entry is occasionally a non-array, which originates upstream of QM. The normal logging path is unchanged. Fixes #1120.

## Testing

- [x] I have tested this change on a real installation of WordPress (required)

Steps to test:

1. On a WordPress install (I used a fresh install on MySQL 8.4, PHP 8.2), check out this branch and activate the QM database drop-in (symlink `wp-content/db.php` to the plugin's `db.php`).
2. Load the front end and `wp-admin/plugins.php` (the surface in the report). Both return 200 with no PHP error and `debug.log` stays clean.
3. Confirm queries are still collected: the last `$wpdb->queries` entry is an array carrying `trace` (a `QM_Backtrace`) and `result`, i.e. the normal logging path is unchanged.
4. The non-array case needs the upstream race from the issue to occur naturally, so I verified it with a standalone repro of the code path: the old `isset` guard throws `Cannot access offset of type string on string`, the new `is_array( ... ?? null )` guard bails safely. `composer test:phpcs` and `composer test:phpstan` both pass.

Happy to add a regression test to the integration suite if you point me at the harness you'd prefer.

## AI assistance

- [x] I have used AI assistance to produce this pull request
- [ ] I am an AI agent acting on behalf of a human

## Screenshots

No before/after screenshot: this is a database drop-in guard with no visual change.
