### PR TITLE
Fix drop-ins link on single site installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"phpstan/phpstan": "2.1.46",
 		"phpstan/phpstan-deprecation-rules": "2.0.4",
 		"phpstan/phpstan-phpunit": "2.0.16",
-		"squizlabs/php_codesniffer": "3.13.5",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"szepeviktor/phpstan-wordpress": "2.0.3",
 		"wp-coding-standards/wpcs": "3.4.1"
 	},

--- a/dispatchers/Html.php
+++ b/dispatchers/Html.php
@@ -370,6 +370,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 			'settings'    => array(
 				'verified' => self::user_verified(),
 				'color_scheme' => $color_scheme,
+				'is_multisite' => is_multisite(),
 			),
 			'panel_menu'  => $this->panel_menu,
 			'data'        => $data,

--- a/output/html/overview.tsx
+++ b/output/html/overview.tsx
@@ -272,7 +272,7 @@ export const Overview = ( { data, settings }: OverviewProps ) => {
 								<p>
 									<span className="qm-info">
 										<a
-											href={ `${ settings.admin_url }network/plugins.php?plugin_status=dropins` }
+											href={ `${ settings.admin_url }${ settings.is_multisite ? 'network/' : '' }plugins.php?plugin_status=dropins` }
 											target="_blank"
 											rel="noopener noreferrer"
 										>

--- a/output/panels/panels.tsx
+++ b/output/panels/panels.tsx
@@ -47,6 +47,7 @@ export type iPanelData = {
 export type iSettings = {
 	verified: boolean;
 	color_scheme: 'fresh' | 'modern';
+	is_multisite: boolean;
 	ajaxurl: string;
 	admin_url: string;
 	auth_nonce: {

--- a/src/panels.tsx
+++ b/src/panels.tsx
@@ -39,7 +39,7 @@ import { Transients, transientsMenu } from '../output/html/transients';
 /**
  * Raw settings from PHP, before merging with l10n values.
  */
-export type iQMSettings = Pick<iSettings, 'verified' | 'color_scheme'>;
+export type iQMSettings = Pick<iSettings, 'verified' | 'color_scheme' | 'is_multisite'>;
 
 /**
  * Localization data from PHP.


### PR DESCRIPTION
## Summary

The "Persistent object cache in use" link in the Overview panel always pointed at the network admin drop-ins screen. On single-site installs it now points to the regular plugins drop-ins screen. Fixes #1138.

**Note:** this PR also bumps `squizlabs/php_codesniffer` from `3.13.5` to `3.13.6`. That change is unrelated to the bug but is required for CI to pass, because `3.13.5` is blocked by Composer security advisory `PKSA-rdkp-vv9z-mjkg` (CVE-2026-67434). Happy to split it into a separate PR if you'd prefer.

## Testing

- [x] I have reproduced this bug or have a desire for this feature on a real installation of WordPress (required)
- [x] I have tested this change on a real installation of WordPress (required)

Steps to test:

1. On a single-site install with a persistent object cache drop-in in place, open Query Monitor → Overview.
2. Click the "Persistent object cache in use" link.
3. Confirm it goes to `wp-admin/plugins.php?plugin_status=dropins` (previously `wp-admin/network/plugins.php?plugin_status=dropins`).

## CI note (flaky acceptance tests)

The Acceptance Tests workflow has an intermittent flake that is **unrelated to this PR's changes**. The same code produces a *different* failing test on each run — e.g. `Callbacks.spec.ts` › "Function callback should be displayed" failing because the QM admin bar shows a transient `qm-notice` (a PHP notice captured by QM on the first page load after a fresh WordPress install), or `Basic.spec.ts` › "administrator should have access to Query Monitor" failing on login timing. Across three consecutive runs of identical code, three different matrix jobs failed with three different tests, and all other checks passed. This looks environment/timing-sensitive rather than a regression; re-running the failed job typically passes.

## AI assistance

- [x] I have used AI assistance to produce this pull request
- [ ] I am an AI agent acting on behalf of a human

## Screenshots

- [ ] I have included a before and after screenshot (required, unless there is genuinely no visual change)

### Before

### After
